### PR TITLE
Implement resource capacity aware task assignment

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -35,35 +35,38 @@ class TaskCalculationDate extends Component
 
     public function calculateRessource()
     {
-        // Dans votre contrôleur ou ailleurs où vous avez besoin de cette information
-        $countLines = Task::whereNotNull('order_lines_id')->whereDoesntHave('resources')->count();
+        $countLines = Task::whereNotNull('order_lines_id')
+            ->whereDoesntHave('resources')
+            ->count();
 
-        $taskWithoutRessources = Task::whereNotNull('order_lines_id')->whereDoesntHave('resources')->get();
+        $taskWithoutRessources = Task::whereNotNull('order_lines_id')
+            ->whereDoesntHave('resources')
+            ->get();
 
         foreach ($taskWithoutRessources as $task) {
-            // Obtenez le service associé à la tâche
             $service = $task->service;
-        
-            // Obtenez la première ressource associée à ce service (ajustez selon vos besoins)
-            $resource = $service->Ressources()->first();
+            $taskDate = $task->start_date ? Carbon::parse($task->start_date) : Carbon::today();
+
+            $resource = $service->Ressources
+                ->first(function ($res) use ($taskDate, $task) {
+                    return $res->remainingCapacity($taskDate) >= $task->TotalTime();
+                });
 
             if ($resource) {
-                // Attachez la ressource à la tâche
                 $task->resources()->attach($resource->id, [
                     'autoselected_ressource' => 0,
                     'userforced_ressource' => 0,
                 ]);
 
-                $this->progressRessourceLog .= '<li>'. $resource->label. ' affected to task #'. $task->id  .' for '.  $task->service['label']  .' service </li>';
+                $this->progressRessourceLog .= '<li>' . $resource->label . ' affected to task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
             } else {
-                // Aucune ressource trouvée pour ce service, gestion des erreurs ou autre action nécessaire
-                // Par exemple, vous pouvez journaliser un avertissement ou effectuer une autre logique
-                // en fonction des besoins de votre application.
-                $this->progressRessourceLog .= '<li> No ressource affected to task #'. $task->id  .' for '.  $task->service['label']  .' service </li>';
+                $this->progressRessourceLog .= '<li> No ressource available for task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
+                throw new \RuntimeException('No resource has remaining capacity for task #' . $task->id);
             }
+
             $this->countTaskCalculateRessource += 1;
-            $this->progressRessource  += (1/$countLines)*100; 
-        }     
+            $this->progressRessource += (1 / $countLines) * 100;
+        }
 
         $this->toBeCalculateRessource = false;
     }

--- a/app/Models/Methods/MethodsRessources.php
+++ b/app/Models/Methods/MethodsRessources.php
@@ -6,6 +6,7 @@ use App\Models\Planning\Task;
 use App\Models\Methods\MethodsSection;
 use App\Models\Methods\MethodsLocation;
 use App\Models\Methods\MethodsServices;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -35,6 +36,24 @@ class MethodsRessources extends Model
     public function locations()
     {
         return $this->hasMany(MethodsLocation::class);
+    }
+
+    /**
+     * Calculate remaining available capacity for the given day.
+     *
+     * The capacity field represents the number of hours available per day
+     * for this resource. This method sums the duration of tasks already
+     * assigned on the provided date and subtracts this from the daily
+     * capacity.
+     */
+    public function remainingCapacity(Carbon $date): float
+    {
+        $usedCapacity = $this->tasks()
+            ->whereDate('start_date', $date->toDateString())
+            ->get()
+            ->sum(fn (Task $task) => $task->TotalTime());
+
+        return max(0, $this->capacity - $usedCapacity);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add remainingCapacity calculation to resource model
- auto-select resources with available capacity for tasks
- throw exception when no resource remains available

## Testing
- ⚠️ `composer install --ignore-platform-req=ext-ldap` *(missing php-ldap extension and network issues prevented installing dependencies)*
- ⚠️ `./vendor/bin/phpunit` *(dependencies not installed, test suite could not run)*
- ✅ `php -l app/Models/Methods/MethodsRessources.php`
- ✅ `php -l app/Livewire/TaskCalculationDate.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9c17a1200832dbef84eeb2681f776