### PR TITLE
Add docker (draft) directives to run dev istance in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.env
+vendor
+node_modules
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:7.4-fpm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    libzip-dev \
+    zip \
+    unzip \
+    npm \
+    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-install mbstring \
+    && docker-php-ext-install exif \
+    && docker-php-ext-install pcntl \
+    && docker-php-ext-install bcmath \
+    && docker-php-ext-install gd \
+    && docker-php-ext-install zip \
+    && docker-php-source delete
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- \
+        --install-dir=/usr/local/bin --filename=composer
+
+WORKDIR /app
+COPY . .
+
+RUN npm ci
+RUN composer install

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3.8'
+services:
+  wem-dev:
+    container_name: wem-dev
+    build: .
+    restart: unless-stopped
+    entrypoint: "php artisan serve --host=0.0.0.0 --port=8000"
+    depends_on:
+      - db-dev
+    ports:
+      - "127.0.0.1:45060:8000"
+    env_file: .env
+    environment:
+      DB_CONNECTION: mysql
+      DB_HOST: db-dev
+      DB_PORT: 3306
+      DB_DATABASE: laravel
+      DB_USERNAME: root
+      DB_PASSWORD: wemdev
+    volumes:
+      - ./app:/app/app
+
+  db-dev:
+    container_name: db-dev
+    image: mariadb:10.3.32
+    environment:
+      MARIADB_DATABASE: laravel
+      MARIADB_ROOT_PASSWORD: wemdev
+    volumes:
+      - db-dev_data:/var/lib/mysql
+
+volumes:
+  db-dev_data:


### PR DESCRIPTION
This PR contains a basis to run a dev instance of WEM in docker using docker compose.

It is based on `php:7.4-fpm` image, and it uses an instance of mariadb as db.

**PAY ATTENTION**
`composer i` will fail because `name` in `composer.json` has to be lowercase