### PR TITLE
style: apply AdminLTE layout to energy consumption views

### DIFF
--- a/resources/views/energy-consumptions/energy-consumptions-index.blade.php
+++ b/resources/views/energy-consumptions/energy-consumptions-index.blade.php
@@ -1,30 +1,36 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>{{ __('general_content.energy_consumption_trans_key') }}</title>
-</head>
-<body>
+@extends('adminlte::page')
+
+@section('title', __('general_content.energy_consumption_trans_key'))
+
+@section('content_header')
     <h1>{{ __('general_content.energy_consumption_trans_key') }}</h1>
-    <form method="POST" action="{{ route('energy-consumptions.store') }}">
-        @csrf
-        <div>
-            <label for="recorded_at">Date</label>
-            <input type="date" name="recorded_at" id="recorded_at" required>
-        </div>
-        <div>
-            <label for="amount">Amount (kWh)</label>
-            <input type="number" step="0.01" name="amount" id="amount" required>
-        </div>
-        <button type="submit">Save</button>
-    </form>
-    <ul>
-        @foreach ($energyConsumptions as $energyConsumption)
-            <li>
-                <a href="{{ route('energy-consumptions.show', $energyConsumption->id) }}">
-                    {{ $energyConsumption->recorded_at }} - {{ $energyConsumption->amount }} kWh
-                </a>
-            </li>
-        @endforeach
-    </ul>
-</body>
-</html>
+@stop
+
+@section('content')
+    <x-adminlte-card theme="primary" icon="fas fa-bolt">
+        <form method="POST" action="{{ route('energy-consumptions.store') }}" class="mb-4">
+            @csrf
+            <div class="row">
+                <div class="col-md-5">
+                    <x-adminlte-input name="recorded_at" type="date" label="{{ __('general_content.date_trans_key') }}" required />
+                </div>
+                <div class="col-md-5">
+                    <x-adminlte-input name="amount" type="number" step="0.01" label="{{ __('general_content.amount_trans_key') }} (kWh)" required />
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
+                    <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.add_trans_key') }}" theme="success" icon="fas fa-plus"/>
+                </div>
+            </div>
+        </form>
+
+        <ul class="list-group">
+            @foreach ($energyConsumptions as $energyConsumption)
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <a href="{{ route('energy-consumptions.show', $energyConsumption->id) }}">
+                        {{ $energyConsumption->recorded_at }} - {{ $energyConsumption->amount }} kWh
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </x-adminlte-card>
+@stop

--- a/resources/views/energy-consumptions/energy-consumptions-show.blade.php
+++ b/resources/views/energy-consumptions/energy-consumptions-show.blade.php
@@ -1,12 +1,19 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>{{ __('general_content.energy_consumption_trans_key') }}</title>
-</head>
-<body>
+@extends('adminlte::page')
+
+@section('title', __('general_content.energy_consumption_trans_key'))
+
+@section('content_header')
     <h1>{{ __('general_content.energy_consumption_trans_key') }}</h1>
-    <p>Date: {{ $energyConsumption->recorded_at }}</p>
-    <p>Amount: {{ $energyConsumption->amount }} kWh</p>
-    <a href="{{ route('energy-consumptions.index') }}">Back to list</a>
-</body>
-</html>
+@stop
+
+@section('content')
+    <x-adminlte-card theme="primary" icon="fas fa-bolt">
+        <dl class="row">
+            <dt class="col-sm-3">{{ __('general_content.date_trans_key') }}</dt>
+            <dd class="col-sm-9">{{ $energyConsumption->recorded_at }}</dd>
+            <dt class="col-sm-3">{{ __('general_content.amount_trans_key') }}</dt>
+            <dd class="col-sm-9">{{ $energyConsumption->amount }} kWh</dd>
+        </dl>
+        <x-adminlte-button class="btn-flat" theme="secondary" icon="fas fa-arrow-left" label="{{ __('general_content.back_to_list_trans_key') }}" onclick="window.location='{{ route('energy-consumptions.index') }}'"/>
+    </x-adminlte-card>
+@stop


### PR DESCRIPTION
## Summary
- migrate energy consumption index and show templates to AdminLTE layout
- add card-based styling, inputs, and buttons for energy consumption pages

## Testing
- `phpunit` *(fails: command not found)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: missing PHP extension and GitHub access errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa451b0b50832d85a332eb42b46e06