### PR TITLE
Upgrade base image to make composer work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:8.2-fpm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Dependencies in composer.json requires a higher version of PHP therefore the base image should be upgraded.

composer.json says `^php 8.1.0`, but some dependencies specified in composer.lock file requires php 8.2 to work. Therefore I updated the base image to php:8.2-fpm which works with existing lock files out of box.