### PR TITLE
test: add TaskDateCalculator tests

### DIFF
--- a/app/Services/TaskDateCalculator.php
+++ b/app/Services/TaskDateCalculator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use App\Models\Planning\Task;
+use App\Models\Methods\MethodsRessources;
+use App\Models\Times\TimesBanckHoliday;
+use Illuminate\Support\Collection;
+
+class TaskDateCalculator
+{
+    /**
+     * Adjust date to previous working day if it falls on weekend or bank holiday.
+     */
+    public function adjustForWeekendsAndHolidays(Carbon $date): Carbon
+    {
+        do {
+            if ($date->isSaturday()) {
+                $date->subDay();
+            } elseif ($date->isSunday()) {
+                $date->subDays(2);
+            }
+            if (TimesBanckHoliday::isBankHoliday($date)) {
+                $date->subDay();
+            }
+        } while ($date->isWeekend() || TimesBanckHoliday::isBankHoliday($date));
+
+        return $date;
+    }
+
+    /**
+     * Calculate start and end dates for the given task.
+     *
+     * @return array{0: Carbon,1: Carbon}
+     */
+    public function calculateTaskDates(Task $task, Carbon $end): array
+    {
+        $end = $this->adjustForWeekendsAndHolidays($end);
+        $duration = ($task->seting_time ?? 0) + (($task->unit_time ?? 0) * ($task->qty ?? 0));
+        $start = (clone $end)->subHours($duration);
+        $start = $this->adjustForWeekendsAndHolidays($start);
+        return [$start, $end];
+    }
+
+    /**
+     * Select a resource that still has capacity.
+     */
+    public function selectResourceForTask(Task $task, Collection|array $resources): ?MethodsRessources
+    {
+        foreach ($resources as $resource) {
+            if ($resource->capacity >= 1) {
+                return $resource;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/Unit/TaskDateCalculatorTest.php
+++ b/tests/Unit/TaskDateCalculatorTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Carbon\Carbon;
+use App\Services\TaskDateCalculator;
+use App\Models\Methods\MethodsServices;
+use App\Models\Methods\MethodsUnits;
+use App\Models\Methods\MethodsRessources;
+use App\Models\Planning\Task;
+use App\Models\Times\TimesBanckHoliday;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaskDateCalculatorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        Schema::create('methods_services', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->nullable();
+            $table->integer('ordre')->default(1);
+            $table->string('label');
+            $table->integer('type')->default(1);
+            $table->double('hourly_rate')->default(0);
+            $table->double('margin')->default(0);
+            $table->string('color')->nullable();
+            $table->string('picture')->nullable();
+            $table->integer('companies_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('methods_units', function (Blueprint $table) {
+            $table->id();
+            $table->string('code');
+            $table->string('label');
+            $table->string('type')->nullable();
+            $table->boolean('default')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->integer('ordre')->default(1);
+            $table->foreignId('methods_services_id')->nullable();
+            $table->foreignId('methods_units_id')->nullable();
+            $table->float('seting_time')->default(0);
+            $table->float('unit_time')->default(0);
+            $table->integer('qty')->default(1);
+            $table->integer('qty_init')->default(1);
+            $table->integer('type')->default(1);
+            $table->integer('status_id')->default(1);
+            $table->timestamp('start_date')->nullable();
+            $table->timestamp('end_date')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('methods_ressources', function (Blueprint $table) {
+            $table->id();
+            $table->integer('ordre')->default(1);
+            $table->string('code')->nullable();
+            $table->string('label');
+            $table->integer('capacity')->default(1);
+            $table->foreignId('methods_services_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('times_banck_holidays', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('fixed')->default(true);
+            $table->date('date');
+            $table->string('label');
+            $table->timestamps();
+        });
+    }
+
+    public function test_adjustment_of_weekends_and_holidays(): void
+    {
+        TimesBanckHoliday::create(['fixed' => false, 'date' => '2024-05-08', 'label' => 'Holiday']);
+        $calculator = new TaskDateCalculator();
+
+        $this->assertSame('2024-05-03', $calculator->adjustForWeekendsAndHolidays(Carbon::create(2024, 5, 4))->toDateString());
+        $this->assertSame('2024-05-07', $calculator->adjustForWeekendsAndHolidays(Carbon::create(2024, 5, 8))->toDateString());
+    }
+
+    public function test_calculates_start_and_end_for_simple_task(): void
+    {
+        $service = MethodsServicesFactory::new()->create();
+        $unit = MethodsUnitsFactory::new()->create();
+        $task = TaskTestFactory::new()->create([
+            'methods_services_id' => $service->id,
+            'methods_units_id' => $unit->id,
+            'seting_time' => 1,
+            'unit_time' => 1,
+            'qty' => 1,
+            'qty_init' => 1,
+        ]);
+
+        $calculator = new TaskDateCalculator();
+        $end = Carbon::create(2024, 5, 3, 18, 0, 0);
+        [$start, $finish] = $calculator->calculateTaskDates($task, $end);
+
+        $this->assertEquals('2024-05-03 16:00:00', $start->format('Y-m-d H:i:s'));
+        $this->assertEquals('2024-05-03 18:00:00', $finish->format('Y-m-d H:i:s'));
+    }
+
+    public function test_selects_resource_respecting_capacity(): void
+    {
+        $service = MethodsServicesFactory::new()->create();
+        $unit = MethodsUnitsFactory::new()->create();
+        $task = TaskTestFactory::new()->create([
+            'methods_services_id' => $service->id,
+            'methods_units_id' => $unit->id,
+            'qty' => 1,
+            'seting_time' => 0,
+            'unit_time' => 1,
+            'qty_init' => 1,
+        ]);
+
+        $insufficient = MethodsRessourcesFactory::new()->create([
+            'methods_services_id' => $service->id,
+            'capacity' => 0,
+            'label' => 'R1',
+        ]);
+        $sufficient = MethodsRessourcesFactory::new()->create([
+            'methods_services_id' => $service->id,
+            'capacity' => 2,
+            'label' => 'R2',
+        ]);
+
+        $calculator = new TaskDateCalculator();
+        $selected = $calculator->selectResourceForTask($task, collect([$insufficient, $sufficient]));
+
+        $this->assertSame('R2', $selected->label);
+    }
+}
+
+class MethodsServicesFactory extends Factory
+{
+    protected $model = MethodsServices::class;
+
+    public function definition(): array
+    {
+        return [
+            'code' => 'SVC',
+            'ordre' => 1,
+            'label' => 'Service',
+            'type' => 1,
+            'hourly_rate' => 10,
+            'margin' => 0,
+            'color' => '#000',
+            'picture' => '',
+            'companies_id' => 1,
+        ];
+    }
+}
+
+class MethodsUnitsFactory extends Factory
+{
+    protected $model = MethodsUnits::class;
+
+    public function definition(): array
+    {
+        return [
+            'code' => 'U',
+            'label' => 'Unit',
+            'type' => 'qty',
+            'default' => true,
+        ];
+    }
+}
+
+class TaskTestFactory extends Factory
+{
+    protected $model = Task::class;
+
+    public function definition(): array
+    {
+        return [
+            'label' => 'Task',
+            'ordre' => 1,
+            'methods_services_id' => null,
+            'methods_units_id' => null,
+            'seting_time' => 1,
+            'unit_time' => 1,
+            'qty' => 1,
+            'qty_init' => 1,
+            'type' => 1,
+            'status_id' => 1,
+        ];
+    }
+}
+
+class MethodsRessourcesFactory extends Factory
+{
+    protected $model = MethodsRessources::class;
+
+    public function definition(): array
+    {
+        return [
+            'ordre' => 1,
+            'code' => 'RES',
+            'label' => 'Resource',
+            'capacity' => 1,
+            'methods_services_id' => null,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add TaskDateCalculator service handling working-day adjustments and resource choice
- cover weekend/holiday shifts, simple task scheduling and capacity-aware resource selection

## Testing
- `php artisan test tests/Unit/TaskDateCalculatorTest.php` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a9c185c594832dbe1c27e3854e3467