### PR TITLE
Add batches translation key for multiple languages

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -296,7 +296,8 @@ return [
     'units_trans_key'                          => 'الوحدات',
     'families_trans_key'                       => 'الأسر',
     'tools_trans_key'                          => 'الأدوات',
-    
+    'batches_trans_key'                        => 'الدفعات',
+
     'absence_trans_key'                        => 'الغياب',
     'banck_holiday_trans_key'                  => 'إجازة بنكية',
     'improduct_time_trans_key'                 => 'الوقت غير الإنتاجي',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -328,7 +328,8 @@ return [
     'units_trans_key'                          => 'Units',
     'families_trans_key'                       => 'Families',
     'tools_trans_key'                          => 'Tools',
-    
+    'batches_trans_key'                        => 'Batches',
+
     'absence_trans_key'                        => 'Absence',
     'banck_holiday_trans_key'                  => 'Bank holiday',
     'improduct_time_trans_key'                 => 'Non-productive time',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -293,6 +293,7 @@ return [
     'units_trans_key'                          => 'Unidades',
     'families_trans_key'                       => 'Familias',
     'tools_trans_key'                          => 'Herramientas',
+    'batches_trans_key'                        => 'Lotes',
 
     'absence_trans_key'                        => 'Ausencia',
     'banck_holiday_trans_key'                  => 'Día festivo bancario',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -328,6 +328,7 @@ return [
     'units_trans_key'                          => 'Unités',
     'families_trans_key'                       => 'Famille',
     'tools_trans_key'                          => 'Outils',
+    'batches_trans_key'                        => 'Lots',
 
     'absence_trans_key'                        => 'Absence',
     'banck_holiday_trans_key'                  => 'jour férié',


### PR DESCRIPTION
## Summary
- add `batches_trans_key` translation in English, French, Spanish, and Arabic general content files

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub token / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab852f3d80832d8b77bb4222bd0247