### PR TITLE
Refactor task calculation logs to use arrays

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -8,6 +8,7 @@ use App\Models\Planning\Task;
 use App\Models\Workflow\OrderLines;
 use App\Models\Times\TimesBanckHoliday;
 use Illuminate\Database\Eloquent\Builder;
+use App\Models\TaskCalculationLog;
 
 class TaskCalculationDate extends Component
 {
@@ -17,9 +18,9 @@ class TaskCalculationDate extends Component
     public $toBeCalculateDate = true;
     public $toBeCalculateRessource = true;
     
-    public $progressDateLog  = '';
+    public $progressDateMessages  = [];
     public $countTaskCalculateDate = 0;
-    public $progressRessourceLog  = '';
+    public $progressRessourceMessages  = [];
     public $countTaskCalculateRessource = 0;
 
     public function render()
@@ -28,8 +29,8 @@ class TaskCalculationDate extends Component
             'Tasklists' =>  $this->Tasklists,
             'countTaskCalculateDate' =>  $this->countTaskCalculateDate,
             'countTaskCalculateRessource' =>  $this->countTaskCalculateRessource,
-            'progressDateLog' =>  $this->progressDateLog,
-            'progressRessourceLog' =>  $this->progressRessourceLog,
+            'progressDateMessages' =>  $this->progressDateMessages,
+            'progressRessourceMessages' =>  $this->progressRessourceMessages,
         ]);
     }
 
@@ -54,16 +55,28 @@ class TaskCalculationDate extends Component
                     'userforced_ressource' => 0,
                 ]);
 
-                $this->progressRessourceLog .= '<li>'. $resource->label. ' affected to task #'. $task->id  .' for '.  $task->service['label']  .' service </li>';
+                $message = $resource->label. ' affected to task #'. $task->id  .' for '.  $task->service['label']  .' service';
+                $this->progressRessourceMessages[] = $message;
+                TaskCalculationLog::create([
+                    'task_id' => $task->id,
+                    'type'    => 'resource',
+                    'message' => $message,
+                ]);
             } else {
                 // Aucune ressource trouvée pour ce service, gestion des erreurs ou autre action nécessaire
                 // Par exemple, vous pouvez journaliser un avertissement ou effectuer une autre logique
                 // en fonction des besoins de votre application.
-                $this->progressRessourceLog .= '<li> No ressource affected to task #'. $task->id  .' for '.  $task->service['label']  .' service </li>';
+                $message = 'No ressource affected to task #'. $task->id  .' for '.  $task->service['label']  .' service';
+                $this->progressRessourceMessages[] = $message;
+                TaskCalculationLog::create([
+                    'task_id' => $task->id,
+                    'type'    => 'resource',
+                    'message' => $message,
+                ]);
             }
             $this->countTaskCalculateRessource += 1;
-            $this->progressRessource  += (1/$countLines)*100; 
-        }     
+            $this->progressRessource  += (1/$countLines)*100;
+        }
 
         $this->toBeCalculateRessource = false;
     }
@@ -104,8 +117,14 @@ class TaskCalculationDate extends Component
                 // Date de fin de la tâche actuelle
                 $endDate = $this->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
                 $task->end_date = $endDate;
-        
-                $this->progressDateLog .= '<li>End date : '. $endDate .' updated for task #'. $task->id .' ordre '. $task->ordre .'</li>';
+
+                $message = 'End date : '. $endDate .' updated for task #'. $task->id .' ordre '. $task->ordre;
+                $this->progressDateMessages[] = $message;
+                TaskCalculationLog::create([
+                    'task_id' => $task->id,
+                    'type'    => 'date',
+                    'message' => $message,
+                ]);
         
                 // Calcul de la durée ajustée de la tâche
                 $totalTaskHours = $task->TotalTime();

--- a/app/Models/TaskCalculationLog.php
+++ b/app/Models/TaskCalculationLog.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TaskCalculationLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'task_id',
+        'type',
+        'message',
+    ];
+}
+

--- a/database/migrations/2025_03_10_000000_create_task_calculation_logs_table.php
+++ b/database/migrations/2025_03_10_000000_create_task_calculation_logs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('task_calculation_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('task_id')->nullable()->constrained('tasks')->onDelete('cascade');
+            $table->string('type');
+            $table->text('message');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('task_calculation_logs');
+    }
+};
+

--- a/resources/views/livewire/task-calculation-date.blade.php
+++ b/resources/views/livewire/task-calculation-date.blade.php
@@ -11,7 +11,9 @@
         <div class="card-body">
             <x-adminlte-progress theme="success" value="{{ $progressRessource }}"/> {{ $progressRessource }} % ({{ $countTaskCalculateRessource  }})
             <ul>
-                {!! $progressRessourceLog!!}
+                @foreach($progressRessourceMessages as $message)
+                    <li>{{ $message }}</li>
+                @endforeach
             </ul>
         </div>
     </x-adminlte-modal>
@@ -29,7 +31,9 @@
             <x-adminlte-progress theme="success" value="{{ $progressDate }}"/> {{ $progressDate }} % ({{ $countTaskCalculateDate }})
         </div>
         <ul>
-            {!! $progressDateLog !!}
+            @foreach($progressDateMessages as $message)
+                <li>{{ $message }}</li>
+            @endforeach
         </ul>
         
     </x-adminlte-modal>


### PR DESCRIPTION
## Summary
- track task calculation messages in arrays instead of concatenated HTML
- render progress logs via Blade `@foreach`
- persist each message using new `TaskCalculationLog` model and migration

## Testing
- `composer install` *(fails: ext-ldap extension missing / GitHub token required)*
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c1906b10832db19d5a333938a43e