### PR TITLE
Add GTD task board with automated reminders

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\DispatchGtdTaskReminders;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -24,7 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->job(new DispatchGtdTaskReminders())->dailyAt('08:00')->withoutOverlapping();
     }
 
     /**

--- a/app/Http/Controllers/Planning/TaskController.php
+++ b/app/Http/Controllers/Planning/TaskController.php
@@ -39,6 +39,11 @@ class TaskController extends Controller
         return view('workflow/task-index');
     }
 
+    public function gtd()
+    {
+        return view('workflow/task-gtd');
+    }
+
     /**
      * @param  $id_type, $id_page, $id_line
      * @return \Illuminate\Contracts\View\View

--- a/app/Jobs/DispatchGtdTaskReminders.php
+++ b/app/Jobs/DispatchGtdTaskReminders.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Planning\Status;
+use App\Models\Planning\Task;
+use App\Notifications\TaskReminderNotification;
+use App\Services\NotificationService;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DispatchGtdTaskReminders implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle(NotificationService $notificationService): void
+    {
+        $today = Carbon::today();
+        $soonThreshold = $today->copy()->addDays(2);
+
+        $doneStatusIds = Status::query()
+            ->whereIn('title', ['Finished', 'Supplied', 'Done'])
+            ->pluck('id')
+            ->all();
+
+        $tasks = Task::query()
+            ->whereNull('quote_lines_id')
+            ->whereNull('order_lines_id')
+            ->whereNull('products_id')
+            ->whereNull('sub_assembly_id')
+            ->whereNotNull('due_date')
+            ->when(!empty($doneStatusIds), fn ($query) => $query->whereNotIn('status_id', $doneStatusIds))
+            ->with(['user', 'secondaryAssignee'])
+            ->get();
+
+        foreach ($tasks as $task) {
+            $alertType = null;
+
+            if ($task->due_date->lt($today)) {
+                $alertType = 'overdue';
+            } elseif ($task->due_date->between($today, $soonThreshold, true)) {
+                $alertType = 'due_soon';
+            }
+
+            if (! $alertType) {
+                continue;
+            }
+
+            $recipients = collect([$task->user, $task->secondaryAssignee])->filter();
+
+            if ($recipients->isEmpty()) {
+                continue;
+            }
+
+            $notificationService->sendTaskAlert(TaskReminderNotification::class, $task, $recipients, $alertType);
+        }
+    }
+}

--- a/app/Livewire/GtdBoard.php
+++ b/app/Livewire/GtdBoard.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Events\TaskChangeStatu;
+use App\Models\Planning\Status;
+use App\Models\Planning\Task;
+use App\Models\Planning\TaskActivities;
+use App\Models\User;
+use App\Services\TaskService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class GtdBoard extends Component
+{
+    public array $columns = [];
+    public Collection $users;
+    public array $commentBodies = [];
+    public array $primaryAssignments = [];
+    public array $secondaryAssignments = [];
+    public array $priorityLevels = [];
+
+    protected TaskService $taskService;
+
+    protected array $statusMap = [];
+
+    protected $listeners = [
+        'refreshGtdBoard' => 'loadBoard',
+    ];
+
+    public function mount(TaskService $taskService): void
+    {
+        $this->taskService = $taskService;
+        $this->users = User::select('id', 'name')->orderBy('name')->get();
+
+        $this->resolveStatuses();
+        $this->loadBoard();
+    }
+
+    public function render()
+    {
+        return view('livewire.gtd-board');
+    }
+
+    public function saveAssignment(int $taskId): void
+    {
+        $task = Task::find($taskId);
+
+        if (! $task) {
+            return;
+        }
+
+        $task->user_id = $this->normalizeUserId($this->primaryAssignments[$taskId] ?? null);
+        $task->secondary_user_id = $this->normalizeUserId($this->secondaryAssignments[$taskId] ?? null);
+        $task->save();
+
+        $this->loadBoard();
+
+        session()->flash('success', __('Assignment updated successfully.'));
+    }
+
+    public function updatePriority(int $taskId): void
+    {
+        $task = Task::find($taskId);
+
+        if (! $task) {
+            return;
+        }
+
+        $priority = (int) ($this->priorityLevels[$taskId] ?? Task::PRIORITY_MEDIUM);
+        $validPriorities = array_keys(Task::priorityLabels());
+
+        if (! in_array($priority, $validPriorities, true)) {
+            $priority = Task::PRIORITY_MEDIUM;
+        }
+
+        $task->priority = $priority;
+        $task->save();
+
+        $this->loadBoard();
+
+        session()->flash('success', __('Priority updated successfully.'));
+    }
+
+    public function moveTask(int $taskId, int $statusId): void
+    {
+        $task = Task::find($taskId);
+
+        if (! $task || $task->status_id === $statusId) {
+            return;
+        }
+
+        $task->status_id = $statusId;
+        $task->save();
+
+        if (in_array($statusId, $this->statusMap['in_progress'] ?? [], true)) {
+            $this->taskService->recordTaskActivity($taskId, TaskActivities::TYPE_START);
+        } elseif (in_array($statusId, $this->statusMap['done'] ?? [], true)) {
+            $this->taskService->recordTaskActivity($taskId, TaskActivities::TYPE_FINISH);
+        }
+
+        event(new TaskChangeStatu($taskId));
+
+        $this->loadBoard();
+
+        session()->flash('success', __('Task status updated.'));
+    }
+
+    public function addComment(int $taskId): void
+    {
+        $comment = trim($this->commentBodies[$taskId] ?? '');
+
+        if ($comment === '') {
+            return;
+        }
+
+        $this->taskService->recordTaskActivity($taskId, TaskActivities::TYPE_COMMENT, 0, 0, $comment);
+        $this->commentBodies[$taskId] = '';
+
+        $this->loadBoard();
+
+        session()->flash('success', __('Comment added successfully.'));
+    }
+
+    public function loadBoard(): void
+    {
+        $this->columns = [
+            'backlog' => [
+                'title' => __('Backlog'),
+                'default_status' => $this->statusMap['backlog'][0] ?? null,
+                'tasks' => $this->getTasksForStatus('backlog'),
+            ],
+            'in_progress' => [
+                'title' => __('In progress'),
+                'default_status' => $this->statusMap['in_progress'][0] ?? null,
+                'tasks' => $this->getTasksForStatus('in_progress'),
+            ],
+            'done' => [
+                'title' => __('Done'),
+                'default_status' => $this->statusMap['done'][0] ?? null,
+                'tasks' => $this->getTasksForStatus('done'),
+            ],
+        ];
+
+        $allTasks = collect();
+        foreach ($this->columns as $column) {
+            $allTasks = $allTasks->merge($column['tasks']);
+        }
+
+        $this->hydrateAssignments($allTasks);
+    }
+
+    protected function getTasksForStatus(string $column): Collection
+    {
+        $statusIds = $this->statusMap[$column] ?? [];
+        $query = $this->genericTaskQuery();
+
+        if (empty($statusIds)) {
+            if ($column === 'backlog') {
+                return $query->whereNull('status_id')->get();
+            }
+
+            return collect();
+        }
+
+        if ($column === 'backlog') {
+            $query->where(function ($innerQuery) use ($statusIds) {
+                $innerQuery->whereIn('status_id', $statusIds)
+                    ->orWhereNull('status_id');
+            });
+        } else {
+            $query->whereIn('status_id', $statusIds);
+        }
+
+        return $query->get();
+    }
+
+    protected function genericTaskQuery(): Builder
+    {
+        return Task::query()
+            ->with([
+                'user:id,name',
+                'secondaryAssignee:id,name',
+                'status:id,title',
+                'taskActivities' => function ($query) {
+                    $query->where('type', TaskActivities::TYPE_COMMENT)
+                        ->with('user:id,name')
+                        ->latest()
+                        ->take(5);
+                },
+            ])
+            ->whereNull('quote_lines_id')
+            ->whereNull('order_lines_id')
+            ->whereNull('products_id')
+            ->whereNull('sub_assembly_id')
+            ->orderBy('priority')
+            ->orderBy('due_date')
+            ->orderBy('label');
+    }
+
+    protected function hydrateAssignments(Collection $tasks): void
+    {
+        foreach ($tasks as $task) {
+            $this->primaryAssignments[$task->id] = $task->user_id ? (string) $task->user_id : '';
+            $this->secondaryAssignments[$task->id] = $task->secondary_user_id ? (string) $task->secondary_user_id : '';
+            $this->priorityLevels[$task->id] = (string) ($task->priority ?? Task::PRIORITY_MEDIUM);
+            $this->commentBodies[$task->id] = $this->commentBodies[$task->id] ?? '';
+        }
+    }
+
+    protected function resolveStatuses(): void
+    {
+        $statuses = Status::orderBy('order')->get();
+
+        $this->statusMap = [
+            'backlog' => $this->matchStatuses($statuses, ['open', 'pending', 'to do']),
+            'in_progress' => $this->matchStatuses($statuses, ['in progress', 'started', 'ongoing']),
+            'done' => $this->matchStatuses($statuses, ['finished', 'done', 'completed']),
+        ];
+
+        if (empty($this->statusMap['backlog']) && $statuses->isNotEmpty()) {
+            $this->statusMap['backlog'] = [$statuses->first()->id];
+        }
+
+        if (empty($this->statusMap['in_progress']) && $statuses->count() > 1) {
+            $this->statusMap['in_progress'] = [$statuses->get(1)->id ?? $statuses->first()->id];
+        }
+
+        if (empty($this->statusMap['done']) && $statuses->isNotEmpty()) {
+            $this->statusMap['done'] = [$statuses->last()->id];
+        }
+    }
+
+    protected function matchStatuses(Collection $statuses, array $labels): array
+    {
+        $expected = collect($labels)->map(fn ($label) => mb_strtolower($label));
+
+        return $statuses
+            ->filter(fn ($status) => $expected->contains(mb_strtolower($status->title)))
+            ->pluck('id')
+            ->all();
+    }
+
+    protected function normalizeUserId($value): ?int
+    {
+        $value = is_numeric($value) ? (int) $value : null;
+
+        return $value ?: null;
+    }
+}

--- a/app/Livewire/TaskStatu.php
+++ b/app/Livewire/TaskStatu.php
@@ -138,25 +138,29 @@ class TaskStatu extends Component
             if ($taskActivitie->user && $taskActivitie->user->name) { $userName = $taskActivitie->user->name; }
             else{$userName = 'System'; }
 
-            if($taskActivitie->type == 1){
+            if($taskActivitie->type == TaskActivities::TYPE_START){
                 $icon = 'fas fa-play-circle bg-primary';
                 $content =  $userName .' - '. __('general_content.set_to_start_trans_key');
             }
-            elseif ($taskActivitie->type == 2){
+            elseif ($taskActivitie->type == TaskActivities::TYPE_END){
                 $icon = 'fas fa-stop-circle bg-warning';
                 $content =  $userName .' - '. __('general_content.set_to_end_trans_key');
             }
-            elseif ($taskActivitie->type == 3){
+            elseif ($taskActivitie->type == TaskActivities::TYPE_FINISH){
                 $icon = 'fas fa-check-circle bg-info';
                 $content =  $userName .' - '. __('general_content.set_to_finish_trans_key');
             }
-            elseif ($taskActivitie->type == 4){
+            elseif ($taskActivitie->type == TaskActivities::TYPE_DECLARE_GOOD){
                 $icon = 'fas fa-thumbs-up bg-success';
                 $content =  $userName .' - '. __('general_content.declare_finish_trans_key') .' '. $taskActivitie->good_qt .' '.  __('general_content.part_trans_key');
             }
-            elseif ($taskActivitie->type == 5){
+            elseif ($taskActivitie->type == TaskActivities::TYPE_DECLARE_BAD){
                 $icon = 'fas fa-thumbs-down bg-danger';
                 $content =  $userName .' - '. __('general_content.declare_rejected_trans_key') .' '. $taskActivitie->bad_qt .' '. __('general_content.part_trans_key');
+            }
+            elseif ($taskActivitie->type == TaskActivities::TYPE_COMMENT){
+                $icon = 'fas fa-comment-dots bg-secondary';
+                $content = $userName .' - '. $taskActivitie->comment;
             }
 
             $this->timelineData[] = [

--- a/app/Models/Planning/Task.php
+++ b/app/Models/Planning/Task.php
@@ -28,6 +28,10 @@ class Task extends Model
 {
     use HasFactory, LogsActivity;
 
+    public const PRIORITY_HIGH = 1;
+    public const PRIORITY_MEDIUM = 2;
+    public const PRIORITY_LOW = 3;
+
     // Fillable attributes for mass assignment
     protected $fillable= ['code',
                             'label', 
@@ -41,9 +45,12 @@ class Task extends Model
                             'seting_time', 
                             'unit_time', 
                             'remaining_time', 
-                            'status_id', 
+                            'status_id',
+                            'user_id',
+                            'priority',
                             'type',
                             'delay',
+                            'due_date',
                             'qty',
                             'qty_init',
                             'qty_aviable',
@@ -64,11 +71,37 @@ class Task extends Model
                             'not_recalculate',
                             'material', 
                             'thickness', 
-                            'weight', 
+                            'weight',
                             'methods_tools_id',
+                            'secondary_user_id',
                             'origin'];
 
     protected $appends = ["open"];
+
+    protected $attributes = [
+        'priority' => self::PRIORITY_MEDIUM,
+    ];
+
+    protected $casts = [
+        'due_date' => 'date',
+        'priority' => 'integer',
+    ];
+
+    public static function priorityLabels(): array
+    {
+        return [
+            self::PRIORITY_HIGH => __('High'),
+            self::PRIORITY_MEDIUM => __('Medium'),
+            self::PRIORITY_LOW => __('Low'),
+        ];
+    }
+
+    public function getPriorityLabelAttribute(): string
+    {
+        $labels = self::priorityLabels();
+
+        return $labels[$this->priority] ?? $labels[self::PRIORITY_MEDIUM];
+    }
 
     public function service()
     {
@@ -209,6 +242,11 @@ class Task extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function secondaryAssignee()
+    {
+        return $this->belongsTo(User::class, 'secondary_user_id');
     }
 
     /**

--- a/app/Models/Planning/TaskActivities.php
+++ b/app/Models/Planning/TaskActivities.php
@@ -11,6 +11,13 @@ class TaskActivities extends Model
 {
     use HasFactory;
 
+    public const TYPE_START = 1;
+    public const TYPE_END = 2;
+    public const TYPE_FINISH = 3;
+    public const TYPE_DECLARE_GOOD = 4;
+    public const TYPE_DECLARE_BAD = 5;
+    public const TYPE_COMMENT = 6;
+
     // Fillable attributes for mass assignment
     protected $fillable= ['task_id', 
                             'user_id',

--- a/app/Notifications/TaskReminderNotification.php
+++ b/app/Notifications/TaskReminderNotification.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Planning\Task;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TaskReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected Task $task;
+
+    protected string $alertType;
+
+    public function __construct(Task $task, string $alertType)
+    {
+        $this->task = $task;
+        $this->alertType = $alertType;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject(__('Task reminder'))
+            ->line(__('Task ":label" requires your attention.', ['label' => $this->task->label]))
+            ->line(__('Due date: :date', ['date' => optional($this->task->due_date)->format('d/m/Y') ?? __('Not defined')]))
+            ->action(__('View task'), route('production.task.gtd'));
+    }
+
+    public function toArray($notifiable)
+    {
+        return [
+            'task_id' => $this->task->id,
+            'label' => $this->task->label,
+            'alert_type' => $this->alertType,
+            'due_date' => optional($this->task->due_date)->toDateString(),
+            'priority' => $this->task->priority,
+            'primary_user_id' => $this->task->user_id,
+            'secondary_user_id' => $this->task->secondary_user_id,
+        ];
+    }
+}

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Planning\Task;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;
 
@@ -21,5 +22,18 @@ class NotificationService
 
         // Envoyer la notification correspondante
         Notification::send($users, new $notificationType($entityCreated));
+    }
+
+    public function sendTaskAlert(string $notificationType, Task $task, iterable $users, string $alertType): void
+    {
+        $recipients = collect($users)
+            ->filter()
+            ->unique('id');
+
+        if ($recipients->isEmpty()) {
+            return;
+        }
+
+        Notification::send($recipients, new $notificationType($task, $alertType));
     }
 }

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -10,6 +10,7 @@ use App\Models\Planning\Status;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use App\Models\Planning\TaskActivities;
+use App\Models\User;
 
 class TaskService
 {
@@ -37,7 +38,7 @@ class TaskService
                 $task->update(['status_id' => $statusUpdate->id]);
 
                 // Enregistrer une activité de fermeture
-                $this->recordTaskActivity($task->id, 3, 0, 0);
+                $this->recordTaskActivity($task->id, TaskActivities::TYPE_FINISH, 0, 0);
 
                 // Déclencher un événement pour notifier le changement de statut
                 Event::dispatch(new TaskChangeStatu($task->id));
@@ -54,16 +55,30 @@ class TaskService
      * @param int $addBadQt The quantity of bad items.
      * @return void
      */
-    public function recordTaskActivity($taskId, $type, $goodQty, $addBadQt)
+    public function recordTaskActivity($taskId, $type, $goodQty = 0, $addBadQt = 0, string $comment = '')
     {
+        $userId = Auth::id();
+
+        if (!$userId) {
+            $userId = Task::find($taskId)?->user_id;
+        }
+
+        if (!$userId) {
+            $userId = User::query()->value('id');
+        }
+
+        if (!$userId) {
+            return;
+        }
+
         $taskActivity = TaskActivities::create([
             'task_id' => $taskId,
-            'user_id'=> Auth::user()->id,
+            'user_id'=> $userId,
             'type' => $type,
             'timestamp' => Carbon::now(),
             'good_qt'=> $goodQty,
             'bad_qt'=> $addBadQt,
-            'comment' => '',
+            'comment' => $comment,
         ]);
 
         broadcast(new TaskActivityTriggered($taskActivity));

--- a/database/factories/Planning/TaskFactory.php
+++ b/database/factories/Planning/TaskFactory.php
@@ -6,6 +6,7 @@ use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\QuoteLines;
 use App\Models\Methods\MethodsUnits;
 use App\Models\Methods\MethodsServices;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -44,6 +45,11 @@ class TaskFactory extends Factory
         
         $this->qty = $this->faker->biasedNumberBetween($min = 1, $max = 2990);
 
+        $primaryUser = User::inRandomOrder()->first();
+        $secondaryUser = User::inRandomOrder()
+            ->when($primaryUser, fn ($query) => $query->where('id', '!=', $primaryUser->id))
+            ->first();
+
         return [
             'label' => $methodsService->label,
             'ordre' => $ordre,
@@ -60,6 +66,14 @@ class TaskFactory extends Factory
             'unit_cost' => $this->faker->randomFloat(2, 1, 5),
             'unit_price' => $this->faker->randomFloat(2, 1, 10),
             'methods_units_id' => $methodsUnit->id,
+            'priority' => $this->faker->randomElement([
+                Task::PRIORITY_HIGH,
+                Task::PRIORITY_MEDIUM,
+                Task::PRIORITY_LOW,
+            ]),
+            'due_date' => $this->faker->optional(0.7)->dateTimeBetween('now', '+2 months'),
+            'user_id' => $primaryUser?->id,
+            'secondary_user_id' => $secondaryUser?->id,
         ];
     }
 

--- a/database/migrations/2025_07_01_000000_add_gtd_fields_to_tasks_table.php
+++ b/database/migrations/2025_07_01_000000_add_gtd_fields_to_tasks_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            if (!Schema::hasColumn('tasks', 'priority')) {
+                $table->unsignedTinyInteger('priority')->default(2)->comment('1: High, 2: Medium, 3: Low');
+            }
+
+            if (!Schema::hasColumn('tasks', 'due_date')) {
+                $table->date('due_date')->nullable();
+            }
+
+            if (!Schema::hasColumn('tasks', 'secondary_user_id')) {
+                $table->foreignId('secondary_user_id')->nullable()->constrained('users')->nullOnDelete();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            if (Schema::hasColumn('tasks', 'secondary_user_id')) {
+                $table->dropForeign(['secondary_user_id']);
+                $table->dropColumn('secondary_user_id');
+            }
+
+            if (Schema::hasColumn('tasks', 'due_date')) {
+                $table->dropColumn('due_date');
+            }
+
+            if (Schema::hasColumn('tasks', 'priority')) {
+                $table->dropColumn('priority');
+            }
+        });
+    }
+};

--- a/resources/views/livewire/gtd-board.blade.php
+++ b/resources/views/livewire/gtd-board.blade.php
@@ -1,0 +1,115 @@
+<div>
+    @include('include.alert-result')
+    @php
+        $priorityStyles = [
+            \App\Models\Planning\Task::PRIORITY_HIGH => 'danger',
+            \App\Models\Planning\Task::PRIORITY_MEDIUM => 'warning',
+            \App\Models\Planning\Task::PRIORITY_LOW => 'success',
+        ];
+    @endphp
+    <div class="row">
+        @foreach ($columns as $columnKey => $columnData)
+            <div class="col-xl-4 col-lg-6 mb-4 d-flex" wire:key="gtd-column-{{ $columnKey }}">
+                <div class="card w-100 shadow-sm">
+                    <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                        <span>{{ $columnData['title'] }}</span>
+                        <span class="badge badge-light">{{ $columnData['tasks']->count() }}</span>
+                    </div>
+                    <div class="card-body">
+                        @forelse ($columnData['tasks'] as $task)
+                            <div class="card border mb-3 shadow-sm" wire:key="gtd-task-{{ $task->id }}">
+                                <div class="card-body p-3">
+                                    <div class="d-flex justify-content-between align-items-start mb-2">
+                                        <div>
+                                            <h5 class="card-title mb-1">#{{ $task->id }} - {{ $task->label }}</h5>
+                                            <span class="badge badge-pill badge-{{ $priorityStyles[$task->priority] ?? 'secondary' }}">
+                                                {{ __('Priority') }} : {{ $task->priority_label }}
+                                            </span>
+                                        </div>
+                                        <div class="text-right">
+                                            @if($task->due_date)
+                                                <span class="badge badge-info">{{ $task->due_date->format('d/m/Y') }}</span>
+                                                @if($task->due_date->isPast())
+                                                    <div><span class="badge badge-danger">{{ __('Overdue') }}</span></div>
+                                                @elseif($task->due_date->isToday())
+                                                    <div><span class="badge badge-warning">{{ __('Due today') }}</span></div>
+                                                @endif
+                                            @else
+                                                <small class="text-muted">{{ __('No due date') }}</small>
+                                            @endif
+                                        </div>
+                                    </div>
+                                    <p class="text-muted mb-2">
+                                        {{ __('Status') }} : {{ $task->status->title ?? __('No status') }}
+                                    </p>
+                                    <div class="form-group mb-2">
+                                        <label class="mb-1">{{ __('Primary assignee') }}</label>
+                                        <select class="form-control form-control-sm" wire:model="primaryAssignments.{{ $task->id }}" wire:change="saveAssignment({{ $task->id }})">
+                                            <option value="">{{ __('Unassigned') }}</option>
+                                            @foreach ($users as $user)
+                                                <option value="{{ $user->id }}">{{ $user->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div class="form-group mb-2">
+                                        <label class="mb-1">{{ __('Secondary assignee') }}</label>
+                                        <select class="form-control form-control-sm" wire:model="secondaryAssignments.{{ $task->id }}" wire:change="saveAssignment({{ $task->id }})">
+                                            <option value="">{{ __('Unassigned') }}</option>
+                                            @foreach ($users as $user)
+                                                <option value="{{ $user->id }}">{{ $user->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div class="form-group mb-2">
+                                        <label class="mb-1">{{ __('Priority level') }}</label>
+                                        <select class="form-control form-control-sm" wire:model="priorityLevels.{{ $task->id }}" wire:change="updatePriority({{ $task->id }})">
+                                            @foreach (\App\Models\Planning\Task::priorityLabels() as $priorityKey => $priorityLabel)
+                                                <option value="{{ $priorityKey }}">{{ $priorityLabel }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div class="mb-2">
+                                        <label class="mb-1 d-block">{{ __('Recent comments') }}</label>
+                                        @if($task->taskActivities->isNotEmpty())
+                                            <ul class="list-unstyled small mb-2">
+                                                @foreach ($task->taskActivities as $activity)
+                                                    <li class="mb-1">
+                                                        <strong>{{ $activity->user->name ?? __('System') }}</strong>
+                                                        <span class="text-muted">{{ $activity->created_at->format('d/m/Y H:i') }}</span>
+                                                        <div>{{ $activity->comment }}</div>
+                                                    </li>
+                                                @endforeach
+                                            </ul>
+                                        @else
+                                            <p class="text-muted small mb-2">{{ __('No comments yet.') }}</p>
+                                        @endif
+                                        <div class="form-group mb-0">
+                                            <label class="mb-1">{{ __('Add a comment') }}</label>
+                                            <textarea class="form-control form-control-sm" rows="2" wire:model.defer="commentBodies.{{ $task->id }}"></textarea>
+                                            <div class="d-flex justify-content-between align-items-center mt-2">
+                                                <button type="button" class="btn btn-sm btn-outline-primary" wire:click="addComment({{ $task->id }})">
+                                                    {{ __('Add comment') }}
+                                                </button>
+                                                <div class="btn-group btn-group-sm" role="group">
+                                                    @foreach ($columns as $targetKey => $targetColumn)
+                                                        @if($targetColumn['default_status'] && $targetKey !== $columnKey)
+                                                            <button type="button" class="btn btn-outline-secondary" wire:click="moveTask({{ $task->id }}, {{ $targetColumn['default_status'] }})">
+                                                                {{ $targetColumn['title'] }}
+                                                            </button>
+                                                        @endif
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @empty
+                            <p class="text-muted mb-0">{{ __('No tasks in this column.') }}</p>
+                        @endforelse
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+</div>

--- a/resources/views/workflow/task-gtd.blade.php
+++ b/resources/views/workflow/task-gtd.blade.php
@@ -1,0 +1,19 @@
+@extends('adminlte::page')
+
+@section('title', __('GTD Board'))
+
+@section('content_header')
+    <h1>{{ __('GTD Board') }}</h1>
+@stop
+
+@section('content')
+    @livewire('gtd-board')
+@stop
+
+@section('css')
+<style>
+    .card .card {
+        border-color: #dee2e6;
+    }
+</style>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -361,6 +361,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/Task/Statu/Id/{id}', 'App\Http\Controllers\Planning\TaskController@statu')->name('production.task.statu.id');
         Route::get('/Task/Statu', 'App\Http\Controllers\Planning\TaskController@statu')->name('production.task.statu');
         Route::get('/Task', 'App\Http\Controllers\Planning\TaskController@index')->name('production.task');
+        Route::get('/Task/gtd', 'App\Http\Controllers\Planning\TaskController@gtd')->name('production.task.gtd');
         Route::get('/kanban', 'App\Http\Controllers\Planning\TaskController@kanban')->name('production.kanban');
         Route::get('/calendar/orders', 'App\Http\Controllers\Planning\CalendarController@calendarOders')->name('production.calendar.orders');
         Route::get('/calendar/tasks', 'App\Http\Controllers\Planning\CalendarController@calendarTasks')->name('production.calendar.tasks');


### PR DESCRIPTION
## Summary
- add priority, due date and secondary assignee fields to tasks with supporting factory updates
- introduce a Livewire-based GTD board page with assignment management and comment handling
- schedule automated reminder jobs and notifications for overdue or upcoming GTD tasks

## Testing
- `php artisan test` *(fails: vendor directory missing)*
- `composer install --ignore-platform-req=ext-ldap` *(fails: requires GitHub credentials to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d11d8d3c9c832d98d5d4785b9ad824