### PR TITLE
Add energy cost calculation

### DIFF
--- a/app/Models/EnergyConsumption.php
+++ b/app/Models/EnergyConsumption.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class EnergyConsumption extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'kwh_consumed',
+        'cost',
+    ];
+
+    protected static function booted()
+    {
+        static::saving(function (EnergyConsumption $consumption) {
+            $consumption->cost = $consumption->kwh_consumed * config('energy.price_per_kwh');
+        });
+    }
+
+    public function getCostAttribute($value)
+    {
+        return $value ?? $this->kwh_consumed * config('energy.price_per_kwh');
+    }
+}

--- a/config/energy.php
+++ b/config/energy.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'price_per_kwh' => 0.15,
+];
+

--- a/database/migrations/2024_08_23_000000_create_energy_consumptions_table.php
+++ b/database/migrations/2024_08_23_000000_create_energy_consumptions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('energy_consumptions', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('kwh_consumed', 10, 2);
+            $table->decimal('cost', 10, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('energy_consumptions');
+    }
+};

--- a/tests/Unit/EnergyConsumptionTest.php
+++ b/tests/Unit/EnergyConsumptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\EnergyConsumption;
+use PHPUnit\Framework\TestCase;
+
+class EnergyConsumptionTest extends TestCase
+{
+    public function test_cost_attribute_is_computed()
+    {
+        config(['energy.price_per_kwh' => 0.2]);
+        $model = new EnergyConsumption(['kwh_consumed' => 5]);
+        $this->assertSame(1.0, $model->cost);
+    }
+}


### PR DESCRIPTION
## Summary
- add energy tariff configuration
- compute energy consumption cost automatically and persist
- provide basic tests

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a9ce6bf394832d8db5203d0add89ed