### PR TITLE
Validate permission IDs before syncing

### DIFF
--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -85,10 +85,17 @@ class RoleController extends Controller
      */
     public function RolePemissionStore(Request $request){
 
-        $role= Role::findById($request->role_id);
-        $role->syncPermissions($request->permission);
+        $validated = $request->validate([
+            'role_id' => ['required', 'integer', 'exists:roles,id'],
+            'permission' => ['required', 'array'],
+            'permission.*' => ['integer', 'exists:permissions,id'],
+        ]);
 
-        
+        $role = Role::findById($validated['role_id']);
+
+        $permissions = Permission::whereIn('id', $validated['permission'])->pluck('name');
+        $role->syncPermissions($permissions);
+
         return to_route('admin.roles.permissions')->with('success', 'Permissions added in Role successfully.');
         /*$data = array();
         $permissions = ;


### PR DESCRIPTION
## Summary
- Ensure `RolePemissionStore` validates incoming permission IDs and role ID
- Retrieve permission names from provided IDs before syncing

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-ldap` *(failed: CONNECT tunnel failed, response 403)*
- `php artisan test` *(failed: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a79148f004832db73e03776d9c2e4d