### PR TITLE
Add working time utility and integrate precise task scheduling

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use Carbon\Carbon;
+use App\Support\WorkingTime;
 use Livewire\Component;
 use App\Models\Planning\Task;
 use App\Models\Workflow\OrderLines;
@@ -107,12 +108,12 @@ class TaskCalculationDate extends Component
         
                 $this->progressDateLog .= '<li>End date : '. $endDate .' updated for task #'. $task->id .' ordre '. $task->ordre .'</li>';
         
-                // Calcul de la durée ajustée de la tâche
+                // Calcul du temps à retrancher en tenant compte des jours ouvrés
                 $totalTaskHours = $task->TotalTime();
-                $adjustedTaskHours = $this->calculateWorkingHours($totalTaskHours);
-        
+                $secondsToSubtract = $this->calculateWorkingHours($endDate, $totalTaskHours);
+
                 // Calcul de la date de début
-                $elapsedTimeInSeconds += ($adjustedTaskHours * 3600);
+                $elapsedTimeInSeconds += $secondsToSubtract;
                 $startDate = $this->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
                 $task->start_date = $startDate;
                 $task->save();
@@ -184,13 +185,13 @@ class TaskCalculationDate extends Component
     }
 
     /**
-     * Calcule le temps ajusté en tenant compte des week-ends et des horaires
+     * Calcule précisément le temps à retrancher en tenant compte des
+     * horaires de travail, des week-ends et des jours fériés.
      */
-    private function calculateWorkingHours(int $totalTaskHours): int
+    private function calculateWorkingHours(Carbon $fromDate, int $totalTaskHours): int
     {
-        $workingDays = floor($totalTaskHours / 8);
-        $weekends = floor($workingDays / 5);
-        return $totalTaskHours + ($workingDays * 16) + ($weekends * 48);
+        $startDate = WorkingTime::subtractWorkingHours($fromDate, $totalTaskHours);
+        return $fromDate->diffInSeconds($startDate);
     }
     
 }

--- a/app/Support/WorkingTime.php
+++ b/app/Support/WorkingTime.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Support;
+
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use App\Models\Times\TimesBanckHoliday;
+
+class WorkingTime
+{
+    const WORK_START = 8;
+    const WORK_END = 18;
+
+    /**
+     * Subtract a number of working hours from a date.
+     *
+     * The method walks backwards hour by hour using CarbonPeriod and
+     * skips hours outside the working range (8h-18h), weekends and
+     * bank holidays defined by TimesBanckHoliday::isBankHoliday.
+     */
+    public static function subtractWorkingHours(Carbon $from, int $hours): Carbon
+    {
+        $remaining = (int) round($hours * 3600);
+        $current = $from->copy();
+
+        $period = CarbonPeriod::create($from, '-1 hour');
+        foreach ($period as $step) {
+            if ($remaining <= 0) {
+                break;
+            }
+
+            $hourStart = $step->copy()->subHour();
+            $current = $hourStart;
+
+            if (!self::isWorkingHour($hourStart)) {
+                continue;
+            }
+
+            if ($remaining >= 3600) {
+                $remaining -= 3600;
+            } else {
+                // Partial hour: position within current working hour
+                $current->addSeconds(3600 - $remaining);
+                $remaining = 0;
+            }
+        }
+
+        return $current;
+    }
+
+    private static function isWorkingHour(Carbon $date): bool
+    {
+        if ($date->isWeekend()) {
+            return false;
+        }
+
+        if (TimesBanckHoliday::isBankHoliday($date)) {
+            return false;
+        }
+
+        $hour = $date->hour;
+        return $hour >= self::WORK_START && $hour < self::WORK_END;
+    }
+}


### PR DESCRIPTION
## Summary
- add `WorkingTime` helper to step backwards through working days using `CarbonPeriod`
- use new helper in task date calculations and return exact seconds to subtract

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c18243d0832d98dacdce057c5d4b