### PR TITLE
ci: add static analysis and style checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,12 @@ jobs:
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit --colors=always
+
+      - name: Install PHP QA tools
+        run: composer global require phpstan/phpstan friendsofphp/php-cs-fixer
+
+      - name: Run PHPStan
+        run: $(composer global config bin-dir --absolute)/phpstan analyse
+
+      - name: Run PHP-CS-Fixer (dry run)
+        run: $(composer global config bin-dir --absolute)/php-cs-fixer fix --dry-run


### PR DESCRIPTION
## Summary
- add PHPStan and PHP-CS-Fixer checks to CI workflow
- install QA tools via Composer for consistent versions

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d2b2eecc832d9017c3d437d4706d