### PR TITLE
chore: import missing classes

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -8,6 +8,8 @@ use App\Support\WorkingTime;
 use Livewire\Component;
 use App\Models\Planning\Task;
 use App\Services\TaskDateCalculator;
+use App\Models\Workflow\OrderLines;
+use Illuminate\Database\Eloquent\Builder;
 
 
 class TaskCalculationDate extends Component


### PR DESCRIPTION
## Summary
- import OrderLines model and Eloquent Builder in TaskCalculationDate component

## Testing
- `php -l app/Livewire/TaskCalculationDate.php` *(fails: unexpected token "public" on line 81)*
- `composer install` *(fails: missing ext-ldap)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa406d3ba4832da010f150a106b347