### PR TITLE
feat: add construction site management for orders

### DIFF
--- a/app/Http/Controllers/Workflow/OrderSiteController.php
+++ b/app/Http/Controllers/Workflow/OrderSiteController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Workflow;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Workflow\Orders;
+use App\Models\Workflow\OrderSite;
+use App\Models\Workflow\OrderSiteImplantation;
+
+class OrderSiteController extends Controller
+{
+    /**
+     * Store a newly created construction site for the order.
+     */
+    public function store(Request $request, $id)
+    {
+        $order = Orders::findOrFail($id);
+        $data = $request->validate([
+            'name' => 'nullable|string|max:255',
+            'adress' => 'nullable|string|max:255',
+            'city' => 'nullable|string|max:255',
+            'postal_code' => 'nullable|string|max:25',
+            'description' => 'nullable|string',
+        ]);
+
+        $order->OrderSite()->create($data);
+
+        return back()->with('success', 'Site created');
+    }
+
+    /**
+     * Update the specified construction site.
+     */
+    public function update(Request $request, $order, OrderSite $site)
+    {
+        $data = $request->validate([
+            'name' => 'nullable|string|max:255',
+            'adress' => 'nullable|string|max:255',
+            'city' => 'nullable|string|max:255',
+            'postal_code' => 'nullable|string|max:25',
+            'description' => 'nullable|string',
+        ]);
+
+        $site->update($data);
+
+        return back()->with('success', 'Site updated');
+    }
+
+    /**
+     * Remove the specified construction site.
+     */
+    public function destroy($order, OrderSite $site)
+    {
+        $site->delete();
+
+        return back()->with('success', 'Site deleted');
+    }
+
+    /**
+     * Store a newly created implantation for the site.
+     */
+    public function storeImplantation(Request $request, $order, OrderSite $site)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        $site->OrderSiteImplantations()->create($data);
+
+        return back()->with('success', 'Implantation created');
+    }
+
+    /**
+     * Update the specified implantation.
+     */
+    public function updateImplantation(Request $request, $order, OrderSite $site, OrderSiteImplantation $implantation)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        $implantation->update($data);
+
+        return back()->with('success', 'Implantation updated');
+    }
+
+    /**
+     * Remove the specified implantation.
+     */
+    public function destroyImplantation($order, OrderSite $site, OrderSiteImplantation $implantation)
+    {
+        $implantation->delete();
+
+        return back()->with('success', 'Implantation deleted');
+    }
+}
+

--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -84,7 +84,9 @@ class OrdersController extends Controller
      */
     public function show(Orders $id)
     {
-        $factory = app('Factory'); 
+        $factory = app('Factory');
+
+        $id->load(['OrderSite.OrderSiteImplantations']);
 
         // Retrieve necessary data for dropdowns
         $CompanieSelect = $this->SelectDataService->getCompanies();
@@ -173,6 +175,8 @@ class OrdersController extends Controller
             'forecastMarginPercentageFormatted' => $forecastMarginPercentageFormatted,
             'currentMarginPercentageFormatted' => $currentMarginPercentageFormatted,
             'leadTime' => $leadTime,
+            'OrderSite' => $id->OrderSite,
+            'OrderSiteImplantations' => $id->OrderSite ? $id->OrderSite->OrderSiteImplantations : collect(),
         ]);
     }
     

--- a/app/Models/Workflow/OrderSite.php
+++ b/app/Models/Workflow/OrderSite.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class OrderSite extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'orders_id',
+        'name',
+        'adress',
+        'city',
+        'postal_code',
+        'description',
+    ];
+
+    public function Order()
+    {
+        return $this->belongsTo(Orders::class, 'orders_id');
+    }
+
+    public function OrderSiteImplantations()
+    {
+        return $this->hasMany(OrderSiteImplantation::class, 'order_site_id');
+    }
+}
+

--- a/app/Models/Workflow/OrderSiteImplantation.php
+++ b/app/Models/Workflow/OrderSiteImplantation.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class OrderSiteImplantation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_site_id',
+        'name',
+        'description',
+    ];
+
+    public function OrderSite()
+    {
+        return $this->belongsTo(OrderSite::class, 'order_site_id');
+    }
+}
+

--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -13,6 +13,7 @@ use Spatie\Activitylog\LogOptions;
 use App\Models\Companies\Companies;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\OrderRating;
+use App\Models\Workflow\OrderSite;
 use Illuminate\Database\Eloquent\Model;
 use App\Services\OrderCalculatorService;
 use App\Models\Companies\CompaniesContacts;
@@ -109,6 +110,11 @@ class Orders extends Model
     public function OrderLines()
     {
         return $this->hasMany(OrderLines::class)->orderBy('ordre');
+    }
+
+    public function OrderSite()
+    {
+        return $this->hasOne(OrderSite::class, 'orders_id');
     }
     
     public function getPurchaseLinesCountAttribute()

--- a/database/migrations/2024_10_09_000000_create_order_sites_table.php
+++ b/database/migrations/2024_10_09_000000_create_order_sites_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_sites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('orders_id')->constrained('orders')->onDelete('cascade');
+            $table->string('name')->nullable();
+            $table->string('adress')->nullable();
+            $table->string('city')->nullable();
+            $table->string('postal_code')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_sites');
+    }
+};
+

--- a/database/migrations/2024_10_09_000001_create_order_site_implantations_table.php
+++ b/database/migrations/2024_10_09_000001_create_order_site_implantations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_site_implantations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_site_id')->constrained('order_sites')->onDelete('cascade');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_site_implantations');
+    }
+};
+

--- a/resources/views/workflow/order-site-form.blade.php
+++ b/resources/views/workflow/order-site-form.blade.php
@@ -1,0 +1,40 @@
+@if(isset($Order))
+    <form action="{{ $OrderSite ? route('orders.site.update', ['order' => $Order->id, 'site' => $OrderSite->id]) : route('orders.site.store', ['id' => $Order->id]) }}" method="POST">
+        @csrf
+        @if($OrderSite)
+            @method('PUT')
+        @endif
+        <x-adminlte-card title="{{ __('general_content.informations_trans_key') }}" theme="primary" maximizable>
+            <div class="row">
+                <div class="form-group col-md-6">
+                    <label for="name">{{ __('general_content.name_trans_key') }}</label>
+                    <input type="text" class="form-control" name="name" value="{{ old('name', $OrderSite->name ?? '') }}">
+                </div>
+                <div class="form-group col-md-6">
+                    <label for="adress">{{ __('general_content.adress_trans_key') }}</label>
+                    <input type="text" class="form-control" name="adress" value="{{ old('adress', $OrderSite->adress ?? '') }}">
+                </div>
+            </div>
+            <div class="row">
+                <div class="form-group col-md-6">
+                    <label for="city">{{ __('general_content.city_trans_key') }}</label>
+                    <input type="text" class="form-control" name="city" value="{{ old('city', $OrderSite->city ?? '') }}">
+                </div>
+                <div class="form-group col-md-6">
+                    <label for="postal_code">{{ __('general_content.postal_code_trans_key') }}</label>
+                    <input type="text" class="form-control" name="postal_code" value="{{ old('postal_code', $OrderSite->postal_code ?? '') }}">
+                </div>
+            </div>
+            <div class="row">
+                <div class="form-group col-md-12">
+                    <label for="description">{{ __('general_content.description_trans_key') }}</label>
+                    <textarea class="form-control" name="description">{{ old('description', $OrderSite->description ?? '') }}</textarea>
+                </div>
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="success" icon="fas fa-lg fa-save"/>
+            </x-slot>
+        </x-adminlte-card>
+    </form>
+@endif
+

--- a/resources/views/workflow/order-site-implantations.blade.php
+++ b/resources/views/workflow/order-site-implantations.blade.php
@@ -1,0 +1,47 @@
+@if(isset($Order) && $OrderSite)
+    <x-adminlte-card title="{{ __('Implantations') }}" theme="secondary" maximizable>
+        <form method="POST" action="{{ route('orders.site.implantation.store', ['order' => $Order->id, 'site' => $OrderSite->id]) }}">
+            @csrf
+            <div class="row">
+                <div class="form-group col-md-5">
+                    <input type="text" name="name" class="form-control" placeholder="{{ __('general_content.name_trans_key') }}">
+                </div>
+                <div class="form-group col-md-5">
+                    <input type="text" name="description" class="form-control" placeholder="{{ __('general_content.description_trans_key') }}">
+                </div>
+                <div class="col-md-2">
+                    <x-adminlte-button type="submit" label="{{ __('general_content.add_trans_key') }}" theme="success" icon="fas fa-plus"/>
+                </div>
+            </div>
+        </form>
+        <table class="table table-striped mt-2">
+            <thead>
+                <tr>
+                    <th>{{ __('general_content.name_trans_key') }}</th>
+                    <th>{{ __('general_content.description_trans_key') }}</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($OrderSiteImplantations as $implantation)
+                    <tr>
+                        <td>{{ $implantation->name }}</td>
+                        <td>{{ $implantation->description }}</td>
+                        <td>
+                            <form method="POST" action="{{ route('orders.site.implantation.destroy', ['order' => $Order->id, 'site' => $OrderSite->id, 'implantation' => $implantation->id]) }}">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="3">{{ __('general_content.no_data_trans_key') }}</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </x-adminlte-card>
+@endif
+

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -19,6 +19,7 @@
     <ul class="nav nav-pills" id="DocumentTabs">
       <li class="nav-item"><a class="nav-link" href="#Order" data-toggle="tab">{{ __('general_content.order_info_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Lines" data-toggle="tab">{{ __('general_content.order_line_trans_key') }}  ({{ count($Order->OrderLines) }})</a></li>
+      <li class="nav-item"><a class="nav-link" href="#Site" data-toggle="tab">{{ __('general_content.construction_site_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Charts" data-toggle="tab">{{ __('general_content.charts_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Bilan" data-toggle="tab">{{ __('general_content.business_Review_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#purchase" data-toggle="tab">{{ __('general_content.purchase_list_trans_key') }} ({{ $Order->purchase_lines_count }})</a></li>
@@ -220,7 +221,11 @@
       </div>   
       <div class="tab-pane " id="Lines">
         @livewire('order-line', ['OrderId' => $Order->id, 'OrderStatu' => $Order->statu, 'OrderDelay' => $Order->validity_date, 'OrderType' => $Order->type])
-      </div> 
+      </div>
+      <div class="tab-pane" id="Site">
+        @include('workflow.order-site-form', ['Order' => $Order, 'OrderSite' => $OrderSite])
+        @include('workflow.order-site-implantations', ['Order' => $Order, 'OrderSite' => $OrderSite, 'OrderSiteImplantations' => $OrderSiteImplantations])
+      </div>
       <div class="tab-pane" id="Charts">
         <div class="row">
           <div class="col-md-6">

--- a/routes/web.php
+++ b/routes/web.php
@@ -134,6 +134,13 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/{idOrder}/lines/import', 'App\Http\Controllers\Workflow\OrderLinesController@import')->name('orders.lines.import');
         //import
         Route::post('/import', 'App\Http\Controllers\Admin\ImportsExportsController@importOrders')->name('orders.import');
+        //construction site
+        Route::post('/{id}/site', 'App\Http\Controllers\Workflow\OrderSiteController@store')->name('orders.site.store');
+        Route::put('/{order}/site/{site}', 'App\Http\Controllers\Workflow\OrderSiteController@update')->name('orders.site.update');
+        Route::delete('/{order}/site/{site}', 'App\Http\Controllers\Workflow\OrderSiteController@destroy')->name('orders.site.destroy');
+        Route::post('/{order}/site/{site}/implantation', 'App\Http\Controllers\Workflow\OrderSiteController@storeImplantation')->name('orders.site.implantation.store');
+        Route::put('/{order}/site/{site}/implantation/{implantation}', 'App\Http\Controllers\Workflow\OrderSiteController@updateImplantation')->name('orders.site.implantation.update');
+        Route::delete('/{order}/site/{site}/implantation/{implantation}', 'App\Http\Controllers\Workflow\OrderSiteController@destroyImplantation')->name('orders.site.implantation.destroy');
     });
 
     Route::group(['prefix' => 'deliverys', 'middleware' => ['auth', 'check.factory']], function () {


### PR DESCRIPTION
## Summary
- add OrderSiteController for managing order sites and implantations
- expose construction site tab with form and implantation list
- support order site data with migrations, models, routes and controller updates

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e29393a4832dbefd998f5292545b