### PR TITLE
Add tests for document code generation

### DIFF
--- a/tests/Unit/DocumentCodeGeneratorTest.php
+++ b/tests/Unit/DocumentCodeGeneratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Services\DocumentCodeGenerator;
+use App\Models\DocumentCodeTemplate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+
+class DocumentCodeGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_generates_code_from_template(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 2));
+        DocumentCodeTemplate::create([
+            'document_type' => 'invoice',
+            'template' => 'INV-{year}{month}{day}-{id}',
+        ]);
+
+        $generator = new DocumentCodeGenerator();
+        $code = $generator->generateDocumentCode('invoice', 5);
+
+        $this->assertSame('INV-20240102-6', $code);
+    }
+
+    public function test_it_uses_default_template_when_none_exists(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 2));
+        $generator = new DocumentCodeGenerator();
+
+        $code = $generator->generateDocumentCode('invoice');
+
+        $this->assertSame('INVOICE-0', $code);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering DocumentCodeGenerator service

## Testing
- `vendor/bin/phpunit tests/Unit/DocumentCodeGeneratorTest.php` *(fails: No such file or directory)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: GitHub 403, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a57c415c832da307845b54f41f07