### PR TITLE
feat: add serial number activity history

### DIFF
--- a/app/Livewire/LogsViewer.php
+++ b/app/Livewire/LogsViewer.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use Livewire\Component;
 use Spatie\Activitylog\Models\Activity;
 use Carbon\Carbon;
+use App\Models\User;
 
 class LogsViewer extends Component
 {
@@ -15,29 +16,38 @@ class LogsViewer extends Component
     public $availableModels;
     public $subjectType;  // Variable for the model type (quote, order, etc.)
     public $subjectId;    // Variable for the model ID
+    public $userId;
+    public $availableUsers;
 
     public function mount($subjectType = null, $subjectId = null)  // Pass the model type and ID
     {
         $this->startDate = Carbon::now()->toDateString();
         $this->endDate = Carbon::now()->toDateString();
         $this->availableModels = Activity::select('subject_type')->distinct()->pluck('subject_type');
+        $this->availableUsers = User::select('id', 'name')->get();
         $this->subjectType = $subjectType;  // Initialize the model type
         $this->subjectId = $subjectId;      // Initialize the model ID
     }
 
     public function filterLogs()
     {
-        $this->validate([
-            'model' => 'required|string',
+        $rules = [
             'startDate' => 'required|date',
             'endDate' => 'required|date|after_or_equal:startDate',
-        ]);
+            'userId' => 'nullable|integer',
+        ];
+
+        if (!$this->subjectType) {
+            $rules['model'] = 'required|string';
+        }
+
+        $this->validate($rules);
     }
 
     public function render()
     {
         // If filters are submitted or a specific topic is set
-        if ($this->model || $this->startDate || $this->endDate || $this->subjectType || $this->subjectId) {
+        if ($this->model || $this->startDate || $this->endDate || $this->subjectType || $this->subjectId || $this->userId) {
             $query = Activity::query();
 
             if ($this->model) {
@@ -56,6 +66,10 @@ class LogsViewer extends Component
 
             if ($this->endDate) {
                 $query->whereDate('created_at', '<=', $this->endDate);
+            }
+
+            if ($this->userId) {
+                $query->where('causer_id', $this->userId);
             }
     
             $this->logs = $query->latest()->get();

--- a/app/Models/Products/SerialNumbers.php
+++ b/app/Models/Products/SerialNumbers.php
@@ -9,10 +9,12 @@ use App\Models\Workflow\OrderLines;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Purchases\PurchaseReceiptLines;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\LogOptions;
 
 class SerialNumbers extends Model
 {
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     // Fillable attributes for mass assignment
     protected $fillable= [
@@ -25,6 +27,20 @@ class SerialNumbers extends Model
         'status',
         'additional_information',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()->logOnly([
+            'products_id',
+            'companies_id',
+            'order_line_id',
+            'task_id',
+            'purchase_receipt_line_id',
+            'serial_number',
+            'status',
+            'additional_information',
+        ]);
+    }
 
     public function Product()
     {

--- a/app/Services/SerialNumberService.php
+++ b/app/Services/SerialNumberService.php
@@ -4,16 +4,38 @@ namespace App\Services;
 
 use App\Models\Products\SerialNumbers;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Auth;
 
 class SerialNumberService
 {
     public function createSerialNumber($productId, $OrderLineID, $status = 1)
     {
-        return SerialNumbers::create([
+        $serial = SerialNumbers::create([
             'products_id' => $productId,
             'order_line_id' => $OrderLineID,
             'serial_number' => Str::uuid(),
             'status' => $status,
         ]);
+
+        activity()
+            ->performedOn($serial)
+            ->causedBy(Auth::user())
+            ->withProperties(['status' => $status])
+            ->log('serial number created');
+
+        return $serial;
+    }
+
+    public function updateStatus(SerialNumbers $serialNumber, int $status): SerialNumbers
+    {
+        $serialNumber->update(['status' => $status]);
+
+        activity()
+            ->performedOn($serialNumber)
+            ->causedBy(Auth::user())
+            ->withProperties(['status' => $status])
+            ->log('serial number status updated');
+
+        return $serialNumber;
     }
 }

--- a/resources/views/livewire/logs-viewer.blade.php
+++ b/resources/views/livewire/logs-viewer.blade.php
@@ -14,6 +14,16 @@
         </div>
         @endif
         <div class="form-group col-md-3">
+            <label for="user_id">{{ __('general_content.user_trans_key') }}</label>
+            <select class="form-control" id="user_id" wire:model.defer="userId">
+                <option value="">{{ __('general_content.view_all_trans_key') }}</option>
+                @foreach ($availableUsers as $user)
+                    <option value="{{ $user->id }}">{{ $user->name }}</option>
+                @endforeach
+            </select>
+            @error('userId') <span class="text-danger">{{ $message }}<br/></span>@enderror
+        </div>
+        <div class="form-group col-md-3">
             <label for="date">{{__('general_content.start_date_trans_key') }}</label>
             <input type="date" class="form-control" id="start_date" wire:model.defer="startDate" placeholder="{{__('general_content.start_date_trans_key') }}">
             @error('startDate') <span class="text-danger">{{ $message }}<br/></span>@enderror

--- a/resources/views/products/serial-numbers-index.blade.php
+++ b/resources/views/products/serial-numbers-index.blade.php
@@ -9,7 +9,24 @@
 @section('right-sidebar')
 
 @section('content')
-@livewire('serial-numbers-index')
+<div class="card">
+  <div class="card-header p-2">
+    <ul class="nav nav-pills">
+      <li class="nav-item"><a class="nav-link active" href="#SerialNumbers" data-toggle="tab">{{ __('general_content.serial_numbers_trans_key') }}</a></li>
+      <li class="nav-item"><a class="nav-link" href="#Logs" data-toggle="tab">{{ __('general_content.logs_activity_trans_key') }}</a></li>
+    </ul>
+  </div>
+  <div class="card-body">
+    <div class="tab-content">
+      <div class="active tab-pane" id="SerialNumbers">
+        @livewire('serial-numbers-index')
+      </div>
+      <div class="tab-pane" id="Logs">
+        @livewire('logs-viewer', ['subjectType' => 'App\\Models\\Products\\SerialNumbers'])
+      </div>
+    </div>
+  </div>
+</div>
 @stop
 
 @section('css')


### PR DESCRIPTION
## Summary
- track SerialNumbers changes with Spatie activity logs
- log serial number status updates
- display serial number activity with user and date filters

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: ext-ldap missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ca0a80e4832d93771db25f490ef9