### PR TITLE
Fix CSV import success redirect to use flash session

### DIFF
--- a/app/Services/ImportCsvService.php
+++ b/app/Services/ImportCsvService.php
@@ -662,7 +662,7 @@ class ImportCsvService
                     return redirect()->back()->withErrors($errors);
                 }
             
-                return redirect()->back()->withErrors('success', $importedLines . ' lines imported successfully.');
+                return redirect()->back()->with('success', $importedLines . ' lines imported successfully.');
             }
             else{
                 return redirect()->back()->withErrors('imports failed, unit or accounting vat default');
@@ -740,7 +740,7 @@ class ImportCsvService
                     return redirect()->back()->withErrors($errors);
                 }
             
-                return redirect()->back()->withErrors('success', $importedLines . ' lines imported successfully.');
+                return redirect()->back()->with('success', $importedLines . ' lines imported successfully.');
             }
             else{
                 return redirect()->back()->withErrors('imports failed, unit or accounting vat default');


### PR DESCRIPTION
## Summary
- fix CSV import success messages to use session flash instead of error bag

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction --ignore-platform-req=ext-ldap` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a04139c0832d8896ec7dcbbaad80