### PR TITLE
feat: add production trace view

### DIFF
--- a/app/Http/Controllers/ProductionTraceController.php
+++ b/app/Http/Controllers/ProductionTraceController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Products\SerialNumbers;
+use App\Models\Products\StockMove;
+use App\Models\Planning\Task;
+use App\Models\Quality\QualityNonConformity;
+
+class ProductionTraceController extends Controller
+{
+    /**
+     * Display production trace for a given serial number.
+     *
+     * @param string $serial
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function show(string $serial)
+    {
+        // Retrieve serial number
+        $serialNumber = SerialNumbers::with('Product')
+            ->where('serial_number', $serial)
+            ->firstOrFail();
+
+        $timeline = collect();
+
+        // Serial number creation event
+        $timeline->push([
+            'date' => $serialNumber->created_at,
+            'operation' => __('Serial number created'),
+            'user' => '',
+            'component' => optional($serialNumber->Product)->code,
+        ]);
+
+        // Stock moves related to this serial number
+        $stockMoves = StockMove::with(['UserManagement', 'StockLocationProducts.product'])
+            ->where('tracability', $serial)
+            ->get();
+
+        foreach ($stockMoves as $move) {
+            $timeline->push([
+                'date' => $move->created_at,
+                'operation' => __('Stock move'),
+                'user' => optional($move->UserManagement)->name,
+                'component' => optional(optional($move->StockLocationProducts)->product)->code,
+            ]);
+        }
+
+        // Tasks linked to order line
+        $tasks = Task::with('Component')
+            ->where('order_lines_id', $serialNumber->order_line_id)
+            ->get();
+
+        foreach ($tasks as $task) {
+            $timeline->push([
+                'date' => $task->created_at,
+                'operation' => __('Task') . ' ' . $task->label,
+                'user' => '',
+                'component' => optional($task->Component)->code,
+            ]);
+        }
+
+        // Quality non conformities
+        $nonConformities = QualityNonConformity::with('UserManagement')
+            ->where('order_lines_id', $serialNumber->order_line_id)
+            ->orWhereIn('task_id', $tasks->pluck('id'))
+            ->get();
+
+        foreach ($nonConformities as $nc) {
+            $timeline->push([
+                'date' => $nc->created_at,
+                'operation' => __('Non conformity') . ' ' . $nc->code,
+                'user' => optional($nc->UserManagement)->name,
+                'component' => '',
+            ]);
+        }
+
+        $timeline = $timeline->sortBy('date');
+
+        return view('production-trace', [
+            'serialNumber' => $serialNumber,
+            'timeline' => $timeline,
+        ]);
+    }
+}

--- a/resources/views/livewire/serial-numbers-index.blade.php
+++ b/resources/views/livewire/serial-numbers-index.blade.php
@@ -14,6 +14,7 @@
                         <th>{{__('general_content.po_receipt_trans_key') }}</th>
                         <th>{{ __('general_content.statu_trans_key') }}</th>
                         <th>{{__('general_content.created_at_trans_key') }}</th>
+                        <th>{{ __('Trace') }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -60,10 +61,13 @@
                             @if(5 == $SerialNumbers->status )<span class="badge badge-primary">{{__('general_content.in_stock_trans_key') }}</span>@endif
                         </td>
                         <td>{{ $SerialNumbers->GetPrettyCreatedAttribute() }}</td>
-                        
+                        <td>
+                            <a href="{{ route('production.trace', ['serial' => $SerialNumbers->serial_number]) }}" class="btn btn-sm btn-primary">{{ __('Trace') }}</a>
+                        </td>
+
                     </tr>
                     @empty
-                    <x-EmptyDataLine col="7" text="{{ __('general_content.no_data_trans_key') }}"  />
+                    <x-EmptyDataLine col="8" text="{{ __('general_content.no_data_trans_key') }}"  />
                     @endforelse
                     <tfoot>
                     <tr>
@@ -74,6 +78,7 @@
                         <th>{{ __('general_content.po_receipt_trans_key') }}</th>
                         <th>{{ __('general_content.statu_trans_key') }}</th>
                         <th>{{__('general_content.created_at_trans_key') }}</th>
+                        <th>{{ __('Trace') }}</th>
                     </tr>
                     </tfoot>
                 </tbody>

--- a/resources/views/livewire/stock-detail.blade.php
+++ b/resources/views/livewire/stock-detail.blade.php
@@ -10,8 +10,12 @@
     
     @include('include.alert-result')
 
+    @if($StockDetails && $StockDetails->tracability)
+        <a href="{{ route('production.trace', ['serial' => $StockDetails->tracability]) }}" class="btn btn-primary mb-3">{{ __('Trace') }}</a>
+    @endif
+
     @empty($StockDetails)
-    <h1>No Stock</h1> 
+    <h1>No Stock</h1>
     @else
     <x-adminlte-card title="Stock - {{ $StockDetails->StockLocationProducts->product->code }}" theme="primary" maximizable>
         <table class="table table-hover">

--- a/resources/views/production-trace.blade.php
+++ b/resources/views/production-trace.blade.php
@@ -1,0 +1,43 @@
+@extends('adminlte::page')
+
+@section('title', __('Production Trace'))
+
+@section('content_header')
+    <h1>{{ __('Production Trace') }} - {{ $serialNumber->serial_number }}</h1>
+@stop
+
+@section('right-sidebar')
+@stop
+
+@section('content')
+<x-adminlte-card title="{{ __('Production Trace') }}" theme="info" maximizable>
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>{{ __('Date') }}</th>
+                    <th>{{ __('Operation') }}</th>
+                    <th>{{ __('Operator') }}</th>
+                    <th>{{ __('Components') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($timeline as $event)
+                    <tr>
+                        <td>{{ $event['date']->format('d/m/Y H:i') }}</td>
+                        <td>{{ $event['operation'] }}</td>
+                        <td>{{ $event['user'] }}</td>
+                        <td>{{ $event['component'] }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</x-adminlte-card>
+@stop
+
+@section('css')
+@stop
+
+@section('js')
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -616,8 +616,12 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         ['get', 'post'],
         '/navbar/search',
         'App\Http\Controllers\SearchController@showNavbarSearchResults'
-        
+
     );
+
+    Route::get('/production-trace/{serial}', 'App\Http\Controllers\ProductionTraceController@show')
+        ->middleware(['auth', 'check.factory'])
+        ->name('production.trace');
 
     require __DIR__.'/auth.php';
 


### PR DESCRIPTION
## Summary
- build ProductionTraceController to aggregate serial, stock, task and quality events
- add production-trace route and view with timeline table
- link serial number and stock detail pages to production trace report

## Testing
- `php artisan test` *(fails: Failed opening required vendor/autoload.php)*
- `composer install --no-interaction --no-progress` *(fails: ext-ldap missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ca023808832d80eae4730136e67c