### PR TITLE
Fix missing closing braces in calculateRessource

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -71,7 +71,8 @@ class TaskCalculationDate extends Component
             } else {
                 $this->progressRessourceLog .= '<li> No ressource available for task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
                 throw new \RuntimeException('No resource has remaining capacity for task #' . $task->id);
-
+            }
+        }
 
         $this->toBeCalculateRessource = false;
     }


### PR DESCRIPTION
## Summary
- Close dangling `else` and `foreach` blocks in `TaskCalculationDate::calculateRessource`

## Testing
- `php -l app/Livewire/TaskCalculationDate.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68aa40678b48832db15808d71c17d805