### PR TITLE
Use consistent progress message properties

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -20,9 +20,9 @@ class TaskCalculationDate extends Component
     public $toBeCalculateDate = true;
     public $toBeCalculateRessource = true;
 
-    public $progressDateLog  = '';
+    public $progressDateMessages = [];
     public $countTaskCalculateDate = 0;
-    public $progressRessourceMessages  = [];
+    public $progressRessourceMessages = [];
     public $countTaskCalculateRessource = 0;
 
     public function __construct(TaskDateCalculator $taskDateCalculator)
@@ -67,11 +67,12 @@ class TaskCalculationDate extends Component
                     'userforced_ressource' => 0,
                 ]);
 
-                $this->progressRessourceLog .= '<li>' . $resource->label . ' affected to task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
+                $this->progressRessourceMessages[] = $resource->label . ' affected to task #' . $task->id . ' for ' . $task->service['label'] . ' service';
             } else {
-                $this->progressRessourceLog .= '<li> No ressource available for task #' . $task->id . ' for ' . $task->service['label'] . ' service </li>';
+                $this->progressRessourceMessages[] = 'No ressource available for task #' . $task->id . ' for ' . $task->service['label'] . ' service';
                 throw new \RuntimeException('No resource has remaining capacity for task #' . $task->id);
-
+            }
+        }
 
         $this->toBeCalculateRessource = false;
     }
@@ -113,7 +114,7 @@ class TaskCalculationDate extends Component
                 $endDate = $this->adjustForWorkingHours(clone $taskEndDate, $elapsedTimeInSeconds);
                 $task->end_date = $endDate;
         
-                $this->progressDateLog .= '<li>End date : '. $endDate .' updated for task #'. $task->id .' ordre '. $task->ordre .'</li>';
+                $this->progressDateMessages[] = 'End date : ' . $endDate . ' updated for task #' . $task->id . ' ordre ' . $task->ordre;
         
                 // Calcul du temps à retrancher en tenant compte des jours ouvrés
                 $totalTaskHours = $task->TotalTime();


### PR DESCRIPTION
## Summary
- Replace progressDateLog with progressDateMessages and ensure matching property for resources
- Update render and calculation methods to use message arrays consistently

## Testing
- `php -l app/Livewire/TaskCalculationDate.php`
- `phpunit` *(fails: command not found)*
- `composer install --no-interaction --no-progress` *(fails: ext-ldap missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa40696718832d974a89632550d4b9