### PR TITLE
feat: add resource filter to tasks list

### DIFF
--- a/app/Livewire/TaskLines.php
+++ b/app/Livewire/TaskLines.php
@@ -8,6 +8,7 @@ use Livewire\WithPagination;
 use App\Models\Planning\Task;
 use App\Models\Planning\Status;
 use App\Models\Methods\MethodsServices;
+use App\Models\Methods\MethodsRessources;
 
 class TaskLines extends Component
 {
@@ -17,6 +18,7 @@ class TaskLines extends Component
     public $search = '';
     public $searchIdService = '';
     public $searchIdStatus = '';
+    public $searchIdRessource = '';
     public $sortField = 'end_date'; // default sorting field
     public $sortAsc = true; // default sort direction
     public $ShowGenericTask = false;
@@ -62,6 +64,7 @@ class TaskLines extends Component
         
         $ServicesSelect = MethodsServices::select('id', 'label')->orderBy('ordre')->get();
         $StatusSelect = Status::orderBy('order', 'ASC')->get();
+        $RessourceSelect = MethodsRessources::select('id', 'label')->orderBy('label')->get();
 
         if($this->ShowGenericTask){
             $Tasklist = $this->Tasklist = Task::with('OrderLines.order')
@@ -77,6 +80,9 @@ class TaskLines extends Component
                                         ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
                                         ->where('status_id', 'like', '%'.$this->searchIdStatus.'%')
                                         ->where('label','like', '%'.$this->search.'%')
+                                        ->when($this->searchIdRessource, function($query){
+                                            $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
+                                        })
                                         ->get();
         }
         else{
@@ -94,14 +100,18 @@ class TaskLines extends Component
             ->where('status_id', 'like', '%'.$this->searchIdStatus.'%')
             ->where('label', 'like', '%'.$this->search.'%')
             ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+            ->when($this->searchIdRessource, function($query){
+                $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
+            })
             ->get();
-                            
+
         }
 
         return view('livewire.task-lines', [
             'Tasklist' => $Tasklist,
             'ServicesSelect' => $ServicesSelect,
             'StatusSelect' => $StatusSelect,
+            'RessourceSelect' => $RessourceSelect,
         ]);
     }
 }

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -361,6 +361,7 @@ return [
     'select_payement_methods_trans_key'     => 'اختر طريقة الدفع',
     'select_delivery_trans_key'             => 'اختر التسليم',
     'select_service_trans_key'              => 'اختر الخدمة',
+    'select_ressource_trans_key'            => 'اختر المورد',
     'select_family_trans_key'               => 'اختر الفئة',
     'select_unit_trans_key'                 => 'اختر الوحدة',
     'select_statu_trans_key'                => 'اختر الحالة',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -359,6 +359,7 @@ return [
     'select_payement_methods_trans_key'        => 'Seleccionar método de pago',
     'select_delivery_trans_key'                => 'Seleccionar entrega',
     'select_service_trans_key'                 => 'Seleccionar servicio',
+    'select_ressource_trans_key'               => 'Seleccionar recurso',
     'select_family_trans_key'                  => 'Seleccionar familia',
     'select_unit_trans_key'                    => 'Seleccionar unidad',
     'select_statu_trans_key'                   => 'Seleccionar estado',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -120,5 +120,6 @@ return [
     'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',
     'order_site_trans_key'                     => 'Công trường',
     'characteristics_trans_key'                => 'Đặc điểm',
+    'select_ressource_trans_key'               => 'Chọn nguồn lực',
     'contact_info_trans_key'                   => 'Thông tin liên hệ',
 ];

--- a/resources/views/livewire/task-lines.blade.php
+++ b/resources/views/livewire/task-lines.blade.php
@@ -13,7 +13,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <div class="card-body">
                         <div class="form-group">
                             <label for="service_id">{{ __('general_content.service_trans_key') }}</label>
@@ -33,7 +33,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <div class="card-body">
                         <div class="form-group">
                             <label for="searchIdService">{{ __('general_content.status_trans_key') }}</label>
@@ -52,7 +52,26 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
+                    <div class="card-body">
+                        <div class="form-group">
+                            <label for="searchIdRessource">{{ __('general_content.ressource_trans_key') }}</label>
+                            <div class="input-group">
+                                <div class="input-group-prepend">
+                                    <span class="input-group-text"><i class="fas fa-list"></i></span>
+                                </div>
+                                <select class="form-control" name="searchIdRessource" id="searchIdRessource" wire:model.live="searchIdRessource">
+                                    <option value="">{{ __('general_content.select_ressource_trans_key') }}</option>
+                                    @forelse ($RessourceSelect as $item)
+                                    <option value="{{ $item->id }}">{{ $item->label }}</option>
+                                    @empty
+                                    @endforelse
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
                     <div class="card-body">
                         <div class="form-group">
                             <label for="ShowGenericTask">{{ __('general_content.show_generic_task_trans_key') }}</label>


### PR DESCRIPTION
## Summary
- add resource filter for TaskLines component and view
- include resource translation keys across languages

## Testing
- `php artisan test` *(fails: missing vendor/autoload and composer install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68aa013f0e98832d83811c1b5ddda293