### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/SMEWebify/WebErpMesv2/security/code-scanning/2](https://github.com/SMEWebify/WebErpMesv2/security/code-scanning/2)

To fix the problem, you should add a `permissions` key to the workflow to explicitly specify the least privilege required for it to work. For a workflow that only reads repository contents (e.g., to check out code and install dependencies), typically only `contents: read` is needed. You should add a `permissions:` block either at the root of the workflow file (affecting all jobs) or inside the specific jobs (in this case, under `jobs.tests`). Since there is only one job, it's simplest and clearest to add at the top level, immediately below the `name` field and above the `on` field. This change requires no imports, methods, or new definitions—just adding one configuration block in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
