### PR TITLE
Add customer processing cost KPI

### DIFF
--- a/app/Http/Controllers/Companies/CompaniesController.php
+++ b/app/Http/Controllers/Companies/CompaniesController.php
@@ -23,6 +23,8 @@ use App\Models\Accounting\AccountingDelivery;
 use App\Models\Accounting\AccountingPaymentMethod;
 use App\Http\Requests\Companies\UpdateCompanieRequest;
 use App\Models\Accounting\AccountingPaymentConditions;
+use Carbon\Carbon;
+use App\Models\Methods\MethodsServices;
 
 class CompaniesController extends Controller
 {
@@ -90,13 +92,20 @@ class CompaniesController extends Controller
         $data['orderAverage'] = $this->orderKPIService->getAverageOrderPriceAttribute($id->id);
         $data['orderAverage'] = Number::currency($data['orderAverage'], $factory->curency, config('app.locale'));
         $remainingInvoiceOrder = Number::currency($remainingInvoiceOrder->orderSum ?? 0, $factory->curency, config('app.locale'));
-        
+
+        $customerServiceId = MethodsServices::where('label', 'Customer Service')->value('id');
+        $startOfYear = Carbon::now()->startOfYear();
+        $endOfYear = Carbon::now()->endOfYear();
+        $customerProcessingCost = $this->orderKPIService->getCustomerProcessingCost($id->id, $startOfYear, $endOfYear, $customerServiceId);
+        $customerProcessingCost = Number::currency($customerProcessingCost, $factory->curency, config('app.locale'));
+
         $Companie = $id;
-        return view('companies/companies-show', compact('Companie', 
-                                                        'userSelect', 
-                                                        'previousUrl', 
+        return view('companies/companies-show', compact('Companie',
+                                                        'userSelect',
+                                                        'previousUrl',
                                                         'nextUrl',
                                                         'remainingInvoiceOrder',
+                                                        'customerProcessingCost',
                                                         'paidInvoices',
                                                         'unpaidInvoices',
                                                         'data',));

--- a/app/Services/OrderKPIService.php
+++ b/app/Services/OrderKPIService.php
@@ -7,6 +7,7 @@ use App\Models\Workflow\Orders;
 use App\Models\Workflow\Deliverys;
 use Illuminate\Support\Facades\DB;
 use App\Models\Workflow\OrderLines;
+use App\Models\Planning\Task;
 use Illuminate\Support\Facades\Cache;
 
 class OrderKPIService
@@ -356,6 +357,47 @@ class OrderKPIService
             $serviceRate = round(($onTimeDeliveries / $totalOrderLines) * 100,2);
 
             return $serviceRate;
+        });
+    }
+
+    /**
+     * Calculate the average processing cost of a customer's orders for a given period and service.
+     *
+     * This method filters orders by company and date range, retrieves the related tasks for the
+     * specified service, sums their realized costs, then divides by the number of orders.
+     * The result is cached like other KPIs.
+     *
+     * @param int $companyId   The ID of the customer company.
+     * @param Carbon $start    The start date of the period.
+     * @param Carbon $end      The end date of the period.
+     * @param int $serviceId   The ID of the service.
+     * @return float           The average processing cost per order, or 0 if no orders are found.
+     */
+    public function getCustomerProcessingCost(int $companyId, Carbon $start, Carbon $end, int $serviceId)
+    {
+        $cacheKey = 'customer_processing_cost_' . $companyId . '_' . $start->toDateString() . '_' . $end->toDateString() . '_' . $serviceId;
+
+        return Cache::remember($cacheKey, now()->addHours(1), function () use ($companyId, $start, $end, $serviceId) {
+            $orderCount = Orders::where('companies_id', $companyId)
+                                ->whereBetween('created_at', [$start, $end])
+                                ->count();
+
+            if ($orderCount === 0) {
+                return 0;
+            }
+
+            $tasks = Task::where('methods_services_id', $serviceId)
+                        ->whereHas('OrderLines.order', function ($query) use ($companyId, $start, $end) {
+                            $query->where('companies_id', $companyId)
+                                  ->whereBetween('created_at', [$start, $end]);
+                        })
+                        ->get();
+
+            $totalCost = $tasks->sum(function (Task $task) {
+                return $task->getTotalRealizedCost();
+            });
+
+            return $totalCost / $orderCount;
         });
     }
 

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -446,7 +446,8 @@ return [
     'payment_conditions_trans_key'  => 'شروط الدفع',
     'delevery_method_trans_key'     => 'طريقة التسليم',
     'validity_date_trans_key'       => 'تاريخ الصلاحية',
-    
+    'customer_processing_cost_trans_key' => 'تكلفة معالجة العميل',
+
     'material_trans_key'                    => 'المادة',
     'finishing_trans_key'                   => 'التشطيب',
     'thickness_trans_key'                   => 'السمك',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -500,6 +500,7 @@ return [
     'tolerance_days_trans_key'                 => 'Tolerance days',
     'quoted_delivery_note_trans_key'           => 'Quoted delivery note',
     'order_average_note_trans_key'             => 'Average order',
+    'customer_processing_cost_trans_key'       => 'Customer processing cost',
 
     'material_trans_key'                       => 'Material',
     'finishing_trans_key'                      => 'Finishing',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -446,7 +446,8 @@ return [
     'payment_conditions_trans_key'             => 'Condiciones de pago',
     'delevery_method_trans_key'                => 'Método de entrega',
     'validity_date_trans_key'                  => 'Fecha de validez',
-    
+    'customer_processing_cost_trans_key'       => 'Costo de procesamiento del cliente',
+
     'material_trans_key'                       => 'Material',
     'finishing_trans_key'                      => 'Acabado',
     'thickness_trans_key'                      => 'Espesor',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -500,6 +500,7 @@ return [
     'tolerance_days_trans_key'                 => 'Nombre de jours de tolérance',
     'quoted_delivery_note_trans_key'           => 'Note de livraison chiffré',
     'order_average_note_trans_key'             => 'Commande moyenne',
+    'customer_processing_cost_trans_key'       => 'Coût de traitement client',
 
     'material_trans_key'                       => 'Matière',
     'thickness_trans_key'                      => 'Epaisseur',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -114,6 +114,7 @@ return [
     'your_company_trans_key'                   => 'Công ty',
     'licence_trans_key'                        => 'Giấy phép',
     'release_note_trans_key'                   => 'Nhật ký phát hành',
-    
+
     'search_results_trans_key'                 => 'Kết quả tìm kiếm',
+    'customer_processing_cost_trans_key'       => 'Chi phí xử lý khách hàng',
 ];

--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -36,12 +36,19 @@
           </div>
 
           <div class="col-lg-3 col-md-3">
-            <x-adminlte-small-box title="{{ $remainingInvoiceOrder }}" 
-              text="{{ __('general_content.remaining_invoice_month_trans_key') }}" 
+            <x-adminlte-small-box title="{{ $remainingInvoiceOrder }}"
+              text="{{ __('general_content.remaining_invoice_month_trans_key') }}"
               icon="icon fas fa-info"
               theme="info" />
           </div>
-          
+
+          <div class="col-lg-3 col-md-3">
+            <x-adminlte-small-box title="{{ $customerProcessingCost }}"
+              text="{{ __('general_content.customer_processing_cost_trans_key') }}"
+              icon="icon fas fa-info"
+              theme="teal" />
+          </div>
+
           <div class="col-lg-3 col-md-3">
             <x-adminlte-card  theme="primary" theme-mode="outline">
               <p class="card-text">{{ __('general_content.bills_paid_trans_key') }} : {{ $paidInvoices }}</p>


### PR DESCRIPTION
## Summary
- compute customer processing cost KPI using tasks' realized cost per order with caching
- show processing cost on company dashboard and wire data through controller
- add translation key for customer processing cost in multiple languages

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(not run: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9db3add48832d8df7b301283665f5