### PR TITLE
Refine energy consumption cost logic and relation

### DIFF
--- a/app/Models/EnergyConsumption.php
+++ b/app/Models/EnergyConsumption.php
@@ -2,35 +2,30 @@
 
 namespace App\Models;
 
-
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use App\Models\Methods\MethodsRessources;
+use Illuminate\Database\Eloquent\Model;
 
 class EnergyConsumption extends Model
 {
     use HasFactory;
 
     protected $fillable = [
-        'kwh_consumed',
-        'cost',
         'machine_id',
         'kwh',
         'cost_per_kwh',
         'total_cost',
-        'amount',
     ];
 
     protected static function booted()
     {
         static::saving(function (EnergyConsumption $consumption) {
-            $consumption->cost = $consumption->kwh_consumed * config('energy.price_per_kwh');
+            $consumption->total_cost = $consumption->kwh * $consumption->cost_per_kwh;
         });
     }
 
-    public function getCostAttribute($value)
+    public function machine()
     {
-        return $value ?? $this->kwh_consumed * config('energy.price_per_kwh');
+        return $this->belongsTo(Machine::class);
     }
 }
 

--- a/tests/Unit/EnergyConsumptionTest.php
+++ b/tests/Unit/EnergyConsumptionTest.php
@@ -7,10 +7,15 @@ use PHPUnit\Framework\TestCase;
 
 class EnergyConsumptionTest extends TestCase
 {
-    public function test_cost_attribute_is_computed()
+    public function test_total_cost_is_computed()
     {
-        config(['energy.price_per_kwh' => 0.2]);
-        $model = new EnergyConsumption(['kwh_consumed' => 5]);
-        $this->assertSame(1.0, $model->cost);
+        $model = new EnergyConsumption([
+            'kwh' => 5,
+            'cost_per_kwh' => 0.2,
+        ]);
+
+        $model->fireModelEvent('saving', false);
+
+        $this->assertSame(1.0, $model->total_cost);
     }
 }


### PR DESCRIPTION
## Summary
- simplify `EnergyConsumption` fillable fields
- compute `total_cost` from `kwh` and `cost_per_kwh`
- add `machine` relation and update tests

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-ldap` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab85020038832db01401310dcc980d