### PR TITLE
Return descriptive labels in sales order export

### DIFF
--- a/app/Http/Controllers/Api/ExportSalesOrderController.php
+++ b/app/Http/Controllers/Api/ExportSalesOrderController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ExportSalesOrderRequest;
+use App\Services\Exports\SalesOrderExportService;
+use Illuminate\Http\JsonResponse;
+
+class ExportSalesOrderController extends Controller
+{
+    public function __invoke(ExportSalesOrderRequest $request, SalesOrderExportService $service): JsonResponse
+    {
+        $data = $service->get($request->options());
+
+        return response()->json([
+            'data' => $data,
+            'meta' => [
+                'count' => count($data),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/ExportSalesOrderRequest.php
+++ b/app/Http/Requests/ExportSalesOrderRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExportSalesOrderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+            'status' => ['nullable', 'integer'],
+            'date_format' => ['nullable', 'string', 'max:30'],
+            'datetime_format' => ['nullable', 'string', 'max:30'],
+            'include_lines' => ['nullable', 'boolean'],
+        ];
+    }
+
+    public function options(): array
+    {
+        $validated = $this->validated();
+
+        return [
+            'from' => $validated['from'] ?? null,
+            'to' => $validated['to'] ?? null,
+            'status' => $validated['status'] ?? null,
+            'date_format' => $validated['date_format'] ?? 'Y-m-d',
+            'datetime_format' => $validated['datetime_format'] ?? 'Y-m-d H:i:s',
+            'include_lines' => $this->boolean('include_lines'),
+        ];
+    }
+}

--- a/app/Services/Exports/SalesOrderExportService.php
+++ b/app/Services/Exports/SalesOrderExportService.php
@@ -1,0 +1,464 @@
+<?php
+
+namespace App\Services\Exports;
+
+use App\Models\Accounting\AccountingDelivery;
+use App\Models\Accounting\AccountingPaymentConditions;
+use App\Models\Accounting\AccountingPaymentMethod;
+use App\Models\Accounting\AccountingVat;
+use App\Models\Companies\Companies;
+use App\Models\Companies\CompaniesAddresses;
+use App\Models\Companies\CompaniesContacts;
+use App\Models\Methods\MethodsServices;
+use App\Models\Methods\MethodsTools;
+use App\Models\Methods\MethodsUnits;
+use App\Models\Planning\Status;
+use App\Models\Planning\Task;
+use App\Models\Products\Products;
+use App\Models\User;
+use App\Models\Workflow\OrderLines;
+use App\Models\Workflow\Orders;
+use App\Models\Workflow\Quotes;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+
+class SalesOrderExportService
+{
+    public function get(array $options): array
+    {
+        $includeLines = (bool) ($options['include_lines'] ?? false);
+        $dateFormat = $options['date_format'] ?? 'Y-m-d';
+        $dateTimeFormat = $options['datetime_format'] ?? 'Y-m-d H:i:s';
+
+        $query = Orders::query()->with([
+            'companie',
+            'contact',
+            'adresse',
+            'UserManagement',
+            'payment_condition',
+            'payment_method',
+            'delevery_method',
+            'Quote',
+        ]);
+
+        if ($includeLines) {
+            $query->with([
+                'OrderLines' => function ($lineQuery) {
+                    $lineQuery
+                        ->orderBy('ordre')
+                        ->with([
+                            'Product',
+                            'Unit',
+                            'VAT',
+                            'Task' => function ($taskQuery) {
+                                $taskQuery
+                                    ->orderBy('ordre')
+                                    ->with([
+                                        'service',
+                                        'Unit',
+                                        'MethodsTools',
+                                        'Products',
+                                        'Component',
+                                        'status',
+                                    ]);
+                            },
+                        ]);
+                },
+            ]);
+        }
+
+        if (!empty($options['status'])) {
+            $query->where('statu', (int) $options['status']);
+        }
+
+        if (!empty($options['from'])) {
+            $query->whereDate('created_at', '>=', $options['from']);
+        }
+
+        if (!empty($options['to'])) {
+            $query->whereDate('created_at', '<=', $options['to']);
+        }
+
+        return $query
+            ->orderBy('id')
+            ->get()
+            ->map(function (Orders $order) use ($includeLines, $dateFormat, $dateTimeFormat) {
+                return $this->mapOrder($order, $dateFormat, $dateTimeFormat, $includeLines);
+            })
+            ->all();
+    }
+
+    private function mapOrder(Orders $order, string $dateFormat, string $dateTimeFormat, bool $includeLines): array
+    {
+        $payload = [
+            'id' => $order->id,
+            'uuid' => $order->uuid,
+            'code' => $order->code,
+            'label' => $order->label,
+            'customer_reference' => $order->customer_reference,
+            'company' => $this->mapCompany($order->companie),
+            'company_contact' => $this->mapCompanyContact($order->contact),
+            'company_address' => $this->mapCompanyAddress($order->adresse),
+            'validity_date' => $this->formatDate($order->validity_date, $dateFormat),
+            'statu' => $this->castInt($order->statu),
+            'user' => $this->mapUser($order->UserManagement),
+            'payment_condition' => $this->mapPaymentCondition($order->payment_condition),
+            'payment_method' => $this->mapPaymentMethod($order->payment_method),
+            'delivery_method' => $this->mapDeliveryMethod($order->delevery_method),
+            'quote' => $this->mapQuote($order->Quote),
+            'comment' => $order->comment,
+            'type' => $this->castInt($order->type),
+            'csv_file_name' => $order->csv_file_name,
+            'created_at' => $this->formatDateTime($order->created_at, $dateTimeFormat),
+            'updated_at' => $this->formatDateTime($order->updated_at, $dateTimeFormat),
+        ];
+
+        if ($includeLines) {
+            $payload['order_lines'] = $this->mapOrderLines($order, $dateFormat, $dateTimeFormat);
+        }
+
+        return $payload;
+    }
+
+    private function mapOrderLines(Orders $order, string $dateFormat, string $dateTimeFormat): array
+    {
+        return ($order->OrderLines ?? collect())
+            ->map(function (OrderLines $line) use ($dateFormat, $dateTimeFormat) {
+                return $this->mapOrderLine($line, $dateFormat, $dateTimeFormat);
+            })
+            ->values()
+            ->all();
+    }
+
+    private function mapOrderLine(OrderLines $line, string $dateFormat, string $dateTimeFormat): array
+    {
+        return [
+            'id' => $line->id,
+            'orders_id' => $this->castInt($line->orders_id),
+            'ordre' => $this->castInt($line->ordre),
+            'code' => $line->code,
+            'product_id' => $line->product_id,
+            'product' => $this->mapProduct($line->Product),
+            'label' => $line->label,
+            'qty' => $this->castFloat($line->qty, 3),
+            'delivered_qty' => $this->castFloat($line->delivered_qty, 3),
+            'delivered_remaining_qty' => $this->castFloat($line->delivered_remaining_qty, 3),
+            'invoiced_qty' => $this->castFloat($line->invoiced_qty, 3),
+            'invoiced_remaining_qty' => $this->castFloat($line->invoiced_remaining_qty, 3),
+            'unit' => $this->mapUnit($line->Unit),
+            'selling_price' => $this->castFloat($line->selling_price, 3),
+            'discount' => $this->castFloat($line->discount, 3),
+            'vat' => $this->mapVat($line->VAT),
+            'delivery_date' => $this->formatDate($line->delivery_date, $dateFormat),
+            'tasks_status' => $this->castInt($line->tasks_status),
+            'internal_delay' => $this->formatDate($line->internal_delay, $dateFormat),
+            'delivery_status' => $this->castInt($line->delivery_status),
+            'invoice_status' => $this->castInt($line->invoice_status),
+            'use_calculated_price' => $this->castInt($line->use_calculated_price),
+            'created_at' => $this->formatDateTime($line->created_at, $dateTimeFormat),
+            'updated_at' => $this->formatDateTime($line->updated_at, $dateTimeFormat),
+            'tasks' => $this->mapTasks($line, $dateFormat, $dateTimeFormat),
+        ];
+    }
+
+    private function mapTasks(OrderLines $line, string $dateFormat, string $dateTimeFormat): array
+    {
+        return ($line->Task ?? collect())
+            ->map(function (Task $task) use ($dateFormat, $dateTimeFormat) {
+                return [
+                    'id' => $task->id,
+                    'code' => $task->code,
+                    'label' => $task->label,
+                    'ordre' => $this->castInt($task->ordre),
+                    'quote_lines_id' => $this->castInt($task->quote_lines_id),
+                    'order_lines_id' => $this->castInt($task->order_lines_id),
+                    'products_id' => $this->castInt($task->products_id),
+                    'product' => $this->mapProduct($task->Products),
+                    'sub_assembly_id' => $this->castInt($task->sub_assembly_id),
+                    'service' => $this->mapService($task->service),
+                    'component_id' => $this->castInt($task->component_id),
+                    'component' => $this->mapProduct($task->Component),
+                    'seting_time' => $this->castFloat($task->seting_time, 3),
+                    'unit_time' => $this->castFloat($task->unit_time, 3),
+                    'remaining_time' => $this->castFloat($task->remaining_time, 3),
+                    'status_id' => $this->castInt($task->status_id),
+                    'status' => $this->mapStatus($task->status),
+                    'type' => $this->castInt($task->type),
+                    'delay' => $this->formatDate($task->delay, $dateFormat),
+                    'qty' => $this->castFloat($task->qty, 3),
+                    'qty_init' => $this->castFloat($task->qty_init, 3),
+                    'qty_aviable' => $this->castFloat($task->qty_aviable, 3),
+                    'unit_cost' => $this->castFloat($task->unit_cost, 3),
+                    'unit_price' => $this->castFloat($task->unit_price, 3),
+                    'unit' => $this->mapUnit($task->Unit),
+                    'x_size' => $this->castFloat($task->x_size, 3),
+                    'y_size' => $this->castFloat($task->y_size, 3),
+                    'z_size' => $this->castFloat($task->z_size, 3),
+                    'x_oversize' => $this->castFloat($task->x_oversize, 3),
+                    'y_oversize' => $this->castFloat($task->y_oversize, 3),
+                    'z_oversize' => $this->castFloat($task->z_oversize, 3),
+                    'diameter' => $this->castFloat($task->diameter, 3),
+                    'diameter_oversize' => $this->castFloat($task->diameter_oversize, 3),
+                    'to_schedule' => $this->castInt($task->to_schedule),
+                    'start_date' => $this->formatDateTime($task->start_date, $dateTimeFormat),
+                    'end_date' => $this->formatDateTime($task->end_date, $dateTimeFormat),
+                    'not_recalculate' => $this->castInt($task->not_recalculate),
+                    'material' => $task->material,
+                    'thickness' => $this->castFloat($task->thickness, 3),
+                    'weight' => $this->castFloat($task->weight, 3),
+                    'tool' => $this->mapTool($task->MethodsTools),
+                    'origin' => $task->origin,
+                    'created_at' => $this->formatDateTime($task->created_at, $dateTimeFormat),
+                    'updated_at' => $this->formatDateTime($task->updated_at, $dateTimeFormat),
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    private function formatDate($value, string $format): ?string
+    {
+        return $this->formatTemporal($value, $format);
+    }
+
+    private function formatDateTime($value, string $format): ?string
+    {
+        return $this->formatTemporal($value, $format);
+    }
+
+    private function formatTemporal($value, string $format): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof CarbonInterface) {
+            return $value->format($format);
+        }
+
+        try {
+            return Carbon::parse($value)->format($format);
+        } catch (\Throwable $exception) {
+            return (string) $value;
+        }
+    }
+
+    private function castFloat($value, ?int $precision = null): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $floatValue = (float) $value;
+
+        return $precision !== null ? round($floatValue, $precision) : $floatValue;
+    }
+
+    private function castInt($value): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function mapCompany(?Companies $company): ?array
+    {
+        if (!$company) {
+            return null;
+        }
+
+        return [
+            'id' => $company->id,
+            'code' => $company->code,
+            'label' => $company->label,
+        ];
+    }
+
+    private function mapCompanyContact(?CompaniesContacts $contact): ?array
+    {
+        if (!$contact) {
+            return null;
+        }
+
+        return [
+            'id' => $contact->id,
+            'label' => $this->buildContactLabel($contact),
+            'function' => $contact->function,
+            'phone' => $contact->number,
+            'mobile' => $contact->mobile,
+            'email' => $contact->mail,
+        ];
+    }
+
+    private function mapCompanyAddress(?CompaniesAddresses $address): ?array
+    {
+        if (!$address) {
+            return null;
+        }
+
+        return [
+            'id' => $address->id,
+            'label' => $address->label,
+            'address' => $address->adress,
+            'zipcode' => $address->zipcode,
+            'city' => $address->city,
+            'country' => $address->country,
+        ];
+    }
+
+    private function mapUser(?User $user): ?array
+    {
+        if (!$user) {
+            return null;
+        }
+
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+        ];
+    }
+
+    private function mapPaymentCondition(?AccountingPaymentConditions $condition): ?array
+    {
+        if (!$condition) {
+            return null;
+        }
+
+        return [
+            'id' => $condition->id,
+            'code' => $condition->code,
+            'label' => $condition->label,
+        ];
+    }
+
+    private function mapPaymentMethod(?AccountingPaymentMethod $method): ?array
+    {
+        if (!$method) {
+            return null;
+        }
+
+        return [
+            'id' => $method->id,
+            'code' => $method->code,
+            'label' => $method->label,
+        ];
+    }
+
+    private function mapDeliveryMethod(?AccountingDelivery $delivery): ?array
+    {
+        if (!$delivery) {
+            return null;
+        }
+
+        return [
+            'id' => $delivery->id,
+            'code' => $delivery->code,
+            'label' => $delivery->label,
+        ];
+    }
+
+    private function mapQuote(?Quotes $quote): ?array
+    {
+        if (!$quote) {
+            return null;
+        }
+
+        return [
+            'id' => $quote->id,
+            'code' => $quote->code,
+            'label' => $quote->label,
+        ];
+    }
+
+    private function mapProduct(?Products $product): ?array
+    {
+        if (!$product) {
+            return null;
+        }
+
+        return [
+            'id' => $product->id,
+            'code' => $product->code,
+            'label' => $product->label,
+        ];
+    }
+
+    private function mapUnit(?MethodsUnits $unit): ?array
+    {
+        if (!$unit) {
+            return null;
+        }
+
+        return [
+            'id' => $unit->id,
+            'code' => $unit->code,
+            'label' => $unit->label,
+        ];
+    }
+
+    private function mapVat(?AccountingVat $vat): ?array
+    {
+        if (!$vat) {
+            return null;
+        }
+
+        return [
+            'id' => $vat->id,
+            'code' => $vat->code,
+            'label' => $vat->label,
+            'rate' => $this->castFloat($vat->rate, 3),
+        ];
+    }
+
+    private function mapService(?MethodsServices $service): ?array
+    {
+        if (!$service) {
+            return null;
+        }
+
+        return [
+            'id' => $service->id,
+            'code' => $service->code,
+            'label' => $service->label,
+        ];
+    }
+
+    private function mapTool(?MethodsTools $tool): ?array
+    {
+        if (!$tool) {
+            return null;
+        }
+
+        return [
+            'id' => $tool->id,
+            'code' => $tool->code,
+            'label' => $tool->label,
+        ];
+    }
+
+    private function mapStatus(?Status $status): ?array
+    {
+        if (!$status) {
+            return null;
+        }
+
+        return [
+            'id' => $status->id,
+            'label' => $status->title,
+        ];
+    }
+
+    private function buildContactLabel(CompaniesContacts $contact): string
+    {
+        $parts = array_filter([
+            $contact->civility,
+            $contact->first_name,
+            $contact->name,
+        ]);
+
+        return trim(implode(' ', $parts));
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\QuoteController;
 use App\Http\Controllers\Api\CompanyController;
 use App\Http\Controllers\Api\EnergyConsumptionController;
+use App\Http\Controllers\Api\ExportSalesOrderController;
 
 /*
 |--------------------------------------------------------------------------
@@ -35,3 +36,4 @@ Route::apiResource('quote',QuoteController::class);
 Route::apiResource('order',OrderController::class);
 Route::apiResource('tasks', TaskController::class);
 Route::apiResource('energy-consumptions', EnergyConsumptionController::class)->only(['index','store']);
+Route::get('/exports/sales-orders', ExportSalesOrderController::class);

--- a/tests/Feature/ExportSalesOrderTest.php
+++ b/tests/Feature/ExportSalesOrderTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Accounting\AccountingDelivery;
+use App\Models\Accounting\AccountingPaymentConditions;
+use App\Models\Accounting\AccountingPaymentMethod;
+use App\Models\Accounting\AccountingVat;
+use App\Models\Companies\Companies;
+use App\Models\Companies\CompaniesAddresses;
+use App\Models\Companies\CompaniesContacts;
+use App\Models\Methods\MethodsUnits;
+use App\Models\User;
+use App\Models\Methods\MethodsServices;
+use App\Models\Planning\Task;
+use App\Models\Workflow\OrderLines;
+use App\Models\Workflow\Orders;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ExportSalesOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private MethodsUnits $unit;
+    private AccountingVat $vat;
+    private AccountingPaymentConditions $paymentCondition;
+    private AccountingPaymentMethod $paymentMethod;
+    private AccountingDelivery $delivery;
+    private User $user;
+    private Companies $company;
+    private CompaniesContacts $contact;
+    private CompaniesAddresses $address;
+    private MethodsServices $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->unit = MethodsUnits::create([
+            'code' => 'UNIT',
+            'label' => 'Unit',
+            'type' => 5,
+            'default' => 0,
+        ]);
+        $this->vat = AccountingVat::factory()->create(['rate' => 20]);
+        $this->paymentCondition = AccountingPaymentConditions::factory()->create();
+        $this->paymentMethod = AccountingPaymentMethod::factory()->create();
+        $this->delivery = AccountingDelivery::factory()->create();
+        $this->company = Companies::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+        $this->contact = CompaniesContacts::factory()->create([
+            'companies_id' => $this->company->id,
+        ]);
+        $this->address = CompaniesAddresses::factory()->create([
+            'companies_id' => $this->company->id,
+        ]);
+
+        $this->service = MethodsServices::create([
+            'code' => 'SRV-001',
+            'ordre' => 1,
+            'label' => 'Usinage',
+            'type' => 1,
+            'hourly_rate' => 60,
+            'margin' => 10,
+            'color' => '#FFFFFF',
+            'companies_id' => $this->company->id,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_can_retrieve_sales_orders_as_json(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 10, 8, 0, 0));
+
+        $this->createOrderWithLines([
+            'code' => 'SO-0001',
+            'label' => 'Order 1',
+            'customer_reference' => 'REF-001',
+            'validity_date' => Carbon::create(2024, 1, 15),
+        ]);
+
+        $response = $this->getJson('/api/exports/sales-orders');
+
+        $response->assertOk();
+        $response->assertJson(['meta' => ['count' => 1]]);
+        $response->assertJsonCount(1, 'data');
+
+        $order = $response->json('data.0');
+
+        $this->assertSame('SO-0001', $order['code']);
+        $this->assertSame('Order 1', $order['label']);
+        $this->assertSame('REF-001', $order['customer_reference']);
+        $this->assertSame(1, $order['statu']);
+        $this->assertSame($this->company->label, $order['company']['label']);
+        $this->assertSame($this->company->code, $order['company']['code']);
+        $this->assertSame($this->company->id, $order['company']['id']);
+        $expectedContactLabel = trim(implode(' ', array_filter([
+            $this->contact->civility,
+            $this->contact->first_name,
+            $this->contact->name,
+        ])));
+        $this->assertSame($this->contact->id, $order['company_contact']['id']);
+        $this->assertSame($expectedContactLabel, $order['company_contact']['label']);
+        $this->assertSame($this->contact->mail, $order['company_contact']['email']);
+        $this->assertSame($this->address->label, $order['company_address']['label']);
+        $this->assertSame($this->address->city, $order['company_address']['city']);
+        $this->assertSame($this->user->name, $order['user']['name']);
+        $this->assertSame($this->paymentCondition->label, $order['payment_condition']['label']);
+        $this->assertSame($this->paymentCondition->code, $order['payment_condition']['code']);
+        $this->assertSame($this->paymentMethod->label, $order['payment_method']['label']);
+        $this->assertSame($this->delivery->label, $order['delivery_method']['label']);
+        $this->assertSame('2024-01-15', $order['validity_date']);
+        $this->assertSame('2024-01-10 08:00:00', $order['created_at']);
+        $this->assertSame('2024-01-10 08:00:00', $order['updated_at']);
+        $this->assertNull($order['quote']);
+        $this->assertArrayNotHasKey('order_lines', $order);
+    }
+
+    public function test_can_include_order_lines_in_response(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 2, 1, 9, 0, 0));
+
+        $order = $this->createOrderWithLines([
+            'code' => 'SO-0001',
+            'label' => 'Composite Order',
+            'customer_reference' => 'REF-100',
+        ]);
+
+        OrderLines::create([
+            'orders_id' => $order->id,
+            'ordre' => 2,
+            'code' => 'LINE-2',
+            'product_id' => 'SKU-2',
+            'label' => 'Second line',
+            'qty' => 2,
+            'delivered_qty' => 0,
+            'delivered_remaining_qty' => 2,
+            'invoiced_qty' => 0,
+            'invoiced_remaining_qty' => 2,
+            'methods_units_id' => $this->unit->id,
+            'selling_price' => 12,
+            'discount' => 5,
+            'accounting_vats_id' => $this->vat->id,
+            'internal_delay' => Carbon::create(2024, 2, 10),
+            'delivery_date' => Carbon::create(2024, 2, 15),
+            'tasks_status' => 1,
+            'delivery_status' => 1,
+            'invoice_status' => 1,
+        ]);
+
+        $firstLine = $order->OrderLines()->orderBy('ordre')->first();
+
+        Task::create([
+            'code' => 'TASK-1',
+            'label' => 'Operation 1',
+            'ordre' => 10,
+            'order_lines_id' => $firstLine->id,
+            'methods_services_id' => $this->service->id,
+            'seting_time' => 0.5,
+            'unit_time' => 1.5,
+            'status_id' => 1,
+            'type' => 1,
+            'qty' => 1,
+            'qty_init' => 1,
+            'qty_aviable' => 1,
+            'unit_cost' => 5,
+            'unit_price' => 12,
+            'methods_units_id' => $this->unit->id,
+            'to_schedule' => 1,
+            'start_date' => Carbon::create(2024, 2, 5, 8, 0, 0),
+            'end_date' => Carbon::create(2024, 2, 6, 17, 0, 0),
+            'not_recalculate' => 0,
+            'material' => 'Steel',
+            'thickness' => 2.5,
+            'weight' => 1.2,
+        ]);
+
+        $response = $this->getJson('/api/exports/sales-orders?include_lines=1');
+
+        $response->assertOk();
+        $response->assertJson(['meta' => ['count' => 1]]);
+
+        $payload = $response->json('data.0');
+        $this->assertCount(2, $payload['order_lines']);
+
+        $firstLinePayload = $payload['order_lines'][0];
+        $this->assertSame('LINE-1', $firstLinePayload['code']);
+        $this->assertSame(5.0, (float) $firstLinePayload['qty']);
+        $this->assertSame('Unit', $firstLinePayload['unit']['label']);
+        $this->assertSame('UNIT', $firstLinePayload['unit']['code']);
+        $this->assertSame(20.0, (float) $firstLinePayload['vat']['rate']);
+        $this->assertSame('2024-01-25', $firstLinePayload['delivery_date']);
+        $this->assertArrayHasKey('tasks', $firstLinePayload);
+        $this->assertCount(1, $firstLinePayload['tasks']);
+
+        $taskPayload = $firstLinePayload['tasks'][0];
+        $this->assertSame('TASK-1', $taskPayload['code']);
+        $this->assertSame(10, $taskPayload['ordre']);
+        $this->assertSame(1.5, (float) $taskPayload['unit_time']);
+        $this->assertSame('Usinage', $taskPayload['service']['label']);
+        $this->assertSame('SRV-001', $taskPayload['service']['code']);
+        $this->assertSame('Unit', $taskPayload['unit']['label']);
+        $this->assertSame('2024-02-05 08:00:00', $taskPayload['start_date']);
+
+        $secondLinePayload = $payload['order_lines'][1];
+        $this->assertSame('LINE-2', $secondLinePayload['code']);
+        $this->assertSame(2.0, (float) $secondLinePayload['qty']);
+        $this->assertSame(12.0, (float) $secondLinePayload['selling_price']);
+        $this->assertSame(5.0, (float) $secondLinePayload['discount']);
+        $this->assertSame('2024-02-15', $secondLinePayload['delivery_date']);
+        $this->assertEmpty($secondLinePayload['tasks']);
+    }
+
+    public function test_can_filter_sales_orders_by_date_and_status(): void
+    {
+        Carbon::setTestNow(Carbon::create(2023, 12, 1, 9, 0, 0));
+        $this->createOrderWithLines([
+            'code' => 'SO-0001',
+            'label' => 'Historical Order',
+            'customer_reference' => 'REF-HIST',
+            'statu' => 2,
+        ]);
+
+        Carbon::setTestNow(Carbon::create(2024, 1, 10, 10, 0, 0));
+        $this->createOrderWithLines([
+            'code' => 'SO-0002',
+            'label' => 'Active Order',
+            'customer_reference' => 'REF-ACT',
+            'statu' => 1,
+        ]);
+
+        $response = $this->getJson('/api/exports/sales-orders?from=2024-01-01&status=1');
+
+        $response->assertOk();
+        $response->assertJson(['meta' => ['count' => 1]]);
+        $response->assertJsonCount(1, 'data');
+
+        $order = $response->json('data.0');
+        $this->assertSame('SO-0002', $order['code']);
+        $this->assertSame(1, $order['statu']);
+    }
+
+    private function createOrderWithLines(array $orderOverrides = [], array $lineOverrides = []): Orders
+    {
+        $orderDefaults = [
+            'uuid' => (string) Str::uuid(),
+            'code' => 'SO-' . str_pad((string) (Orders::count() + 1), 4, '0', STR_PAD_LEFT),
+            'label' => 'Order ' . (Orders::count() + 1),
+            'customer_reference' => 'REF-' . (Orders::count() + 1),
+            'companies_id' => $this->company->id,
+            'companies_contacts_id' => $this->contact->id,
+            'companies_addresses_id' => $this->address->id,
+            'validity_date' => Carbon::create(2024, 1, 15),
+            'statu' => 1,
+            'user_id' => $this->user->id,
+            'accounting_payment_conditions_id' => $this->paymentCondition->id,
+            'accounting_payment_methods_id' => $this->paymentMethod->id,
+            'accounting_deliveries_id' => $this->delivery->id,
+            'comment' => 'Sample order for export tests',
+            'quotes_id' => null,
+            'type' => 1,
+        ];
+
+        $order = Orders::create(array_merge($orderDefaults, $orderOverrides));
+
+        $lineDefaults = [
+            'orders_id' => $order->id,
+            'ordre' => 1,
+            'code' => 'LINE-1',
+            'product_id' => 'SKU-1',
+            'label' => 'Line 1',
+            'qty' => 5,
+            'delivered_qty' => 0,
+            'delivered_remaining_qty' => 5,
+            'invoiced_qty' => 0,
+            'invoiced_remaining_qty' => 5,
+            'methods_units_id' => $this->unit->id,
+            'selling_price' => 10,
+            'discount' => 0,
+            'accounting_vats_id' => $this->vat->id,
+            'internal_delay' => Carbon::create(2024, 1, 20),
+            'delivery_date' => Carbon::create(2024, 1, 25),
+            'tasks_status' => 1,
+            'delivery_status' => 1,
+            'invoice_status' => 1,
+        ];
+
+        OrderLines::create(array_merge($lineDefaults, $lineOverrides));
+
+        return $order->fresh(['OrderLines', 'companie']);
+    }
+}


### PR DESCRIPTION
## Summary
- include customer, contact, address, payment, and quote label data in the sales order export instead of raw foreign keys
- surface unit, VAT, service, and tool metadata on exported order lines and tasks while eager loading the required relations
- extend the sales order export feature tests to cover the new label-rich payloads for orders, lines, and tasks

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf18fa3cd8832d8995649fd17ad328