### PR TITLE
[perf] Call Factory::first once and cache the result in FactoryServiceProvider

### DIFF
--- a/app/Providers/FactoryServiceProvider.php
+++ b/app/Providers/FactoryServiceProvider.php
@@ -9,6 +9,13 @@ use Illuminate\Support\ServiceProvider;
 class FactoryServiceProvider extends ServiceProvider
 {
     /**
+     * The first factory
+     *
+     * @var static|null
+     */
+    private static ?Factory $firstFactory = null;
+
+    /**
      * Register services.
      */
     public function register(): void
@@ -21,10 +28,10 @@ class FactoryServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //view()->share('Factory', Factory::first());
+        self::$firstFactory ??= Factory::first();
+        //view()->share('Factory', self::$firstFactory);
         View::composer('*', function ($view) {
-            $Factory = Factory::first();
-            $view->with('Factory', $Factory);
+            $view->with('Factory', self::$firstFactory);
         });
     }
 }


### PR DESCRIPTION
The boot function of FactoryServiceProvider is called multiple times as it's referenced in many views. This PR tries to cache the result and use it when processing current request. The optimization saves more than a hundred queries when opening dashboard.

Closes: #362 