### PR TITLE
Delegate date adjustments to service

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -71,7 +71,8 @@ class TaskCalculationDate extends Component
             } else {
                 $this->progressRessourceLog .= '<li> No ressource available for task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
                 throw new \RuntimeException('No resource has remaining capacity for task #' . $task->id);
-
+            }
+        }
 
         $this->toBeCalculateRessource = false;
     }
@@ -101,7 +102,7 @@ class TaskCalculationDate extends Component
 
         foreach ($OrderLines as $line) {
             $taskEndDate = Carbon::parse($line->internal_delay);
-            $taskEndDate = $this->adjustForWeekends($taskEndDate);
+            $taskEndDate = $this->taskDateCalculator->adjustForWeekendsAndHolidays($taskEndDate);
 
             $elapsedTimeInSeconds = 0;
 
@@ -110,7 +111,7 @@ class TaskCalculationDate extends Component
 
             foreach ($tasks as $task) {
                 // Date de fin de la tâche actuelle
-                $endDate = $this->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
+                $endDate = $this->taskDateCalculator->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
                 $task->end_date = $endDate;
         
                 $this->progressDateLog .= '<li>End date : '. $endDate .' updated for task #'. $task->id .' ordre '. $task->ordre .'</li>';
@@ -121,7 +122,7 @@ class TaskCalculationDate extends Component
 
                 // Calcul de la date de début
                 $elapsedTimeInSeconds += $secondsToSubtract;
-                $startDate = $this->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
+                $startDate = $this->taskDateCalculator->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
                 $task->start_date = $startDate;
                 $task->save();
         

--- a/app/Services/TaskDateCalculator.php
+++ b/app/Services/TaskDateCalculator.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Models\Planning\Task;
 use App\Models\Methods\MethodsRessources;
 use App\Models\Times\TimesBanckHoliday;
+use App\Support\WorkingTime;
 use Illuminate\Support\Collection;
 
 class TaskDateCalculator
@@ -27,6 +28,16 @@ class TaskDateCalculator
         } while ($date->isWeekend() || TimesBanckHoliday::isBankHoliday($date));
 
         return $date;
+    }
+
+    /**
+     * Adjust a date by subtracting the given number of seconds while
+     * respecting working hours, weekends and bank holidays.
+     */
+    public function adjustForWorkingHours(Carbon $date, int $secondsToSubtract): Carbon
+    {
+        $hours = $secondsToSubtract / 3600;
+        return WorkingTime::subtractWorkingHours($date, $hours);
     }
 
     /**

--- a/tests/Unit/TaskDateCalculatorTest.php
+++ b/tests/Unit/TaskDateCalculatorTest.php
@@ -91,6 +91,14 @@ class TaskDateCalculatorTest extends TestCase
         $this->assertSame('2024-05-07', $calculator->adjustForWeekendsAndHolidays(Carbon::create(2024, 5, 8))->toDateString());
     }
 
+    public function test_adjustment_of_working_hours(): void
+    {
+        $calculator = new TaskDateCalculator();
+        $date = Carbon::create(2024, 5, 6, 10, 0, 0); // Monday 10:00
+        $adjusted = $calculator->adjustForWorkingHours($date, 6 * 3600);
+        $this->assertEquals('2024-05-03 14:00:00', $adjusted->format('Y-m-d H:i:s'));
+    }
+
     public function test_calculates_start_and_end_for_simple_task(): void
     {
         $service = MethodsServicesFactory::new()->create();


### PR DESCRIPTION
## Summary
- centralize weekend and working-hour adjustments in `TaskDateCalculator`
- leverage new service methods from `TaskCalculationDate`
- cover working-hour adjustment with a dedicated unit test

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit tests/Unit/TaskDateCalculatorTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa406f2b78832db36d068987db06c0