### PR TITLE
feat: add order site implantation support

### DIFF
--- a/app/Http/Requests/Workflow/OrderSiteImplantationRequest.php
+++ b/app/Http/Requests/Workflow/OrderSiteImplantationRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Workflow;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class OrderSiteImplantationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'order_site_id' => 'required|exists:order_sites,id',
+            'workforce' => 'nullable|integer',
+            'equipment' => 'nullable|string',
+            'step' => 'nullable|string',
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date',
+            'notes' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Models/Workflow/OrderSite.php
+++ b/app/Models/Workflow/OrderSite.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class OrderSite extends Model
+{
+    use HasFactory;
+
+    public function implantations()
+    {
+        return $this->hasMany(OrderSiteImplantation::class);
+    }
+}

--- a/app/Models/Workflow/OrderSiteImplantation.php
+++ b/app/Models/Workflow/OrderSiteImplantation.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class OrderSiteImplantation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_site_id',
+        'workforce',
+        'equipment',
+        'step',
+        'start_date',
+        'end_date',
+        'notes',
+    ];
+
+    public function orderSite()
+    {
+        return $this->belongsTo(OrderSite::class);
+    }
+}

--- a/database/migrations/2025_08_23_154924_create_order_site_implantations_table.php
+++ b/database/migrations/2025_08_23_154924_create_order_site_implantations_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_site_implantations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_site_id')->constrained()->onDelete('cascade');
+            $table->integer('workforce')->nullable();
+            $table->string('equipment')->nullable();
+            $table->string('step')->nullable();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_site_implantations');
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for `order_site_implantations`
- introduce `OrderSiteImplantation` model and request validation
- add relation from `OrderSite` to implantations

## Testing
- `php artisan test` *(fails: require(/workspace/WebErpMesv2/vendor/autoload.php): Failed to open stream)*


------
https://chatgpt.com/codex/tasks/task_e_68a9e28e02b4832d986a55bb0bbbbac8