### PR TITLE
Add energy consumption tracking model and migration

### DIFF
--- a/app/Models/EnergyConsumption.php
+++ b/app/Models/EnergyConsumption.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Methods\MethodsRessources;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EnergyConsumption extends Model
+{
+    use HasFactory;
+
+    // Fillable attributes for mass assignment
+    protected $fillable = [
+        'machine_id',
+        'kwh_consumed',
+        'cost',
+        'recorded_at',
+    ];
+
+    /**
+     * Get the machine or resource associated with this energy consumption record.
+     */
+    public function machine()
+    {
+        return $this->belongsTo(MethodsRessources::class, 'machine_id');
+    }
+}

--- a/database/migrations/2025_06_01_000001_create_energy_consumptions_table.php
+++ b/database/migrations/2025_06_01_000001_create_energy_consumptions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('energy_consumptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('machine_id')->constrained('methods_ressources');
+            $table->float('kwh_consumed');
+            $table->decimal('cost', 10, 2);
+            $table->timestamp('recorded_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('energy_consumptions');
+    }
+};


### PR DESCRIPTION
## Summary
- add energy_consumptions table migration
- create EnergyConsumption model with fillable attributes and machine relation

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub token / network)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ce679e98832d9f829678fd76cc20