### PR TITLE
feat: add energy consumption menu and translations

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -675,6 +675,11 @@ return [
                     'icon_color' => 'secondary',
                 ],
                 [
+                    'text' => 'energy_consumption_trans_key',
+                    'url'  => 'energy-consumptions',
+                    'icon_color' => 'success',
+                ],
+                [
                     'text' => 'logs_view_trans_key',
                     'url'  => 'admin/logs-view',
                     'icon_color' => 'success',

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -922,6 +922,7 @@ return [
     'production_declaration_trans_key'    => 'إعلان الإنتاج',
     'note_1_trans_key'                    => 'استشارة وتخطيط المهام التي يجب إنجازها.',
     'note_2_trans_key'                    => 'إجراء إعلانات الإنتاج.',
+    'energy_consumption_trans_key'        => 'استهلاك الطاقة',
     'average_supply_delay_trans_key'      => 'متوسط مهلة التوريد',
     'order_site_trans_key'                => 'موقع العمل',
     'characteristics_trans_key'           => 'الخصائص',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1090,6 +1090,8 @@ return [
     'note_1_trans_key'                         => 'Consult and plan the tasks to be carried out.',
     'note_2_trans_key'                         => 'Make production declarations.',
 
+    'energy_consumption_trans_key'             => 'Energy consumption',
+
     'order_created_log_trans_key'              => 'Order created',
     'order_creation_failed_log_trans_key'      => 'Order creation failed',
     'quote_updated_log_trans_key'              => 'Quote updated',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -923,6 +923,7 @@ return [
     'production_declaration_trans_key'     => 'Declaración de producción',
     'note_1_trans_key'                     => 'Consultar y planificar las tareas a realizar.',
     'note_2_trans_key'                     => 'Realizar declaraciones de producción.',
+    'energy_consumption_trans_key'         => 'Consumo de energía',
     'average_supply_delay_trans_key'       => 'Plazo medio de aprovisionamiento',
     'order_site_trans_key'                 => 'Sitio de obra',
     'characteristics_trans_key'            => 'Características',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1090,6 +1090,8 @@ return [
     'note_1_trans_key'                         => 'Consult and plan the tasks to be carried out.',
     'note_2_trans_key'                         => 'Faites des déclarations de production',
 
+    'energy_consumption_trans_key'             => "Consommation d'énergie",
+
     'order_created_log_trans_key'              => 'Commande créée',
     'order_creation_failed_log_trans_key'      => 'Échec de création de la commande',
     'quote_updated_log_trans_key'              => 'Devis mis à jour',

--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -81,6 +81,7 @@ return [
     'workflow_settings_trans_key'              => 'Task Workflow',
     'estimated_budget_trans_key'               => 'Estimated budget',
     'template_mail_trans_key'                  => 'Template mail',
+    'energy_consumption_trans_key'             => 'Energy consumption',
     'logs_view_trans_key'                      => 'Logs view',
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Release notes',

--- a/resources/lang/vendor/adminlte/fr/menu.php
+++ b/resources/lang/vendor/adminlte/fr/menu.php
@@ -81,6 +81,7 @@ return [
     'workflow_settings_trans_key'              => 'Flux des Tâches',
     'estimated_budget_trans_key'               => 'Objectif de chiffre',
     'template_mail_trans_key'                  => 'Template de mail',
+    'energy_consumption_trans_key'             => "Consommation d'énergie",
     'logs_view_trans_key'                      => 'Logs view',
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Release notes',

--- a/resources/lang/vendor/adminlte/vi/menu.php
+++ b/resources/lang/vendor/adminlte/vi/menu.php
@@ -51,6 +51,7 @@ return [
     'human_resources_trans_key'                => 'Nguồn nhân lực',
     'users_trans_key'                          => 'Người dùng',
     'your_company_trans_key'                   => 'Công ty của bạn',
+    'energy_consumption_trans_key'             => 'Mức tiêu thụ năng lượng',
     'licence_trans_key'                        => 'Bản quyền',
     'release_note_trans_key'                   => 'Ghi chú phát hành',
 ];

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -115,6 +115,8 @@ return [
     'licence_trans_key'                        => 'Giấy phép',
     'release_note_trans_key'                   => 'Nhật ký phát hành',
 
+    'energy_consumption_trans_key'             => 'Mức tiêu thụ năng lượng',
+
     'search_results_trans_key'                 => 'Kết quả tìm kiếm',
     'customer_processing_cost_trans_key'       => 'Chi phí xử lý khách hàng',
     'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',

--- a/resources/views/energy-consumptions/energy-consumptions-index.blade.php
+++ b/resources/views/energy-consumptions/energy-consumptions-index.blade.php
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Energy Consumptions</title>
+    <title>{{ __('general_content.energy_consumption_trans_key') }}</title>
 </head>
 <body>
-    <h1>Energy Consumptions</h1>
+    <h1>{{ __('general_content.energy_consumption_trans_key') }}</h1>
     <form method="POST" action="{{ route('energy-consumptions.store') }}">
         @csrf
         <div>

--- a/resources/views/energy-consumptions/energy-consumptions-show.blade.php
+++ b/resources/views/energy-consumptions/energy-consumptions-show.blade.php
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Energy Consumption</title>
+    <title>{{ __('general_content.energy_consumption_trans_key') }}</title>
 </head>
 <body>
-    <h1>Energy Consumption Detail</h1>
+    <h1>{{ __('general_content.energy_consumption_trans_key') }}</h1>
     <p>Date: {{ $energyConsumption->recorded_at }}</p>
     <p>Amount: {{ $energyConsumption->amount }} kWh</p>
     <a href="{{ route('energy-consumptions.index') }}">Back to list</a>


### PR DESCRIPTION
## Summary
- add energy consumption submenu entry
- localize energy consumption features across supported locales

## Testing
- `php -l config/adminlte.php resources/lang/ar/general_content.php resources/lang/en/general_content.php resources/lang/es/general_content.php resources/lang/fr/general_content.php resources/lang/vi/general_content.php resources/lang/vendor/adminlte/en/menu.php resources/lang/vendor/adminlte/fr/menu.php resources/lang/vendor/adminlte/vi/menu.php`
- `php -l resources/views/energy-consumptions/energy-consumptions-index.blade.php resources/views/energy-consumptions/energy-consumptions-show.blade.php`
- `composer install --ignore-platform-req=ext-ldap --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa40467018832d858445b014220ea3