### PR TITLE
test: use order_id in OrderSiteTest

### DIFF
--- a/tests/Feature/OrderSiteTest.php
+++ b/tests/Feature/OrderSiteTest.php
@@ -31,7 +31,7 @@ class OrderSiteTest extends TestCase
 
         $response->assertStatus(302);
         $this->assertDatabaseHas('order_sites', [
-            'orders_id' => $order->id,
+            'order_id' => $order->id,
             'label' => 'Main site',
         ]);
     }
@@ -46,7 +46,7 @@ class OrderSiteTest extends TestCase
             'end_date' => now()->addDays(5)->toDateString(),
         ]);
 
-        $siteId = DB::table('order_sites')->where('orders_id', $order->id)->value('id');
+        $siteId = DB::table('order_sites')->where('order_id', $order->id)->value('id');
 
         $response = $this->post(route('orders.sites.implantations.store', [$order->id, $siteId]), [
             'label' => 'Implantation A',


### PR DESCRIPTION
## Summary
- adjust OrderSiteTest to reference `order_id` instead of `orders_id`

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: vendor/bin/phpunit tests/Feature/OrderSiteTest.php` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68aa4057e9dc832d9c3405b914d2ab8c