### PR TITLE
feat: add assets tab to accounting

### DIFF
--- a/app/Http/Controllers/Accounting/AccountingController.php
+++ b/app/Http/Controllers/Accounting/AccountingController.php
@@ -9,6 +9,7 @@ use App\Models\Accounting\AccountingDelivery;
 use App\Models\Accounting\AccountingAllocation;
 use App\Models\Accounting\AccountingPaymentMethod;
 use App\Models\Accounting\AccountingPaymentConditions;
+use App\Models\Assets\Asset;
 
 class AccountingController extends Controller
 {
@@ -30,6 +31,7 @@ class AccountingController extends Controller
         $PaymentMethods = AccountingPaymentMethod::All();
         $VATs = AccountingVat::All();
         $VATSelect = $this->SelectDataService->getVATSelect();
+        $Assets = Asset::paginate(10);
 
         return view('accounting/accounting-index', [
             'Allocations' => $Allocations,
@@ -38,6 +40,7 @@ class AccountingController extends Controller
             'PaymentMethods' => $PaymentMethods,
             'VATs' => $VATs,
             'VATSelect' => $VATSelect,
+            'Assets' => $Assets,
         ]);
     }
 }

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -846,7 +846,8 @@ return [
     'new_vat_trans_key'                     => 'ضريبة القيمة المضافة الجديدة',
     'accounting_allocations_trans_key'      => 'تخصيصات المحاسبة',
     'new_accounting_allocations_trans_key'  => 'تخصيصات محاسبية جديدة',
-    
+    'assets_trans_key'                      => 'الأصول',
+
     //TIME
     'times_setting_trans_key'               => 'إعدادات الأوقات',
     'new_machine_event_trans_key'           => 'نوع حدث جديد للآلة',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -984,7 +984,8 @@ return [
     'new_vat_trans_key'                        => 'New VAT mode',
     'accounting_allocations_trans_key'         => 'Accounting allocations',
     'new_accounting_allocations_trans_key'     => 'New accounting allocation',
-    
+    'assets_trans_key'                         => 'Assets',
+
     //TIME
     'times_setting_trans_key'                  => 'Times setting',  
     'new_machine_event_trans_key'              => 'New machine event type',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -847,6 +847,7 @@ return [
     'new_vat_trans_key'                        => 'Nuevo modo de IVA',
     'accounting_allocations_trans_key'         => 'Asignaciones contables',
     'new_accounting_allocations_trans_key'     => 'Nueva asignación contable',
+    'assets_trans_key'                         => 'Activos',
 
     //TIEMPO
     'times_setting_trans_key'                  => 'Configuración de tiempos',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -984,6 +984,7 @@ return [
     'new_vat_trans_key'                        => 'Nouvelle TVA',
     'accounting_allocations_trans_key'         => 'Allocation comptable',
     'new_accounting_allocations_trans_key'     => 'Nouvelle allocation comptable',
+    'assets_trans_key'                         => 'Immobilisations',
 
     //TIME
     'times_setting_trans_key'                  => 'Réglage temps',  

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -109,6 +109,7 @@ return [
     'settings_trans_key'                       => 'Thiết lập',
     'methods_trans_key'                        => 'Phương thức',
     'accounting_trans_key'                      => 'Kế toán',
+    'assets_trans_key'                          => 'Tài sản',
 
     'users_trans_key'                          => 'Người dùng',
     'your_company_trans_key'                   => 'Công ty',

--- a/resources/views/accounting/accounting-index.blade.php
+++ b/resources/views/accounting/accounting-index.blade.php
@@ -20,6 +20,7 @@
       <li class="nav-item"><a class="nav-link" href="#VAT" data-toggle="tab">{{ __('general_content.vat_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#AccountingAllocations" data-toggle="tab">{{ __('general_content.accounting_allocations_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Delevery" data-toggle="tab">{{ __('general_content.delevery_method_trans_key') }}</a></li>
+      <li class="nav-item"><a class="nav-link" href="#Assets" data-toggle="tab">{{ __('general_content.assets_trans_key') }}</a></li>
     </ul>
   </div>
   <!-- /.card-header -->
@@ -713,6 +714,9 @@
       <!-- /.row -->
     </div>
     <!-- /.tab-pane -->
+    <div class="tab-pane" id="Assets">
+      @include('assets.partials.assets-list', ['assets' => $Assets])
+    </div>
   </div>
   <!-- /.card -->
 </div>

--- a/resources/views/assets/assets-index.blade.php
+++ b/resources/views/assets/assets-index.blade.php
@@ -4,12 +4,6 @@
     <title>Assets</title>
 </head>
 <body>
-    <h1>Assets</h1>
-    <a href="{{ route('assets.create') }}">Create Asset</a>
-    <ul>
-        @foreach($assets as $asset)
-            <li><a href="{{ route('assets.show', $asset->id) }}">{{ $asset->name }}</a></li>
-        @endforeach
-    </ul>
+    @include('assets.partials.assets-list')
 </body>
 </html>

--- a/resources/views/assets/partials/assets-list.blade.php
+++ b/resources/views/assets/partials/assets-list.blade.php
@@ -1,0 +1,10 @@
+<div>
+    <h1>{{ __('general_content.assets_trans_key') }}</h1>
+    <a href="{{ route('assets.create') }}">Create Asset</a>
+    <ul>
+        @foreach($assets as $asset)
+            <li><a href="{{ route('assets.show', $asset->id) }}">{{ $asset->name }}</a></li>
+        @endforeach
+    </ul>
+    {{ $assets->links() }}
+</div>


### PR DESCRIPTION
## Summary
- add assets tab and content to accounting view
- load asset data from controller and provide translations
- reuse asset list markup via shared partial

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68aa4022ad80832dbd20895322ac12d1