### PR TITLE
Use AdminLTE styling for asset views

### DIFF
--- a/resources/views/assets/assets-create.blade.php
+++ b/resources/views/assets/assets-create.blade.php
@@ -1,23 +1,39 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Create Asset</title>
-</head>
-<body>
-    <h1>Create Asset</h1>
+@extends('adminlte::page')
+
+@section('title', __('general_content.new_trans_key') . ' ' . __('general_content.asset_trans_key'))
+
+@section('content_header')
+    <h1>{{ __('general_content.new_trans_key') }} {{ __('general_content.asset_trans_key') }}</h1>
+@stop
+
+@section('content')
     <form method="POST" action="{{ route('assets.store') }}">
         @csrf
-        <label>Name</label>
-        <input type="text" name="name" value="{{ old('name') }}"><br>
-        <label>Category</label>
-        <input type="text" name="category" value="{{ old('category') }}"><br>
-        <label>Acquisition Value</label>
-        <input type="number" step="0.01" name="acquisition_value" value="{{ old('acquisition_value') }}"><br>
-        <label>Acquisition Date</label>
-        <input type="date" name="acquisition_date" value="{{ old('acquisition_date') }}"><br>
-        <label>Depreciation Duration (months)</label>
-        <input type="number" name="depreciation_duration" value="{{ old('depreciation_duration') }}"><br>
-        <button type="submit">Save</button>
+        <x-adminlte-card title="{{ __('general_content.new_trans_key') }} {{ __('general_content.asset_trans_key') }}" theme="secondary" maximizable>
+            <div class="form-group">
+                <label for="name">{{ __('general_content.name_trans_key') }}</label>
+                <input type="text" class="form-control" name="name" id="name" value="{{ old('name') }}">
+            </div>
+            <div class="form-group">
+                <label for="category">Category</label>
+                <input type="text" class="form-control" name="category" id="category" value="{{ old('category') }}">
+            </div>
+            <div class="form-group">
+                <label for="acquisition_value">Acquisition value</label>
+                <input type="number" step="0.01" class="form-control" name="acquisition_value" id="acquisition_value" value="{{ old('acquisition_value') }}">
+            </div>
+            <div class="form-group">
+                <label for="acquisition_date">Acquisition date</label>
+                <input type="date" class="form-control" name="acquisition_date" id="acquisition_date" value="{{ old('acquisition_date') }}">
+            </div>
+            <div class="form-group">
+                <label for="depreciation_duration">Depreciation duration (months)</label>
+                <input type="number" class="form-control" name="depreciation_duration" id="depreciation_duration" value="{{ old('depreciation_duration') }}">
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.submit_trans_key') }}" theme="success" icon="fas fa-lg fa-save" />
+                <a href="{{ route('assets') }}" class="btn btn-secondary float-right">{{ __('general_content.back_trans_key') }}</a>
+            </x-slot>
+        </x-adminlte-card>
     </form>
-</body>
-</html>
+@stop

--- a/resources/views/assets/assets-edit.blade.php
+++ b/resources/views/assets/assets-edit.blade.php
@@ -1,23 +1,39 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Edit Asset</title>
-</head>
-<body>
-    <h1>Edit Asset</h1>
+@extends('adminlte::page')
+
+@section('title', __('general_content.edit_trans_key') . ' ' . __('general_content.asset_trans_key'))
+
+@section('content_header')
+    <h1>{{ __('general_content.edit_trans_key') }} {{ __('general_content.asset_trans_key') }}</h1>
+@stop
+
+@section('content')
     <form method="POST" action="{{ route('assets.update', $asset->id) }}">
         @csrf
-        <label>Name</label>
-        <input type="text" name="name" value="{{ old('name', $asset->name) }}"><br>
-        <label>Category</label>
-        <input type="text" name="category" value="{{ old('category', $asset->category) }}"><br>
-        <label>Acquisition Value</label>
-        <input type="number" step="0.01" name="acquisition_value" value="{{ old('acquisition_value', $asset->acquisition_value) }}"><br>
-        <label>Acquisition Date</label>
-        <input type="date" name="acquisition_date" value="{{ old('acquisition_date', $asset->acquisition_date->format('Y-m-d')) }}"><br>
-        <label>Depreciation Duration (months)</label>
-        <input type="number" name="depreciation_duration" value="{{ old('depreciation_duration', $asset->depreciation_duration) }}"><br>
-        <button type="submit">Update</button>
+        <x-adminlte-card title="{{ __('general_content.edit_trans_key') }} {{ $asset->name }}" theme="secondary" maximizable>
+            <div class="form-group">
+                <label for="name">{{ __('general_content.name_trans_key') }}</label>
+                <input type="text" class="form-control" name="name" id="name" value="{{ old('name', $asset->name) }}">
+            </div>
+            <div class="form-group">
+                <label for="category">Category</label>
+                <input type="text" class="form-control" name="category" id="category" value="{{ old('category', $asset->category) }}">
+            </div>
+            <div class="form-group">
+                <label for="acquisition_value">Acquisition value</label>
+                <input type="number" step="0.01" class="form-control" name="acquisition_value" id="acquisition_value" value="{{ old('acquisition_value', $asset->acquisition_value) }}">
+            </div>
+            <div class="form-group">
+                <label for="acquisition_date">Acquisition date</label>
+                <input type="date" class="form-control" name="acquisition_date" id="acquisition_date" value="{{ old('acquisition_date', $asset->acquisition_date->format('Y-m-d')) }}">
+            </div>
+            <div class="form-group">
+                <label for="depreciation_duration">Depreciation duration (months)</label>
+                <input type="number" class="form-control" name="depreciation_duration" id="depreciation_duration" value="{{ old('depreciation_duration', $asset->depreciation_duration) }}">
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="info" icon="fas fa-lg fa-save" />
+                <a href="{{ route('assets.show', $asset->id) }}" class="btn btn-secondary float-right">{{ __('general_content.back_trans_key') }}</a>
+            </x-slot>
+        </x-adminlte-card>
     </form>
-</body>
-</html>
+@stop

--- a/resources/views/assets/assets-index.blade.php
+++ b/resources/views/assets/assets-index.blade.php
@@ -1,9 +1,11 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Assets</title>
-</head>
-<body>
-    @include('assets.partials.assets-list')
-</body>
-</html>
+@extends('adminlte::page')
+
+@section('title', __('general_content.assets_trans_key'))
+
+@section('content_header')
+    <h1>{{ __('general_content.assets_trans_key') }}</h1>
+@stop
+
+@section('content')
+    @include('assets.partials.assets-list', ['assets' => $assets])
+@stop

--- a/resources/views/assets/assets-show.blade.php
+++ b/resources/views/assets/assets-show.blade.php
@@ -1,25 +1,38 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Asset Details</title>
-</head>
-<body>
+@extends('adminlte::page')
+
+@section('title', $asset->name)
+
+@section('content_header')
     <h1>{{ $asset->name }}</h1>
-    <p>Category: {{ $asset->category }}</p>
-    <p>Acquisition Value: {{ $asset->acquisition_value }}</p>
-    <p>Acquisition Date: {{ $asset->acquisition_date->format('Y-m-d') }}</p>
-    <p>Depreciation Duration: {{ $asset->depreciation_duration }} months</p>
-    <a href="{{ route('assets.edit', $asset->id) }}">Edit</a>
-    <form method="POST" action="{{ route('assets.destroy', $asset->id) }}">
-        @csrf
-        @method('DELETE')
-        <button type="submit">Delete</button>
-    </form>
-    <h2>Accounting Entries</h2>
-    <ul>
-        @foreach($asset->accountingEntries as $entry)
-            <li>{{ $entry->entry_label }} - {{ $entry->debit_amount }} / {{ $entry->credit_amount }}</li>
-        @endforeach
-    </ul>
-</body>
-</html>
+@stop
+
+@section('content')
+    <x-adminlte-card title="{{ $asset->name }}" theme="primary" maximizable>
+        <div class="row">
+            <div class="col-md-6">
+                <dl>
+                    <dt>Category</dt>
+                    <dd>{{ $asset->category }}</dd>
+                    <dt>Acquisition value</dt>
+                    <dd>{{ $asset->acquisition_value }}</dd>
+                    <dt>Acquisition date</dt>
+                    <dd>{{ $asset->acquisition_date->format('Y-m-d') }}</dd>
+                    <dt>Depreciation duration</dt>
+                    <dd>{{ $asset->depreciation_duration }} months</dd>
+                </dl>
+                <a href="{{ route('assets.edit', $asset->id) }}" class="btn btn-info">{{ __('general_content.edit_trans_key') }}</a>
+                <form method="POST" action="{{ route('assets.destroy', $asset->id) }}" class="d-inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">{{ __('general_content.delete_trans_key') }}</button>
+                </form>
+            </div>
+        </div>
+        <h2>{{ __('general_content.accounting_trans_key') }}</h2>
+        <ul>
+            @foreach($asset->accountingEntries as $entry)
+                <li>{{ $entry->entry_label }} - {{ $entry->debit_amount }} / {{ $entry->credit_amount }}</li>
+            @endforeach
+        </ul>
+    </x-adminlte-card>
+@stop

--- a/resources/views/assets/partials/assets-list.blade.php
+++ b/resources/views/assets/partials/assets-list.blade.php
@@ -1,10 +1,40 @@
-<div>
-    <h1>{{ __('general_content.assets_trans_key') }}</h1>
-    <a href="{{ route('assets.create') }}">Create Asset</a>
-    <ul>
-        @foreach($assets as $asset)
-            <li><a href="{{ route('assets.show', $asset->id) }}">{{ $asset->name }}</a></li>
-        @endforeach
-    </ul>
-    {{ $assets->links() }}
-</div>
+<x-adminlte-card title="{{ __('general_content.assets_trans_key') }}" theme="primary" maximizable>
+    <div class="card-body table-responsive p-0">
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th>{{ __('general_content.name_trans_key') }}</th>
+                    <th>Category</th>
+                    <th>Acquisition value</th>
+                    <th>Acquisition date</th>
+                    <th>Depreciation duration (months)</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($assets as $asset)
+                    <tr>
+                        <td><a href="{{ route('assets.show', $asset->id) }}">{{ $asset->name }}</a></td>
+                        <td>{{ $asset->category }}</td>
+                        <td>{{ $asset->acquisition_value }}</td>
+                        <td>{{ $asset->acquisition_date->format('Y-m-d') }}</td>
+                        <td>{{ $asset->depreciation_duration }}</td>
+                        <td class="text-right">
+                            <a href="{{ route('assets.edit', $asset->id) }}" class="btn btn-xs btn-default text-primary mx-1 shadow" title="Edit">
+                                <i class="fa fa-lg fa-fw fa-pen"></i>
+                            </a>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6">{{ __('general_content.no_data_trans_key') }}</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer">
+        <a href="{{ route('assets.create') }}" class="btn btn-primary">{{ __('general_content.new_trans_key') }} {{ __('general_content.asset_trans_key') }}</a>
+        {{ $assets->links() }}
+    </div>
+</x-adminlte-card>


### PR DESCRIPTION
## Summary
- Style asset list with AdminLTE card and table
- Convert asset create, edit, show, and index pages to AdminLTE layout

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68aa441f0df8832d9aa515e258d049c6