### PR TITLE
Remove duplicated columns in migration script

### DIFF
--- a/database/migrations/2022_07_23_150511_create_files_table.php
+++ b/database/migrations/2022_07_23_150511_create_files_table.php
@@ -30,7 +30,6 @@ return new class extends Migration
             $table->integer('purchases_id')->nullable();
             $table->integer('purchase_receipts_id')->nullable();
             $table->integer('quality_non_conformities_id')->nullable();
-            $table->integer('quality_non_conformities_id')->nullable();
             $table->boolean('as_photo')->default(false);
             $table->timestamps();
         });


### PR DESCRIPTION
Closes: #359

There are two `quality_non_conformities_id` columns in 2022_07_23_150511_create_files_table.php

```php
    public function up()
    {   
        Schema::create('files', function (Blueprint $table) {
            $table->id();
            $table->integer('user_id');
            $table->string('name');
            $table->string('original_file_name');
            $table->string('type');
            $table->string('size');
            $table->integer('companies_id')->nullable();
            $table->integer('opportunities_id')->nullable();
            $table->integer('quotes_id')->nullable();
            $table->integer('orders_id')->nullable();
            $table->integer('deliverys_id')->nullable();
            $table->integer('invoices_id')->nullable();
            $table->integer('products_id')->nullable();
            $table->integer('purchases_id')->nullable();
            $table->integer('purchase_receipts_id')->nullable();
            $table->integer('quality_non_conformities_id')->nullable();
            $table->integer('quality_non_conformities_id')->nullable();
            $table->boolean('as_photo')->default(false);
            $table->timestamps();
        }); 
    }
```