### PR TITLE
Align OrderSite fields with order schema

### DIFF
--- a/app/Models/Workflow/OrderSite.php
+++ b/app/Models/Workflow/OrderSite.php
@@ -11,11 +11,6 @@ class OrderSite extends Model
 
     protected $fillable = [
         'order_id',
-        'name',
-        'adress',
-        'city',
-        'postal_code',
-        'description',
         'location',
         'characteristics',
         'contact_info',

--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -114,8 +114,7 @@ class Orders extends Model
 
     public function OrderSite()
     {
-        return $this->hasOne(OrderSite::class, 'order_id');
-
+        return $this->hasOne(OrderSite::class, 'order_id', 'id');
     }
     
     public function getPurchaseLinesCountAttribute()


### PR DESCRIPTION
## Summary
- clean up OrderSite model to match new schema
- point Order model relation at `order_id`

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aae59a8934832d96b0b399c2ea74ca