### PR TITLE
ci: authenticate composer with github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
     steps:
       - uses: actions/checkout@v4
 
@@ -18,11 +18,6 @@ jobs:
           php-version: '8.2'
           extensions: ldap, zip, pdo_mysql, pdo_pgsql, sqlite3, bcmath, gd, intl, pcntl
           coverage: none
-
-      - name: Configure Composer authentication
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: composer config --global github-oauth.github.com "$GITHUB_TOKEN"
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist


### PR DESCRIPTION
## Summary
- run CI on all branches
- set `COMPOSER_AUTH` so Composer can use `GITHUB_TOKEN` before installing dependencies

## Testing
- `composer validate --no-check-publish`
- `composer install --no-progress --no-interaction --prefer-dist` *(fails: missing ext-ldap)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d2b4a03c832db0d377e68524de4c