### PR TITLE
fix: remove trailing comma in OrderService constructor

### DIFF
--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -8,10 +8,11 @@ use App\Notifications\OrderNotification;
 
 class OrderService
 {
-    protected $notificationService ;
+    protected $notificationService;
 
-    public function __construct(NotificationService $notificationService , ){
-        $this->notificationService  = $notificationService ;
+    public function __construct(NotificationService $notificationService)
+    {
+        $this->notificationService = $notificationService;
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix OrderService constructor definition to allow proper DI

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: missing PHP ext-ldap and unable to download packages)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a39f0ad474832d8ef82ec1f45484ad