### PR TITLE
docs: clarify factory controller request types

### DIFF
--- a/app/Http/Controllers/Admin/FactoryController.php
+++ b/app/Http/Controllers/Admin/FactoryController.php
@@ -61,7 +61,7 @@ class FactoryController extends Controller
     /**
      * Update the specified factory in storage.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param \App\Http\Requests\Admin\UpdateFactoryRequest $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(UpdateFactoryRequest $request)
@@ -131,7 +131,7 @@ class FactoryController extends Controller
     /**
      * Store a newly created announcement in storage.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param \App\Http\Requests\Admin\StoreAnnouncementRequest $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function storeAnnouncement(StoreAnnouncementRequest $request)
@@ -162,7 +162,7 @@ class FactoryController extends Controller
     /**
     * Store a newly created custom field in storage.
     *
-    * @param  \Illuminate\Http\Request  $request
+     * @param \App\Http\Requests\Admin\StoreCustomFieldRequest $request
      * @return \Illuminate\Http\RedirectResponse
     */
     public function storeCustomField(StoreCustomFieldRequest $request)


### PR DESCRIPTION
## Summary
- use specific request class docs in FactoryController

## Testing
- `php -l app/Http/Controllers/Admin/FactoryController.php`
- `./vendor/bin/phpstan analyse app/Http/Controllers/Admin/FactoryController.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a041bf8c832d9c36b735a561f845