### PR TITLE
Rename orders_id to order_id for order sites

### DIFF
--- a/app/Models/Workflow/OrderSite.php
+++ b/app/Models/Workflow/OrderSite.php
@@ -10,7 +10,7 @@ class OrderSite extends Model
     use HasFactory;
 
     protected $fillable = [
-        'orders_id',
+        'order_id',
         'name',
         'adress',
         'city',
@@ -23,7 +23,7 @@ class OrderSite extends Model
 
     public function Order()
     {
-        return $this->belongsTo(Orders::class, 'orders_id');
+        return $this->belongsTo(Orders::class, 'order_id');
     }
 
     public function OrderSiteImplantations()

--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -114,7 +114,7 @@ class Orders extends Model
 
     public function OrderSite()
     {
-        return $this->hasOne(OrderSite::class, 'orders_id');
+        return $this->hasOne(OrderSite::class, 'order_id');
 
     }
     

--- a/database/migrations/2024_10_09_000000_create_order_sites_table.php
+++ b/database/migrations/2024_10_09_000000_create_order_sites_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('order_sites', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('orders_id')->constrained('orders')->onDelete('cascade');
+            $table->foreignId('order_id')->constrained('orders')->onDelete('cascade');
             $table->string('name')->nullable();
             $table->string('adress')->nullable();
             $table->string('city')->nullable();

--- a/database/migrations/2025_08_24_000000_create_order_sites_table.php
+++ b/database/migrations/2025_08_24_000000_create_order_sites_table.php
@@ -11,14 +11,16 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('order_sites', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('order_id')->constrained('orders')->onDelete('cascade');
-            $table->string('location')->nullable();
-            $table->text('characteristics')->nullable();
-            $table->text('contact_info')->nullable();
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('order_sites')) {
+            Schema::create('order_sites', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('order_id')->constrained('orders')->onDelete('cascade');
+                $table->string('location')->nullable();
+                $table->text('characteristics')->nullable();
+                $table->text('contact_info')->nullable();
+                $table->timestamps();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2025_08_24_000002_rename_orders_id_to_order_id_in_order_sites_table.php
+++ b/database/migrations/2025_08_24_000002_rename_orders_id_to_order_id_in_order_sites_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('order_sites') && Schema::hasColumn('order_sites', 'orders_id')) {
+            Schema::table('order_sites', function (Blueprint $table) {
+                $table->renameColumn('orders_id', 'order_id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('order_sites') && Schema::hasColumn('order_sites', 'order_id')) {
+            Schema::table('order_sites', function (Blueprint $table) {
+                $table->renameColumn('order_id', 'orders_id');
+            });
+        }
+    }
+};

--- a/tests/Feature/OrderSiteTest.php
+++ b/tests/Feature/OrderSiteTest.php
@@ -31,7 +31,7 @@ class OrderSiteTest extends TestCase
 
         $response->assertStatus(302);
         $this->assertDatabaseHas('order_sites', [
-            'orders_id' => $order->id,
+            'order_id' => $order->id,
             'label' => 'Main site',
         ]);
     }
@@ -46,7 +46,7 @@ class OrderSiteTest extends TestCase
             'end_date' => now()->addDays(5)->toDateString(),
         ]);
 
-        $siteId = DB::table('order_sites')->where('orders_id', $order->id)->value('id');
+        $siteId = DB::table('order_sites')->where('order_id', $order->id)->value('id');
 
         $response = $this->post(route('orders.sites.implantations.store', [$order->id, $siteId]), [
             'label' => 'Implantation A',


### PR DESCRIPTION
## Summary
- use `order_id` field in OrderSite model and Orders relation
- update order site migrations and add rename migration
- adjust feature test for `order_id`

## Testing
- `php artisan migrate` *(fails: Failed opening required 'vendor/autoload.php')*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4050462c832d862da96415ce4947