### PR TITLE
feat: add asset management module

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Assets\Asset;
+use Illuminate\Support\Facades\Redirect;
+
+class AssetController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'check.factory', 'permission:asset_manager']);
+    }
+
+    public function index()
+    {
+        $assets = Asset::all();
+        return view('assets.assets-index', compact('assets'));
+    }
+
+    public function create()
+    {
+        return view('assets.assets-create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'category' => 'nullable|string',
+            'acquisition_value' => 'required|numeric',
+            'acquisition_date' => 'required|date',
+            'depreciation_duration' => 'required|integer',
+        ]);
+        $asset = Asset::create($data);
+        return Redirect::route('assets.show', $asset->id);
+    }
+
+    public function show($id)
+    {
+        $asset = Asset::with('accountingEntries')->findOrFail($id);
+        return view('assets.assets-show', compact('asset'));
+    }
+
+    public function edit($id)
+    {
+        $asset = Asset::findOrFail($id);
+        return view('assets.assets-edit', compact('asset'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $asset = Asset::findOrFail($id);
+        $data = $request->validate([
+            'name' => 'required|string',
+            'category' => 'nullable|string',
+            'acquisition_value' => 'required|numeric',
+            'acquisition_date' => 'required|date',
+            'depreciation_duration' => 'required|integer',
+        ]);
+        $asset->update($data);
+        return Redirect::route('assets.show', $asset->id);
+    }
+
+    public function destroy($id)
+    {
+        $asset = Asset::findOrFail($id);
+        $asset->delete();
+        return Redirect::route('assets');
+    }
+}

--- a/app/Models/Accounting/AccountingEntry.php
+++ b/app/Models/Accounting/AccountingEntry.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Number;
 use App\Models\Companies\Companies;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Accounting\AccountingAllocation;
+use App\Models\Assets\Asset;
 
 /**
  * Class AccountingEntry
@@ -41,6 +42,7 @@ class AccountingEntry extends Model
         'currency_code',
         'invoice_line_id',
         'purchase_invoice_line_id',
+        'asset_id',
         'exported'
     ];
 
@@ -73,6 +75,16 @@ class AccountingEntry extends Model
     public function accountingAllocation()
     {
         return $this->belongsTo(AccountingAllocation::class);
+    }
+
+    /**
+     * Get the asset associated with the accounting entry.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function asset()
+    {
+        return $this->belongsTo(Asset::class);
     }
 
     /**

--- a/app/Models/Assets/Asset.php
+++ b/app/Models/Assets/Asset.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\Assets;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Accounting\AccountingEntry;
+
+class Asset extends Model
+{
+    protected $fillable = [
+        'name',
+        'category',
+        'acquisition_value',
+        'acquisition_date',
+        'depreciation_duration',
+    ];
+
+    protected $casts = [
+        'acquisition_date' => 'date',
+        'acquisition_value' => 'decimal:2',
+        'depreciation_duration' => 'integer',
+    ];
+
+    public function accountingEntries(): HasMany
+    {
+        return $this->hasMany(AccountingEntry::class);
+    }
+}

--- a/database/migrations/2025_03_11_000001_create_assets_table.php
+++ b/database/migrations/2025_03_11_000001_create_assets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('assets', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('category')->nullable();
+            $table->decimal('acquisition_value', 15, 2);
+            $table->date('acquisition_date');
+            $table->integer('depreciation_duration');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('assets');
+    }
+};

--- a/database/migrations/2025_03_11_000002_add_asset_id_to_accounting_entries_table.php
+++ b/database/migrations/2025_03_11_000002_add_asset_id_to_accounting_entries_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('accounting_entries', function (Blueprint $table) {
+            $table->unsignedBigInteger('asset_id')->nullable()->after('purchase_invoice_line_id');
+            $table->foreign('asset_id')->references('id')->on('assets')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('accounting_entries', function (Blueprint $table) {
+            $table->dropForeign(['asset_id']);
+            $table->dropColumn('asset_id');
+        });
+    }
+};

--- a/database/seeders/AssetRolePermissionSeeder.php
+++ b/database/seeders/AssetRolePermissionSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class AssetRolePermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $permission = Permission::firstOrCreate(['name' => 'asset_manager']);
+        Role::firstOrCreate(['name' => 'asset_manager'])->givePermissionTo($permission);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ use Database\Seeders\CreateAdminUserSeeder;
 use Database\Seeders\MethodsFamiliesSeeder;
 use Database\Seeders\OrderLinesTableSeeder;
 use Database\Seeders\PermissionTableSeeder;
+use Database\Seeders\AssetRolePermissionSeeder;
 use Database\Seeders\QuoteLinesTableSeeder;
 use Database\Seeders\EstimatedBudgetsSeeder;
 use Database\Seeders\MethodsUnitTableSeeder;
@@ -53,6 +54,7 @@ class DatabaseSeeder extends Seeder
             MethodsRessourcesSeeder::class,
             MethodsFamiliesSeeder::class,
             PermissionTableSeeder::class,
+            AssetRolePermissionSeeder::class,
             CreateAdminUserSeeder::class,
             AllocationSeeder::class,
         ]);

--- a/database/seeders/PermissionTableSeeder.php
+++ b/database/seeders/PermissionTableSeeder.php
@@ -33,6 +33,7 @@ class PermissionTableSeeder  extends Seeder
                         'human-resources-menu',
                         'osh-menu',
                         'your-company-menu',
+                        'asset_manager',
                         ];
     
                         foreach ($permissions as $permission) {

--- a/resources/views/assets/assets-create.blade.php
+++ b/resources/views/assets/assets-create.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Create Asset</title>
+</head>
+<body>
+    <h1>Create Asset</h1>
+    <form method="POST" action="{{ route('assets.store') }}">
+        @csrf
+        <label>Name</label>
+        <input type="text" name="name" value="{{ old('name') }}"><br>
+        <label>Category</label>
+        <input type="text" name="category" value="{{ old('category') }}"><br>
+        <label>Acquisition Value</label>
+        <input type="number" step="0.01" name="acquisition_value" value="{{ old('acquisition_value') }}"><br>
+        <label>Acquisition Date</label>
+        <input type="date" name="acquisition_date" value="{{ old('acquisition_date') }}"><br>
+        <label>Depreciation Duration (months)</label>
+        <input type="number" name="depreciation_duration" value="{{ old('depreciation_duration') }}"><br>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/resources/views/assets/assets-edit.blade.php
+++ b/resources/views/assets/assets-edit.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Edit Asset</title>
+</head>
+<body>
+    <h1>Edit Asset</h1>
+    <form method="POST" action="{{ route('assets.update', $asset->id) }}">
+        @csrf
+        <label>Name</label>
+        <input type="text" name="name" value="{{ old('name', $asset->name) }}"><br>
+        <label>Category</label>
+        <input type="text" name="category" value="{{ old('category', $asset->category) }}"><br>
+        <label>Acquisition Value</label>
+        <input type="number" step="0.01" name="acquisition_value" value="{{ old('acquisition_value', $asset->acquisition_value) }}"><br>
+        <label>Acquisition Date</label>
+        <input type="date" name="acquisition_date" value="{{ old('acquisition_date', $asset->acquisition_date->format('Y-m-d')) }}"><br>
+        <label>Depreciation Duration (months)</label>
+        <input type="number" name="depreciation_duration" value="{{ old('depreciation_duration', $asset->depreciation_duration) }}"><br>
+        <button type="submit">Update</button>
+    </form>
+</body>
+</html>

--- a/resources/views/assets/assets-index.blade.php
+++ b/resources/views/assets/assets-index.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Assets</title>
+</head>
+<body>
+    <h1>Assets</h1>
+    <a href="{{ route('assets.create') }}">Create Asset</a>
+    <ul>
+        @foreach($assets as $asset)
+            <li><a href="{{ route('assets.show', $asset->id) }}">{{ $asset->name }}</a></li>
+        @endforeach
+    </ul>
+</body>
+</html>

--- a/resources/views/assets/assets-show.blade.php
+++ b/resources/views/assets/assets-show.blade.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Asset Details</title>
+</head>
+<body>
+    <h1>{{ $asset->name }}</h1>
+    <p>Category: {{ $asset->category }}</p>
+    <p>Acquisition Value: {{ $asset->acquisition_value }}</p>
+    <p>Acquisition Date: {{ $asset->acquisition_date->format('Y-m-d') }}</p>
+    <p>Depreciation Duration: {{ $asset->depreciation_duration }} months</p>
+    <a href="{{ route('assets.edit', $asset->id) }}">Edit</a>
+    <form method="POST" action="{{ route('assets.destroy', $asset->id) }}">
+        @csrf
+        @method('DELETE')
+        <button type="submit">Delete</button>
+    </form>
+    <h2>Accounting Entries</h2>
+    <ul>
+        @foreach($asset->accountingEntries as $entry)
+            <li>{{ $entry->entry_label }} - {{ $entry->debit_amount }} / {{ $entry->credit_amount }}</li>
+        @endforeach
+    </ul>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -237,6 +237,16 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
             Route::post('/edit/{id}', 'App\Http\Controllers\Accounting\VatController@update')->name('accounting.vat.update');
         }); });
 
+    Route::group(['prefix' => 'assets', 'middleware' => ['auth', 'check.factory']], function () {
+        Route::get('/', 'App\\Http\\Controllers\\AssetController@index')->name('assets');
+        Route::get('/create', 'App\\Http\\Controllers\\AssetController@create')->name('assets.create');
+        Route::post('/create', 'App\\Http\\Controllers\\AssetController@store')->name('assets.store');
+        Route::get('/{id}', 'App\\Http\\Controllers\\AssetController@show')->name('assets.show');
+        Route::get('/edit/{id}', 'App\\Http\\Controllers\\AssetController@edit')->name('assets.edit');
+        Route::post('/edit/{id}', 'App\\Http\\Controllers\\AssetController@update')->name('assets.update');
+        Route::delete('/{id}', 'App\\Http\\Controllers\\AssetController@destroy')->name('assets.destroy');
+    });
+
     Route::group(['prefix' => 'times', 'middleware' => ['auth', 'check.factory']], function () {
         // Index route
         Route::get('/', 'App\Http\Controllers\Times\TimesController@index')->name('times');

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Models\Assets\Asset;
+
+class AssetTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testCreateAsset()
+    {
+        $data = [
+            'name' => 'Laptop',
+            'category' => 'IT',
+            'acquisition_value' => 1500,
+            'acquisition_date' => '2024-01-01',
+            'depreciation_duration' => 36,
+        ];
+
+        $asset = Asset::create($data);
+
+        $this->assertDatabaseHas('assets', ['name' => 'Laptop']);
+        $this->assertEquals('IT', $asset->category);
+    }
+}


### PR DESCRIPTION
## Summary
- add Asset model, controller, routes, and views for CRUD
- link assets to accounting entries with migrations and relation
- seed asset_manager role/permission

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c59f6d30832da86f4c82a4ec385b