### PR TITLE
Handle missing customer service id in company controller

### DIFF
--- a/app/Http/Controllers/Companies/CompaniesController.php
+++ b/app/Http/Controllers/Companies/CompaniesController.php
@@ -94,9 +94,20 @@ class CompaniesController extends Controller
         $remainingInvoiceOrder = Number::currency($remainingInvoiceOrder->orderSum ?? 0, $factory->curency, config('app.locale'));
 
         $customerServiceId = MethodsServices::where('label', 'Customer Service')->value('id');
-        $startOfYear = Carbon::now()->startOfYear();
-        $endOfYear = Carbon::now()->endOfYear();
-        $customerProcessingCost = $this->orderKPIService->getCustomerProcessingCost($id->id, $startOfYear, $endOfYear, $customerServiceId);
+
+        if ($customerServiceId === null || filter_var($customerServiceId, FILTER_VALIDATE_INT) === false) {
+            $customerProcessingCost = 0;
+        } else {
+            $startOfYear = Carbon::now()->startOfYear();
+            $endOfYear = Carbon::now()->endOfYear();
+            $customerProcessingCost = $this->orderKPIService->getCustomerProcessingCost(
+                $id->id,
+                $startOfYear,
+                $endOfYear,
+                (int) $customerServiceId
+            );
+        }
+
         $customerProcessingCost = Number::currency($customerProcessingCost, $factory->curency, config('app.locale'));
 
         $Companie = $id;


### PR DESCRIPTION
## Summary
- avoid calling getCustomerProcessingCost when Customer Service method is missing
- default customer processing cost to zero when the service id is invalid

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3f47372c832d97f8fe44c4938e06