### PR TITLE
Add database presence assertion in registration test

### DIFF
--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -26,6 +26,7 @@ class RegistrationTest extends TestCase
             'password_confirmation' => 'password',
         ]);
 
+        $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
         $this->assertAuthenticated();
         $response->assertRedirect(RouteServiceProvider::HOME);
     }


### PR DESCRIPTION
## Summary
- ensure registration test verifies user persists in database

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: ext-ldap extension missing, 403 when fetching packages)*
- `vendor/bin/phpunit tests/Feature/RegistrationTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a0427308832d84589b966fdb01fb