### PR TITLE
Update energy consumption to use methods ressources

### DIFF
--- a/app/Http/Controllers/Api/EnergyConsumptionController.php
+++ b/app/Http/Controllers/Api/EnergyConsumptionController.php
@@ -10,20 +10,20 @@ class EnergyConsumptionController extends Controller
 {
     public function index()
     {
-        return response()->json(EnergyConsumption::with('machine')->get());
+        return response()->json(EnergyConsumption::with('methodsRessource')->get());
     }
 
     public function store(Request $request)
     {
         $data = $request->validate([
-            'machine_id' => 'required|exists:machines,id',
+            'methods_ressource_id' => 'required|exists:methods_ressources,id',
             'kwh' => 'required|numeric',
             'cost_per_kwh' => 'required|numeric',
         ]);
 
         $consumption = EnergyConsumption::create($data);
 
-        return response()->json($consumption->load('machine'), 201);
+        return response()->json($consumption->load('methodsRessource'), 201);
     }
 }
 

--- a/app/Http/Controllers/EnergyConsumptionController.php
+++ b/app/Http/Controllers/EnergyConsumptionController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\EnergyConsumption;
-use App\Models\Machine;
+use App\Models\Methods\MethodsRessources;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 
@@ -11,15 +11,16 @@ class EnergyConsumptionController extends Controller
 {
     public function index()
     {
-        $energyConsumptions = EnergyConsumption::all();
-        $machines = Machine::all();
-        return view('energy-consumptions.energy-consumptions-index', compact('energyConsumptions', 'machines'));
+        $energyConsumptions = EnergyConsumption::with('methodsRessource')->get();
+        $methodsRessources = MethodsRessources::orderBy('label')->get();
+
+        return view('energy-consumptions.energy-consumptions-index', compact('energyConsumptions', 'methodsRessources'));
     }
 
     public function store(Request $request)
     {
         $data = $request->validate([
-            'machine_id' => 'required|exists:machines,id',
+            'methods_ressource_id' => 'required|exists:methods_ressources,id',
             'kwh' => 'required|numeric',
             'cost_per_kwh' => 'required|numeric',
         ]);
@@ -32,7 +33,7 @@ class EnergyConsumptionController extends Controller
 
     public function show($id)
     {
-        $energyConsumption = EnergyConsumption::findOrFail($id);
+        $energyConsumption = EnergyConsumption::with('methodsRessource')->findOrFail($id);
         return view('energy-consumptions.energy-consumptions-show', compact('energyConsumption'));
     }
 }

--- a/app/Models/EnergyConsumption.php
+++ b/app/Models/EnergyConsumption.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Models\Methods\MethodsRessources;
-use App\Models\Machine;
 use Illuminate\Database\Eloquent\Model;
 
 class EnergyConsumption extends Model
@@ -12,11 +11,16 @@ class EnergyConsumption extends Model
     use HasFactory;
 
     protected $fillable = [
-        'machine_id',
+        'methods_ressource_id',
         'kwh',
         'cost_per_kwh',
         'total_cost',
     ];
+
+    public function methodsRessource()
+    {
+        return $this->belongsTo(MethodsRessources::class, 'methods_ressource_id');
+    }
 
     protected static function booted()
     {

--- a/database/factories/EnergyConsumptionFactory.php
+++ b/database/factories/EnergyConsumptionFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\EnergyConsumption;
-use App\Models\Machine;
+use App\Models\Methods\MethodsRessources;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class EnergyConsumptionFactory extends Factory
@@ -16,7 +16,7 @@ class EnergyConsumptionFactory extends Factory
         $cost = $this->faker->randomFloat(2, 0.1, 1);
 
         return [
-            'machine_id' => Machine::factory(),
+            'methods_ressource_id' => MethodsRessources::factory(),
             'kwh' => $kwh,
             'cost_per_kwh' => $cost,
             'total_cost' => $kwh * $cost,

--- a/database/factories/MethodsRessourcesFactory.php
+++ b/database/factories/MethodsRessourcesFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Methods\MethodsRessources;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MethodsRessourcesFactory extends Factory
+{
+    protected $model = MethodsRessources::class;
+
+    public function definition(): array
+    {
+        return [
+            'ordre' => $this->faker->numberBetween(1, 100),
+            'code' => strtoupper($this->faker->unique()->lexify('RES???')),
+            'label' => $this->faker->words(3, true),
+            'picture' => null,
+            'mask_time' => $this->faker->numberBetween(0, 100),
+            'capacity' => $this->faker->randomFloat(3, 1, 100),
+            'section_id' => 1,
+            'color' => $this->faker->safeHexColor,
+            'methods_services_id' => 1,
+            'comment' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000001_create_energy_consumptions_table.php
+++ b/database/migrations/2024_01_01_000001_create_energy_consumptions_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('energy_consumptions', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('machine_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('methods_ressource_id')->constrained('methods_ressources')->cascadeOnDelete();
             $table->decimal('kwh', 10, 2);
             $table->decimal('cost_per_kwh', 10, 2);
             $table->decimal('total_cost', 10, 2);

--- a/resources/views/energy-consumptions/energy-consumptions-index.blade.php
+++ b/resources/views/energy-consumptions/energy-consumptions-index.blade.php
@@ -12,9 +12,9 @@
             @csrf
             <div class="row">
                 <div class="col-md-4">
-                    <x-adminlte-select name="machine_id" label="{{ __('general_content.machine_trans_key') }}" required>
-                        @foreach ($machines as $machine)
-                            <option value="{{ $machine->id }}">{{ $machine->id }} - {{ $machine->name }}</option>
+                    <x-adminlte-select name="methods_ressource_id" label="{{ __('general_content.machine_trans_key') }}" required>
+                        @foreach ($methodsRessources as $resource)
+                            <option value="{{ $resource->id }}">{{ $resource->id }} - {{ $resource->label }}</option>
                         @endforeach
                     </x-adminlte-select>
                 </div>
@@ -34,7 +34,7 @@
             @foreach ($energyConsumptions as $energyConsumption)
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <a href="{{ route('energy-consumptions.show', $energyConsumption->id) }}">
-                        {{ $energyConsumption->machine_id }} - {{ $energyConsumption->kwh }} kWh @ {{ $energyConsumption->cost_per_kwh }} = {{ $energyConsumption->total_cost }}
+                        {{ optional($energyConsumption->methodsRessource)->label ?? '-' }} - {{ $energyConsumption->kwh }} kWh @ {{ $energyConsumption->cost_per_kwh }} = {{ $energyConsumption->total_cost }}
                     </a>
                 </li>
             @endforeach

--- a/resources/views/energy-consumptions/energy-consumptions-show.blade.php
+++ b/resources/views/energy-consumptions/energy-consumptions-show.blade.php
@@ -10,7 +10,7 @@
     <x-adminlte-card theme="primary" icon="fas fa-bolt">
         <dl class="row">
             <dt class="col-sm-3">{{ __('general_content.machine_trans_key') }}</dt>
-            <dd class="col-sm-9">{{ $energyConsumption->machine_id }}</dd>
+            <dd class="col-sm-9">{{ optional($energyConsumption->methodsRessource)->label ?? '-' }}</dd>
             <dt class="col-sm-3">{{ __('general_content.kwh_trans_key') }}</dt>
             <dd class="col-sm-9">{{ $energyConsumption->kwh }}</dd>
             <dt class="col-sm-3">{{ __('general_content.cost_per_kwh_trans_key') }}</dt>

--- a/tests/Feature/EnergyConsumptionTest.php
+++ b/tests/Feature/EnergyConsumptionTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\EnergyConsumption;
-use App\Models\Machine;
+use App\Models\Methods\MethodsRessources;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -13,10 +13,10 @@ class EnergyConsumptionTest extends TestCase
 
     public function test_total_cost_is_calculated()
     {
-        $machine = Machine::factory()->create();
+        $resource = MethodsRessources::factory()->create();
 
         $consumption = EnergyConsumption::create([
-            'machine_id' => $machine->id,
+            'methods_ressource_id' => $resource->id,
             'kwh' => 20,
             'cost_per_kwh' => 0.5,
         ]);
@@ -26,10 +26,10 @@ class EnergyConsumptionTest extends TestCase
 
     public function test_can_create_energy_consumption_record()
     {
-        $machine = Machine::factory()->create();
+        $resource = MethodsRessources::factory()->create();
 
         $response = $this->postJson('/api/energy-consumptions', [
-            'machine_id' => $machine->id,
+            'methods_ressource_id' => $resource->id,
             'kwh' => 10,
             'cost_per_kwh' => 0.5,
         ]);
@@ -38,7 +38,7 @@ class EnergyConsumptionTest extends TestCase
                  ->assertJsonFragment(['total_cost' => 5.0]);
 
         $this->assertDatabaseHas('energy_consumptions', [
-            'machine_id' => $machine->id,
+            'methods_ressource_id' => $resource->id,
             'total_cost' => 5.0,
         ]);
     }


### PR DESCRIPTION
## Summary
- replace machine dependencies with methods resources in the energy consumption controllers and validation rules
- update the energy consumption model, migration, views, and factories to store the methods resource label instead of machine data
- add a factory and adjust feature tests to create methods resources for energy consumption scenarios

## Testing
- Tests not run (composer install blocked by GitHub authentication requirement)


------
https://chatgpt.com/codex/tasks/task_e_68d1b7423338832d956f3e887fa1c2ab