### PR TITLE
feat: add order site support

### DIFF
--- a/app/Models/Workflow/OrderSite.php
+++ b/app/Models/Workflow/OrderSite.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class OrderSite extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'location',
+        'characteristics',
+        'contact_info',
+    ];
+
+    public function order()
+    {
+        return $this->belongsTo(Orders::class);
+    }
+}

--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -13,6 +13,7 @@ use Spatie\Activitylog\LogOptions;
 use App\Models\Companies\Companies;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\OrderRating;
+use App\Models\Workflow\OrderSite;
 use Illuminate\Database\Eloquent\Model;
 use App\Services\OrderCalculatorService;
 use App\Models\Companies\CompaniesContacts;
@@ -109,6 +110,11 @@ class Orders extends Model
     public function OrderLines()
     {
         return $this->hasMany(OrderLines::class)->orderBy('ordre');
+    }
+
+    public function OrderSite()
+    {
+        return $this->hasOne(OrderSite::class);
     }
     
     public function getPurchaseLinesCountAttribute()

--- a/database/migrations/2025_08_24_000000_create_order_sites_table.php
+++ b/database/migrations/2025_08_24_000000_create_order_sites_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_sites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders')->onDelete('cascade');
+            $table->string('location')->nullable();
+            $table->text('characteristics')->nullable();
+            $table->text('contact_info')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_sites');
+    }
+};

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -922,4 +922,7 @@ return [
     'note_1_trans_key'                    => 'استشارة وتخطيط المهام التي يجب إنجازها.',
     'note_2_trans_key'                    => 'إجراء إعلانات الإنتاج.',
     'average_supply_delay_trans_key'      => 'متوسط مهلة التوريد',
+    'order_site_trans_key'                => 'موقع العمل',
+    'characteristics_trans_key'           => 'الخصائص',
+    'contact_info_trans_key'              => 'معلومات الاتصال',
 ];

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1096,4 +1096,7 @@ return [
     'quote_update_failed_log_trans_key'        => 'Quote update failed',
     'quote_update_success_trans_key'           => 'Successfully updated quote',
     'average_supply_delay_trans_key'           => 'Average supply delay',
+    'order_site_trans_key'                     => 'Job site',
+    'characteristics_trans_key'                => 'Characteristics',
+    'contact_info_trans_key'                   => 'Contact info',
 ];

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -923,4 +923,7 @@ return [
     'note_1_trans_key'                     => 'Consultar y planificar las tareas a realizar.',
     'note_2_trans_key'                     => 'Realizar declaraciones de producción.',
     'average_supply_delay_trans_key'       => 'Plazo medio de aprovisionamiento',
+    'order_site_trans_key'                 => 'Sitio de obra',
+    'characteristics_trans_key'            => 'Características',
+    'contact_info_trans_key'               => 'Información de contacto',
 ];

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1096,4 +1096,7 @@ return [
     'quote_update_failed_log_trans_key'        => 'Échec de mise à jour du devis',
     'quote_update_success_trans_key'           => 'Devis mis à jour avec succès',
     'average_supply_delay_trans_key'           => "Délai moyen d'approvisionnement",
+    'order_site_trans_key'                     => 'Chantier',
+    'characteristics_trans_key'                => 'Caractéristiques',
+    'contact_info_trans_key'                   => 'Informations de contact',
 ];

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -118,4 +118,7 @@ return [
     'search_results_trans_key'                 => 'Kết quả tìm kiếm',
     'customer_processing_cost_trans_key'       => 'Chi phí xử lý khách hàng',
     'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',
+    'order_site_trans_key'                     => 'Công trường',
+    'characteristics_trans_key'                => 'Đặc điểm',
+    'contact_info_trans_key'                   => 'Thông tin liên hệ',
 ];


### PR DESCRIPTION
## Summary
- add migration for order sites and model
- link orders to a related job site
- translate job site labels in all locales

## Testing
- `php artisan test` *(fails: require(/workspace/WebErpMesv2/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e282be5c832db133504eb5b97682