### PR TITLE
Fix delivery line options label loading

### DIFF
--- a/app/Livewire/ReturnsIndex.php
+++ b/app/Livewire/ReturnsIndex.php
@@ -127,9 +127,19 @@ class ReturnsIndex extends Component
 
     public function updatedDeliverysId($value): void
     {
-        $this->deliveryLinesOptions = DeliveryLines::where('deliverys_id', $value)
+        $this->deliveryLinesOptions = DeliveryLines::with('OrderLine')
+            ->where('deliverys_id', $value)
             ->orderBy('ordre')
-            ->get(['id', 'label', 'ordre'])
+            ->get(['id', 'ordre', 'order_line_id'])
+            ->map(function ($line) {
+                $orderLine = $line->OrderLine;
+
+                return [
+                    'id' => $line->id,
+                    'ordre' => $line->ordre,
+                    'label' => $orderLine?->label ?? '',
+                ];
+            })
             ->toArray();
     }
 


### PR DESCRIPTION
## Summary
- eager-load delivery lines with their order line to use the correct label data
- map delivery line options to include the related order line label with a fallback for empty labels

## Testing
- php artisan test --testsuite=Feature --filter=Return *(fails: missing vendor/autoload.php because Composer dependencies are not installed in the environment)*
- composer install *(fails: missing ext-ldap in the execution environment)*
- composer install --ignore-platform-req=ext-ldap *(fails: GitHub API rate limits require authentication to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b36f8d30832da017dc546351f36c