### PR TITLE
Add energy consumption API and tests

### DIFF
--- a/app/Http/Controllers/Api/EnergyConsumptionController.php
+++ b/app/Http/Controllers/Api/EnergyConsumptionController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\EnergyConsumption;
+use Illuminate\Http\Request;
+
+class EnergyConsumptionController extends Controller
+{
+    public function index()
+    {
+        return response()->json(EnergyConsumption::with('machine')->get());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'machine_id' => 'required|exists:machines,id',
+            'kwh' => 'required|numeric',
+            'cost_per_kwh' => 'required|numeric',
+        ]);
+
+        $consumption = EnergyConsumption::create($data);
+
+        return response()->json($consumption->load('machine'), 201);
+    }
+}
+

--- a/app/Models/EnergyConsumption.php
+++ b/app/Models/EnergyConsumption.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EnergyConsumption extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'machine_id',
+        'kwh',
+        'cost_per_kwh',
+        'total_cost',
+    ];
+
+    protected static function booted()
+    {
+        static::saving(function ($model) {
+            $model->total_cost = $model->kwh * $model->cost_per_kwh;
+        });
+    }
+
+    public function machine()
+    {
+        return $this->belongsTo(Machine::class);
+    }
+}
+

--- a/app/Models/Machine.php
+++ b/app/Models/Machine.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Machine extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function energyConsumptions()
+    {
+        return $this->hasMany(EnergyConsumption::class);
+    }
+}
+

--- a/database/factories/EnergyConsumptionFactory.php
+++ b/database/factories/EnergyConsumptionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EnergyConsumption;
+use App\Models\Machine;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EnergyConsumptionFactory extends Factory
+{
+    protected $model = EnergyConsumption::class;
+
+    public function definition(): array
+    {
+        $kwh = $this->faker->numberBetween(10, 100);
+        $cost = $this->faker->randomFloat(2, 0.1, 1);
+
+        return [
+            'machine_id' => Machine::factory(),
+            'kwh' => $kwh,
+            'cost_per_kwh' => $cost,
+        ];
+    }
+}
+

--- a/database/factories/MachineFactory.php
+++ b/database/factories/MachineFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Machine;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MachineFactory extends Factory
+{
+    protected $model = Machine::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+        ];
+    }
+}
+

--- a/database/migrations/2024_01_01_000000_create_machines_table.php
+++ b/database/migrations/2024_01_01_000000_create_machines_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('machines', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('machines');
+    }
+};
+

--- a/database/migrations/2024_01_01_000001_create_energy_consumptions_table.php
+++ b/database/migrations/2024_01_01_000001_create_energy_consumptions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('energy_consumptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('machine_id')->constrained()->cascadeOnDelete();
+            $table->decimal('kwh', 10, 2);
+            $table->decimal('cost_per_kwh', 10, 2);
+            $table->decimal('total_cost', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('energy_consumptions');
+    }
+};
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\QuoteController;
 use App\Http\Controllers\Api\CompanyController;
+use App\Http\Controllers\Api\EnergyConsumptionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -33,3 +34,4 @@ Route::post('/company', 'App\Http\Controllers\Api\CompanyController@store');
 Route::apiResource('quote',QuoteController::class);
 Route::apiResource('order',OrderController::class);
 Route::apiResource('tasks', TaskController::class);
+Route::apiResource('energy-consumptions', EnergyConsumptionController::class)->only(['index','store']);

--- a/tests/Feature/EnergyConsumptionTest.php
+++ b/tests/Feature/EnergyConsumptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\EnergyConsumption;
+use App\Models\Machine;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EnergyConsumptionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_total_cost_is_calculated()
+    {
+        $machine = Machine::factory()->create();
+
+        $consumption = EnergyConsumption::create([
+            'machine_id' => $machine->id,
+            'kwh' => 20,
+            'cost_per_kwh' => 0.5,
+        ]);
+
+        $this->assertEquals(10.0, $consumption->total_cost);
+    }
+
+    public function test_can_create_energy_consumption_record()
+    {
+        $machine = Machine::factory()->create();
+
+        $response = $this->postJson('/api/energy-consumptions', [
+            'machine_id' => $machine->id,
+            'kwh' => 10,
+            'cost_per_kwh' => 0.5,
+        ]);
+
+        $response->assertCreated()
+                 ->assertJsonFragment(['total_cost' => 5.0]);
+
+        $this->assertDatabaseHas('energy_consumptions', [
+            'machine_id' => $machine->id,
+            'total_cost' => 5.0,
+        ]);
+    }
+
+    public function test_it_displays_energy_consumptions()
+    {
+        $consumption = EnergyConsumption::factory()->create();
+
+        $response = $this->getJson('/api/energy-consumptions');
+
+        $response->assertOk()
+                 ->assertJsonFragment([
+                     'id' => $consumption->id,
+                     'total_cost' => $consumption->total_cost,
+                 ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Machine and EnergyConsumption models with factories and migrations
- expose energy consumption index and store API routes
- cover energy consumption creation and listing with feature tests

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/EnergyConsumptionTest.php` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a9ce703bd8832d880f39e598770006