### PR TITLE
feat: compute average supply delay for products

### DIFF
--- a/app/Http/Controllers/Products/ProductsController.php
+++ b/app/Http/Controllers/Products/ProductsController.php
@@ -12,6 +12,7 @@ use App\Services\SelectDataService;
 use App\Http\Controllers\Controller;
 use App\Models\Planning\SubAssembly;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use App\Models\Purchases\PurchaseLines;
 use App\Services\StockCalculationService;
 use App\Services\ABC_MFR_CalculatorService;
@@ -101,6 +102,20 @@ class ProductsController extends Controller
     }
 
     /**
+     * Calculate the average supply delay for a product.
+     *
+     * @param int $productId
+     * @return float|null
+     */
+    private function calculateAverageSupplyDelay($productId)
+    {
+        return DB::table('purchase_receipt_lines')
+            ->join('purchase_lines', 'purchase_receipt_lines.purchase_line_id', '=', 'purchase_lines.id')
+            ->where('purchase_lines.product_id', $productId)
+            ->avg(DB::raw('DATEDIFF(purchase_receipt_lines.created_at, purchase_lines.created_at)'));
+    }
+
+    /**
      * @param $id
      * @return \Illuminate\Contracts\View\View
      */
@@ -114,6 +129,10 @@ class ProductsController extends Controller
         $finalAnalysis = $this->abcFMRService->calculateABC_FMR($Product->id);
         $lastPurchasePrice = $this->calculateLastPurchasePrice($id);
         $averageCost = $this->calculateAverageCost($id);
+        $averageSupplyDelay = null;
+        if ($Product->purchased == 1) {
+            $averageSupplyDelay = $this->calculateAverageSupplyDelay($id);
+        }
 
         return view('products/products-show', array_merge($selectData, [
             'Product' => $Product,
@@ -124,6 +143,7 @@ class ProductsController extends Controller
             'finalAnalysis' => $finalAnalysis,
             'lastPurchasePrice' => $lastPurchasePrice,
             'averageCost' => $averageCost,
+            'averageSupplyDelay' => $averageSupplyDelay,
         ]));
     }
 

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -921,4 +921,5 @@ return [
     'production_declaration_trans_key'    => 'إعلان الإنتاج',
     'note_1_trans_key'                    => 'استشارة وتخطيط المهام التي يجب إنجازها.',
     'note_2_trans_key'                    => 'إجراء إعلانات الإنتاج.',
+    'average_supply_delay_trans_key'      => 'متوسط مهلة التوريد',
 ];

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1095,4 +1095,5 @@ return [
     'quote_updated_log_trans_key'              => 'Quote updated',
     'quote_update_failed_log_trans_key'        => 'Quote update failed',
     'quote_update_success_trans_key'           => 'Successfully updated quote',
+    'average_supply_delay_trans_key'           => 'Average supply delay',
 ];

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -922,5 +922,5 @@ return [
     'production_declaration_trans_key'     => 'Declaración de producción',
     'note_1_trans_key'                     => 'Consultar y planificar las tareas a realizar.',
     'note_2_trans_key'                     => 'Realizar declaraciones de producción.',
-
+    'average_supply_delay_trans_key'       => 'Plazo medio de aprovisionamiento',
 ];

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1095,4 +1095,5 @@ return [
     'quote_updated_log_trans_key'              => 'Devis mis à jour',
     'quote_update_failed_log_trans_key'        => 'Échec de mise à jour du devis',
     'quote_update_success_trans_key'           => 'Devis mis à jour avec succès',
+    'average_supply_delay_trans_key'           => "Délai moyen d'approvisionnement",
 ];

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -117,4 +117,5 @@ return [
 
     'search_results_trans_key'                 => 'Kết quả tìm kiếm',
     'customer_processing_cost_trans_key'       => 'Chi phí xử lý khách hàng',
+    'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',
 ];

--- a/resources/views/products/products-show.blade.php
+++ b/resources/views/products/products-show.blade.php
@@ -555,6 +555,15 @@
           <p class="text-sm">{{ __('general_content.last_purchase_price_price_trans_key') }}
             <b class="d-block">{{ number_format($lastPurchasePrice, 2) }} {{ $Factory->curency }}</b>
           </p>
+          <p class="text-sm">{{ __('general_content.average_supply_delay_trans_key') }}
+            <b class="d-block">
+              @if(!is_null($averageSupplyDelay))
+                {{ number_format($averageSupplyDelay, 0) }} {{ __('general_content.day_trans_key') }}
+              @else
+                N/A
+              @endif
+            </b>
+          </p>
           </div>
         </div>
       <!-- /.div row -->


### PR DESCRIPTION
## Summary
- add average supply delay calculation for products
- display delay information on product page with translations

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9df461890832da257a9acadab2427