### PR TITLE
feat: add contextual logging for orders and quotes

### DIFF
--- a/app/Http/Controllers/Workflow/QuotesController.php
+++ b/app/Http/Controllers/Workflow/QuotesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Workflow;
 
 use Carbon\Carbon;
 use Illuminate\Support\Number;
+use Illuminate\Support\Facades\Log;
 use App\Models\Workflow\Quotes;
 use App\Services\QuoteKPIService;
 use App\Traits\NextPreviousTrait;
@@ -114,11 +115,27 @@ class QuotesController extends Controller
     {
         $validated = $request->validated();
 
-        $Quote = Quotes::findOrFail($request->id);
-        $Quote->fill($validated);
-        $Quote->save();
-        
-        return redirect()->route('quotes.show', ['id' => $Quote->id])->with('success', 'Successfully updated quote');
+        try {
+            $Quote = Quotes::findOrFail($request->id);
+            $Quote->fill($validated);
+            $Quote->save();
+
+            Log::channel('quotes')->info(__('general_content.quote_updated_log_trans_key'), [
+                'user_id' => $request->user()?->id,
+                'quote_id' => $Quote->id,
+                'parameters' => $validated,
+            ]);
+
+            return redirect()->route('quotes.show', ['id' => $Quote->id])->with('success', __('general_content.quote_update_success_trans_key'));
+        } catch (\Exception $e) {
+            Log::channel('quotes')->error(__('general_content.quote_update_failed_log_trans_key'), [
+                'user_id' => $request->user()?->id,
+                'quote_id' => $request->id,
+                'parameters' => $validated,
+                'exception' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
     }
 
     public function saveProjectEstimate(ProjectEstimateRequest $request, $quoteId)

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
 use App\Models\Workflow\Orders;
 use App\Notifications\OrderNotification;
 
@@ -52,31 +53,57 @@ class OrderService
         $quotes_id,
         $filename
     ) {
-        
-        $OrdersCreated = Orders::create([
-            'uuid' => Str::uuid(),
-            'code' => $code,
-            'label' => $label,
-            'customer_reference' => $customerReference,
-            'companies_id' => $companyId,
-            'companies_contacts_id' => $companyContactId,
-            'companies_addresses_id' => $companyAddressId,
-            'validity_date' => $validityDate,
-            'statu' => $status,
-            'user_id' => $userId,
-            'accounting_payment_conditions_id' => $paymentConditionId,
-            'accounting_payment_methods_id' => $paymentMethodId,
-            'accounting_deliveries_id' => $deliveryId,
-            'comment' => $comment,
-            'type' => $type,
-            'quotes_id' => $quotes_id,
-            'csv_file_name' => $filename,
-        ]);
+        try {
+            $OrdersCreated = Orders::create([
+                'uuid' => Str::uuid(),
+                'code' => $code,
+                'label' => $label,
+                'customer_reference' => $customerReference,
+                'companies_id' => $companyId,
+                'companies_contacts_id' => $companyContactId,
+                'companies_addresses_id' => $companyAddressId,
+                'validity_date' => $validityDate,
+                'statu' => $status,
+                'user_id' => $userId,
+                'accounting_payment_conditions_id' => $paymentConditionId,
+                'accounting_payment_methods_id' => $paymentMethodId,
+                'accounting_deliveries_id' => $deliveryId,
+                'comment' => $comment,
+                'type' => $type,
+                'quotes_id' => $quotes_id,
+                'csv_file_name' => $filename,
+            ]);
 
-        // notification
-        $this->notificationService->sendNotification(OrderNotification::class, $OrdersCreated, 'orders_notification');
+            // notification
+            $this->notificationService->sendNotification(OrderNotification::class, $OrdersCreated, 'orders_notification');
 
-        return $OrdersCreated;
+            Log::channel('orders')->info(__('general_content.order_created_log_trans_key'), [
+                'user_id' => $userId,
+                'order_id' => $OrdersCreated->id,
+                'parameters' => [
+                    'code' => $code,
+                    'company_id' => $companyId,
+                    'contact_id' => $companyContactId,
+                    'address_id' => $companyAddressId,
+                    'status' => $status,
+                ],
+            ]);
+
+            return $OrdersCreated;
+        } catch (\Exception $e) {
+            Log::channel('orders')->error(__('general_content.order_creation_failed_log_trans_key'), [
+                'user_id' => $userId,
+                'exception' => $e->getMessage(),
+                'parameters' => [
+                    'code' => $code,
+                    'company_id' => $companyId,
+                    'contact_id' => $companyContactId,
+                    'address_id' => $companyAddressId,
+                    'status' => $status,
+                ],
+            ]);
+            throw $e;
+        }
     }
 
     

--- a/config/logging.php
+++ b/config/logging.php
@@ -47,6 +47,18 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
         ],
 
+        'orders' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/orders.log'),
+            'level' => env('LOG_LEVEL', 'info'),
+        ],
+
+        'quotes' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/quotes.log'),
+            'level' => env('LOG_LEVEL', 'info'),
+        ],
+
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1088,4 +1088,10 @@ return [
     'production_declaration_trans_key'         => 'Production Declaration',
     'note_1_trans_key'                         => 'Consult and plan the tasks to be carried out.',
     'note_2_trans_key'                         => 'Make production declarations.',
+
+    'order_created_log_trans_key'              => 'Order created',
+    'order_creation_failed_log_trans_key'      => 'Order creation failed',
+    'quote_updated_log_trans_key'              => 'Quote updated',
+    'quote_update_failed_log_trans_key'        => 'Quote update failed',
+    'quote_update_success_trans_key'           => 'Successfully updated quote',
 ];

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1088,4 +1088,10 @@ return [
     'production_declaration_trans_key'         => 'Déclaration de Production',
     'note_1_trans_key'                         => 'Consult and plan the tasks to be carried out.',
     'note_2_trans_key'                         => 'Faites des déclarations de production',
+
+    'order_created_log_trans_key'              => 'Commande créée',
+    'order_creation_failed_log_trans_key'      => 'Échec de création de la commande',
+    'quote_updated_log_trans_key'              => 'Devis mis à jour',
+    'quote_update_failed_log_trans_key'        => 'Échec de mise à jour du devis',
+    'quote_update_success_trans_key'           => 'Devis mis à jour avec succès',
 ];


### PR DESCRIPTION
## Summary
- add contextual logs for order creation
- log quote updates and report failures
- configure dedicated order and quote log channels

## Testing
- `composer install --no-interaction --no-progress` *(fails: ext-ldap missing; network 403 downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c861f170832d97756010c6198b5c