### PR TITLE
Add dynamic custom requirements for line details

### DIFF
--- a/app/Http/Controllers/Workflow/OrderLinesController.php
+++ b/app/Http/Controllers/Workflow/OrderLinesController.php
@@ -26,9 +26,28 @@ class OrderLinesController extends Controller
     public function update($idOrder, UpdateOrderLineDetailsRequest $request)
     {
         $OrderLineDetails = OrderLineDetails::findOrFail($request->id);
-        $OrderLineDetails->update($request->validated());
+        $validated = $request->validated();
+        $validated['custom_requirements'] = $this->sanitizeCustomRequirements($request->input('custom_requirements', []));
+
+        $OrderLineDetails->update($validated);
 
         return redirect()->route('orders.show', ['id' => $idOrder])->with('success', 'Successfully updated order detail line');
+    }
+
+    private function sanitizeCustomRequirements(array $requirements): array
+    {
+        return collect($requirements)
+            ->map(function ($requirement) {
+                return [
+                    'label' => isset($requirement['label']) ? trim($requirement['label']) : '',
+                    'value' => isset($requirement['value']) ? trim($requirement['value']) : '',
+                ];
+            })
+            ->filter(function ($requirement) {
+                return $requirement['label'] !== '' || $requirement['value'] !== '';
+            })
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Http/Controllers/Workflow/QuoteLinesController.php
+++ b/app/Http/Controllers/Workflow/QuoteLinesController.php
@@ -26,9 +26,28 @@ class QuoteLinesController extends Controller
     public function update($idQuote, UpdateQuoteLineDetailsRequest $request)
     {
         $QuoteLineDetails = QuoteLineDetails::findOrFail($request->id);
-        $QuoteLineDetails->update($request->validated());
+        $validated = $request->validated();
+        $validated['custom_requirements'] = $this->sanitizeCustomRequirements($request->input('custom_requirements', []));
+
+        $QuoteLineDetails->update($validated);
 
         return redirect()->route('quotes.show', ['id' => $idQuote])->with('success', 'Successfully updated quote detail line');
+    }
+
+    private function sanitizeCustomRequirements(array $requirements): array
+    {
+        return collect($requirements)
+            ->map(function ($requirement) {
+                return [
+                    'label' => isset($requirement['label']) ? trim($requirement['label']) : '',
+                    'value' => isset($requirement['value']) ? trim($requirement['value']) : '',
+                ];
+            })
+            ->filter(function ($requirement) {
+                return $requirement['label'] !== '' || $requirement['value'] !== '';
+            })
+            ->values()
+            ->all();
     }
     
     /**

--- a/app/Http/Requests/Workflow/UpdateOrderLineDetailsRequest.php
+++ b/app/Http/Requests/Workflow/UpdateOrderLineDetailsRequest.php
@@ -39,6 +39,9 @@ class UpdateOrderLineDetailsRequest extends FormRequest
             'material_loss_rate' => 'nullable|numeric|min:0|max:100',
             'internal_comment' => 'nullable|string|max:255',
             'external_comment' => 'nullable|string|max:255',
+            'custom_requirements' => 'nullable|array',
+            'custom_requirements.*.label' => 'nullable|string|max:255',
+            'custom_requirements.*.value' => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Http/Requests/Workflow/UpdateQuoteLineDetailsRequest.php
+++ b/app/Http/Requests/Workflow/UpdateQuoteLineDetailsRequest.php
@@ -39,6 +39,9 @@ class UpdateQuoteLineDetailsRequest extends FormRequest
             'material_loss_rate' => 'nullable|numeric|min:0|max:100',
             'internal_comment' => 'nullable|string|max:255',
             'external_comment' => 'nullable|string|max:255',
+            'custom_requirements' => 'nullable|array',
+            'custom_requirements.*.label' => 'nullable|string|max:255',
+            'custom_requirements.*.value' => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -60,6 +60,7 @@ class OrderLine extends Component
     public $ProductSelect  = [];
 
     public $data = [];
+    public $customRequirements = [];
     public $RemoveFromStock = false;
     public $CreateSerialNumber = false;
     
@@ -142,14 +143,72 @@ class OrderLine extends Component
         $this->VATSelect = AccountingVat::select('id', 'label')->orderBy('rate')->get();
         $this->UnitsSelect = MethodsUnits::select('id', 'label', 'code')->orderBy('label')->get();
         $this->ProductSelect = Products::select('id', 'code','label', 'methods_services_id')->get();
+        $this->initializeCustomRequirements();
 }
 
     public function render()
     {
-        $OrderLineslist = $this->OrderLineslist = Orderlines::orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->where('orders_id', '=', $this->orders_id)->where('label','like', '%'.$this->search.'%')->get();
+        $OrderLineslist = $this->OrderLineslist = Orderlines::with('OrderLineDetails')->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->where('orders_id', '=', $this->orders_id)->where('label','like', '%'.$this->search.'%')->get();
+
+        foreach ($OrderLineslist as $line) {
+            $detail = $line->OrderLineDetails;
+            if ($detail && !array_key_exists($detail->id, $this->customRequirements)) {
+                $this->customRequirements[$detail->id] = $this->normalizeCustomRequirements($detail->custom_requirements);
+            }
+        }
+
         return view('livewire.order-lines', [
             'OrderLineslist' => $OrderLineslist,
         ]);
+    }
+
+    private function initializeCustomRequirements(): void
+    {
+        $lineIds = OrderLines::where('orders_id', $this->orders_id)->pluck('id');
+
+        if ($lineIds->isEmpty()) {
+            $this->customRequirements = [];
+            return;
+        }
+
+        OrderLineDetails::whereIn('order_lines_id', $lineIds)
+            ->get()
+            ->each(function ($detail) {
+                $this->customRequirements[$detail->id] = $this->normalizeCustomRequirements($detail->custom_requirements);
+            });
+    }
+
+    private function normalizeCustomRequirements($requirements): array
+    {
+        if (!is_array($requirements)) {
+            return [];
+        }
+
+        return array_values(array_map(function ($requirement) {
+            return [
+                'label' => $requirement['label'] ?? '',
+                'value' => $requirement['value'] ?? '',
+            ];
+        }, $requirements));
+    }
+
+    public function addCustomRequirement($detailId): void
+    {
+        if (!isset($this->customRequirements[$detailId])) {
+            $this->customRequirements[$detailId] = [];
+        }
+
+        $this->customRequirements[$detailId][] = ['label' => '', 'value' => ''];
+    }
+
+    public function removeCustomRequirement($detailId, $index): void
+    {
+        if (!isset($this->customRequirements[$detailId][$index])) {
+            return;
+        }
+
+        unset($this->customRequirements[$detailId][$index]);
+        $this->customRequirements[$detailId] = array_values($this->customRequirements[$detailId]);
     }
 
     public function resetFields(){
@@ -206,7 +265,8 @@ class OrderLine extends Component
         ]);
 
         //add line detail
-        OrderLineDetails::create(['order_lines_id'=>$NewOrderLine->id]);
+        $orderLineDetails = OrderLineDetails::create(['order_lines_id'=>$NewOrderLine->id]);
+        $this->customRequirements[$orderLineDetails->id] = [];
 
         // Set Flash Message
         session()->flash('success','Line added Successfully');
@@ -274,9 +334,17 @@ class OrderLine extends Component
     private function duplicateOrderLineDetails($oldOrderLineId, $newOrderLineId)
     {
         $orderLineDetails = OrderLineDetails::where('order_lines_id', $oldOrderLineId)->first();
-        $newOrderLineDetails = $orderLineDetails->replicate();
-        $newOrderLineDetails->order_lines_id = $newOrderLineId;
-        $newOrderLineDetails->save();
+        if (!$orderLineDetails) {
+            $newOrderLineDetails = OrderLineDetails::create([
+                'order_lines_id' => $newOrderLineId,
+            ]);
+        } else {
+            $newOrderLineDetails = $orderLineDetails->replicate();
+            $newOrderLineDetails->order_lines_id = $newOrderLineId;
+            $newOrderLineDetails->save();
+        }
+
+        $this->customRequirements[$newOrderLineDetails->id] = $this->normalizeCustomRequirements($newOrderLineDetails->custom_requirements);
     }
     
     private function duplicateTasks($oldOrderLineId, $newOrderLineId)

--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -52,6 +52,7 @@ class QuoteLine extends Component
     public $ProductSelect  = [];
 
     public $data = [];
+    public $customRequirements = [];
 
     protected $orderService;
 
@@ -112,17 +113,75 @@ class QuoteLine extends Component
         $this->VATSelect = AccountingVat::select('id', 'label', 'default')->orderBy('rate')->get();
         $this->UnitsSelect = MethodsUnits::select('id', 'label', 'code', 'default')->orderBy('label')->get();
         $this->ProductSelect = Products::select('id', 'code','label', 'methods_services_id')->get();
+        $this->initializeCustomRequirements();
     }
 
     public function render()
     {
-        $QuoteLineslist = $this->QuoteLineslist = Quotelines::orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+        $QuoteLineslist = $this->QuoteLineslist = Quotelines::with('QuoteLineDetails')
+                                                            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
                                                             ->where('quotes_id', '=', $this->quotes_id)
                                                             ->where('label','like', '%'.$this->search.'%')->get();
-        
+
+        foreach ($QuoteLineslist as $line) {
+            $detail = $line->QuoteLineDetails;
+            if ($detail && !array_key_exists($detail->id, $this->customRequirements)) {
+                $this->customRequirements[$detail->id] = $this->normalizeCustomRequirements($detail->custom_requirements);
+            }
+        }
+
         return view('livewire.quote-lines', [
             'QuoteLineslist' => $QuoteLineslist,
         ]);
+    }
+
+    private function initializeCustomRequirements(): void
+    {
+        $lineIds = QuoteLines::where('quotes_id', $this->quotes_id)->pluck('id');
+
+        if ($lineIds->isEmpty()) {
+            $this->customRequirements = [];
+            return;
+        }
+
+        QuoteLineDetails::whereIn('quote_lines_id', $lineIds)
+            ->get()
+            ->each(function ($detail) {
+                $this->customRequirements[$detail->id] = $this->normalizeCustomRequirements($detail->custom_requirements);
+            });
+    }
+
+    private function normalizeCustomRequirements($requirements): array
+    {
+        if (!is_array($requirements)) {
+            return [];
+        }
+
+        return array_values(array_map(function ($requirement) {
+            return [
+                'label' => $requirement['label'] ?? '',
+                'value' => $requirement['value'] ?? '',
+            ];
+        }, $requirements));
+    }
+
+    public function addCustomRequirement($detailId): void
+    {
+        if (!isset($this->customRequirements[$detailId])) {
+            $this->customRequirements[$detailId] = [];
+        }
+
+        $this->customRequirements[$detailId][] = ['label' => '', 'value' => ''];
+    }
+
+    public function removeCustomRequirement($detailId, $index): void
+    {
+        if (!isset($this->customRequirements[$detailId][$index])) {
+            return;
+        }
+
+        unset($this->customRequirements[$detailId][$index]);
+        $this->customRequirements[$detailId] = array_values($this->customRequirements[$detailId]);
     }
 
     public function resetFields(){
@@ -160,7 +219,8 @@ class QuoteLine extends Component
         ]);
         
         //add line detail
-        QuoteLineDetails::create(['quote_lines_id'=>$NewQuoteLine->id]);
+        $quoteLineDetails = QuoteLineDetails::create(['quote_lines_id'=>$NewQuoteLine->id]);
+        $this->customRequirements[$quoteLineDetails->id] = [];
         
         // Set Flash Message
         session()->flash('success','Line added Successfully');
@@ -247,9 +307,17 @@ class QuoteLine extends Component
     private function duplicateQuoteLineDetails($oldQuoteLineId, $newQuoteLineId)
     {
         $quoteLineDetails = QuoteLineDetails::where('quote_lines_id', $oldQuoteLineId)->first();
-        $newQuoteLineDetails = $quoteLineDetails->replicate();
-        $newQuoteLineDetails->quote_lines_id = $newQuoteLineId;
-        $newQuoteLineDetails->save();
+        if (!$quoteLineDetails) {
+            $newQuoteLineDetails = QuoteLineDetails::create([
+                'quote_lines_id' => $newQuoteLineId,
+            ]);
+        } else {
+            $newQuoteLineDetails = $quoteLineDetails->replicate();
+            $newQuoteLineDetails->quote_lines_id = $newQuoteLineId;
+            $newQuoteLineDetails->save();
+        }
+
+        $this->customRequirements[$newQuoteLineDetails->id] = $this->normalizeCustomRequirements($newQuoteLineDetails->custom_requirements);
     }
     
     private function duplicateTasks($oldQuoteLineId, $newQuoteLineId)

--- a/app/Models/Workflow/OrderLineDetails.php
+++ b/app/Models/Workflow/OrderLineDetails.php
@@ -28,9 +28,14 @@ class OrderLineDetails extends Model
                             'material_loss_rate', 
                             'cad_file',
                             'picture', 
-                            'internal_comment', 
-                            'external_comment',  
+                            'internal_comment',
+                            'external_comment',
+                            'custom_requirements',
                         ];
+
+    protected $casts = [
+        'custom_requirements' => 'array',
+    ];
 
     public function OrderLines()
     {

--- a/app/Models/Workflow/QuoteLineDetails.php
+++ b/app/Models/Workflow/QuoteLineDetails.php
@@ -28,9 +28,14 @@ class QuoteLineDetails extends Model
                             'material_loss_rate', 
                             'cad_file',  
                             'picture', 
-                            'internal_comment', 
-                            'external_comment', 
+                            'internal_comment',
+                            'external_comment',
+                            'custom_requirements',
                         ];
+
+    protected $casts = [
+        'custom_requirements' => 'array',
+    ];
 
     public function QuoteLines()
     {

--- a/database/migrations/2023_01_13_221432_create_quote_line_details_table.php
+++ b/database/migrations/2023_01_13_221432_create_quote_line_details_table.php
@@ -30,8 +30,9 @@ return new class extends Migration
 			$table->decimal('material_loss_rate', 10, 3)->nullable();
             $table->string('cad_file')->nullable();
             $table->string('picture')->nullable();
-			$table->text('internal_comment')->nullable();
-			$table->text('external_comment')->nullable();
+                        $table->text('internal_comment')->nullable();
+                        $table->text('external_comment')->nullable();
+            $table->json('custom_requirements')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_01_13_221442_create_order_line_details_table.php
+++ b/database/migrations/2023_01_13_221442_create_order_line_details_table.php
@@ -30,8 +30,9 @@ return new class extends Migration
 			$table->decimal('material_loss_rate', 10, 3)->nullable();
             $table->string('cad_file')->nullable();
             $table->string('picture')->nullable();
-			$table->text('internal_comment')->nullable();
-			$table->text('external_comment')->nullable();
+                        $table->text('internal_comment')->nullable();
+                        $table->text('external_comment')->nullable();
+            $table->json('custom_requirements')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/guest/guest-order-info.blade.php
+++ b/resources/views/guest/guest-order-info.blade.php
@@ -140,6 +140,19 @@
                                                     <div class="flex-lg-grow-1 ms-3">
                                                         <h6 class="small mb-0">{{ $DocumentLine->label }}</h6>
                                                         <span style="color: #6c757d">{{ $DocumentLine->code }}</span>
+                                                        @php
+                                                            $guestDetail = $DocumentLine->OrderLineDetails ?? null;
+                                                            $guestCustomRequirements = $guestDetail ? collect($guestDetail->custom_requirements ?? [])->filter(function ($requirement) {
+                                                                return !empty($requirement['label'] ?? null) || !empty($requirement['value'] ?? null);
+                                                            }) : collect();
+                                                        @endphp
+                                                        @if($guestCustomRequirements->isNotEmpty())
+                                                            <ul class="list-unstyled mb-0 small text-muted">
+                                                                @foreach($guestCustomRequirements as $requirement)
+                                                                    <li><strong>{{ $requirement['label'] ?? __('Requirement') }}:</strong> {{ $requirement['value'] ?? '' }}</li>
+                                                                @endforeach
+                                                            </ul>
+                                                        @endif
                                                     </div>
                                                 </div>
                                             </td>

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -277,6 +277,34 @@
                                                             </div>
                                                         </div>
                                                     </div>
+                                                    @php $orderDetailId = $OrderLine->OrderLineDetails->id; @endphp
+                                                    <div class="row">
+                                                        <div class="col-12">
+                                                            <label class="text-info">{{ __('Custom requirements') }}</label>
+                                                        </div>
+                                                        @forelse($customRequirements[$orderDetailId] ?? [] as $index => $requirement)
+                                                            <div class="form-row align-items-end w-100" wire:key="order-custom-{{ $orderDetailId }}-{{ $index }}">
+                                                                <div class="form-group col-md-5">
+                                                                    <label for="order_custom_requirement_label_{{ $orderDetailId }}_{{ $index }}">{{ __('Label') }}</label>
+                                                                    <input type="text" class="form-control" id="order_custom_requirement_label_{{ $orderDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][label]" wire:model="customRequirements.{{ $orderDetailId }}.{{ $index }}.label" placeholder="{{ __('Label') }}">
+                                                                </div>
+                                                                <div class="form-group col-md-5">
+                                                                    <label for="order_custom_requirement_value_{{ $orderDetailId }}_{{ $index }}">{{ __('Value') }}</label>
+                                                                    <input type="text" class="form-control" id="order_custom_requirement_value_{{ $orderDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][value]" wire:model="customRequirements.{{ $orderDetailId }}.{{ $index }}.value" placeholder="{{ __('Value') }}">
+                                                                </div>
+                                                                <div class="form-group col-md-2">
+                                                                    <button type="button" class="btn btn-outline-danger mt-4" wire:click="removeCustomRequirement({{ $orderDetailId }}, {{ $index }})"><i class="fas fa-trash"></i></button>
+                                                                </div>
+                                                            </div>
+                                                        @empty
+                                                            <div class="col-12">
+                                                                <p class="text-muted">{{ __('No custom requirement added yet.') }}</p>
+                                                            </div>
+                                                        @endforelse
+                                                        <div class="col-12 mb-3">
+                                                            <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $orderDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
+                                                        </div>
+                                                    </div>
                                                     <div class="row">
                                                         <div class="form-group col-md-4">
                                                             <div class="input-group">

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -197,6 +197,34 @@
                                                             </div>
                                                         </div>
                                                     </div>
+                                                    @php $quoteDetailId = $QuoteLine->QuoteLineDetails->id; @endphp
+                                                    <div class="row">
+                                                        <div class="col-12">
+                                                            <label class="text-info">{{ __('Custom requirements') }}</label>
+                                                        </div>
+                                                        @forelse($customRequirements[$quoteDetailId] ?? [] as $index => $requirement)
+                                                            <div class="form-row align-items-end w-100" wire:key="quote-custom-{{ $quoteDetailId }}-{{ $index }}">
+                                                                <div class="form-group col-md-5">
+                                                                    <label for="custom_requirement_label_{{ $quoteDetailId }}_{{ $index }}">{{ __('Label') }}</label>
+                                                                    <input type="text" class="form-control" id="custom_requirement_label_{{ $quoteDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][label]" wire:model="customRequirements.{{ $quoteDetailId }}.{{ $index }}.label" placeholder="{{ __('Label') }}">
+                                                                </div>
+                                                                <div class="form-group col-md-5">
+                                                                    <label for="custom_requirement_value_{{ $quoteDetailId }}_{{ $index }}">{{ __('Value') }}</label>
+                                                                    <input type="text" class="form-control" id="custom_requirement_value_{{ $quoteDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][value]" wire:model="customRequirements.{{ $quoteDetailId }}.{{ $index }}.value" placeholder="{{ __('Value') }}">
+                                                                </div>
+                                                                <div class="form-group col-md-2">
+                                                                    <button type="button" class="btn btn-outline-danger mt-4" wire:click="removeCustomRequirement({{ $quoteDetailId }}, {{ $index }})"><i class="fas fa-trash"></i></button>
+                                                                </div>
+                                                            </div>
+                                                        @empty
+                                                            <div class="col-12">
+                                                                <p class="text-muted">{{ __('No custom requirement added yet.') }}</p>
+                                                            </div>
+                                                        @endforelse
+                                                        <div class="col-12 mb-3">
+                                                            <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $quoteDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
+                                                        </div>
+                                                    </div>
                                                     <div class="row">
                                                         <div class="form-group col-md-4">
                                                             <div class="input-group">

--- a/resources/views/livewire/task-manage.blade.php
+++ b/resources/views/livewire/task-manage.blade.php
@@ -1,4 +1,28 @@
 <div>
+    @php
+        $detail = $Line->OrderLineDetails ?? $Line->QuoteLineDetails ?? null;
+        $customRequirementsForDisplay = $detail ? collect($detail->custom_requirements ?? [])->filter(function ($requirement) {
+            return !empty($requirement['label'] ?? null) || !empty($requirement['value'] ?? null);
+        }) : collect();
+    @endphp
+
+    @if($detail)
+        <x-adminlte-card title="{{ __('Custom requirements') }}" theme="secondary" icon="fas fa-swatchbook" class="mb-3">
+            @if($customRequirementsForDisplay->isNotEmpty())
+                <ul class="list-unstyled mb-0">
+                    @foreach($customRequirementsForDisplay as $requirement)
+                        <li>
+                            <strong>{{ $requirement['label'] ?? __('Requirement') }}:</strong>
+                            <span>{{ $requirement['value'] ?? '' }}</span>
+                        </li>
+                    @endforeach
+                </ul>
+            @else
+                <span class="text-muted">{{ __('No custom requirement added yet.') }}</span>
+            @endif
+        </x-adminlte-card>
+    @endif
+
     @if($statu == 1 || $idType == "nomenclature_lines_id")
         @include('include.alert-result')
         @if($updateLines)


### PR DESCRIPTION
## Summary
- add JSON storage for custom line requirements and cast them in detail models
- extend Livewire order and quote line components with dynamic custom requirement management
- render custom requirement fields in line detail forms and display them on workshop and guest views

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11dc75810832da8cebd4ac028f528