### PR TITLE
ci: add ldap extension and composer auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: ldap, zip, pdo_mysql, pdo_pgsql, sqlite3, bcmath, gd, intl, pcntl
+          coverage: none
+
+      - name: Configure Composer authentication
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: composer config --global github-oauth.github.com "$GITHUB_TOKEN"
+
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --colors=always


### PR DESCRIPTION
## Summary
- run CI workflow with PHP 8.2 and required extensions including ldap
- configure Composer authentication before installing dependencies
- run PHPUnit tests in CI

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-ldap` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c723e174832d8627828f217f9f63