### PR TITLE
Use progress counters in calculateRessource

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -71,7 +71,11 @@ class TaskCalculationDate extends Component
             } else {
                 $this->progressRessourceLog .= '<li> No ressource available for task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
                 throw new \RuntimeException('No resource has remaining capacity for task #' . $task->id);
+            }
 
+            $this->countTaskCalculateRessource += 1;
+            $this->progressRessource += (1 / $countLines) * 100;
+        }
 
         $this->toBeCalculateRessource = false;
     }


### PR DESCRIPTION
## Summary
- Increment resource calculation progress and task count for each task processed
- Track progress with `$countLines` inside `calculateRessource`

## Testing
- `php -l app/Livewire/TaskCalculationDate.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68aa407110e4832db248ff1dfba70c28