### PR TITLE
Ensure weighted average cost returns float

### DIFF
--- a/app/Services/StockCalculationService.php
+++ b/app/Services/StockCalculationService.php
@@ -24,9 +24,14 @@ class StockCalculationService
      * @param int $stockLocationProductId The ID of the stock location product.
      * @return float The weighted average cost of the product. Returns 0 if there is no quantity.
      */
-    public function calculateWeightedAverageCost($stockLocationProductId)
+    public function calculateWeightedAverageCost(int $stockLocationProductId): float
     {
         $stockLocationProduct = StockLocationProducts::find($stockLocationProductId);
+
+        if (! $stockLocationProduct) {
+            return 0.0;
+        }
+
         $stockMoves = $stockLocationProduct->StockMove;
 
         $totalQuantity = 0;
@@ -45,7 +50,7 @@ class StockCalculationService
             return $totalValue / $totalQuantity;
         }
 
-        return 0; // If no quantity, return zero or other default behavior
+        return 0.0; // If no quantity, return zero or other default behavior
     }
 
     public function canDispatch($tracabilityId, $quantityRequested, $stockLocationProductId)


### PR DESCRIPTION
## Summary
- type-hint the weighted average stock cost method to always return a float
- safely handle missing stock location products and keep zero return consistent with float expectation

## Testing
- not run (composer install requires external downloads that are blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d119f64020832d8bcf880d877a69a3