### PR TITLE
Use boot for service injection in TaskCalculationDate Livewire component

### DIFF
--- a/app/Livewire/TaskCalculationDate.php
+++ b/app/Livewire/TaskCalculationDate.php
@@ -26,10 +26,9 @@ class TaskCalculationDate extends Component
     public $countTaskCalculateDate = 0;
     public $progressRessourceMessages  = [];
     public $countTaskCalculateRessource = 0;
-
-    public function __construct(TaskDateCalculator $taskDateCalculator)
+    
+    public function boot(TaskDateCalculator $taskDateCalculator): void
     {
-        parent::__construct();
         $this->taskDateCalculator = $taskDateCalculator;
     }
 


### PR DESCRIPTION
## Summary
- Replace constructor injection with `boot` method to initialize `TaskDateCalculator` in `TaskCalculationDate` component.

## Testing
- `composer install` *(fails: ext-ldap missing)*
- `apt-get update` *(fails: repository 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan tinker --execute="Livewire\\Livewire::test(App\\Livewire\\TaskCalculationDate::class);"` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa444229f4832d958e453817a7fd0e