### PR TITLE
Add machine relation to energy consumption model

### DIFF
--- a/app/Models/EnergyConsumption.php
+++ b/app/Models/EnergyConsumption.php
@@ -3,9 +3,9 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use App\Models\Methods\MethodsRessources;
 use App\Models\Machine;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class EnergyConsumption extends Model
 {
@@ -25,6 +25,11 @@ class EnergyConsumption extends Model
                 $consumption->total_cost = $consumption->kwh * $consumption->cost_per_kwh;
             }
         });
+    }
+
+    public function machine(): BelongsTo
+    {
+        return $this->belongsTo(Machine::class);
     }
 
     public function getTotalCostAttribute($value)


### PR DESCRIPTION
## Summary
- add the missing belongsTo relation from energy consumptions to machines so the API can eager load machines

## Testing
- php artisan test --filter=EnergyConsumptionTest *(fails: vendor autoload missing because Composer install requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b745b218832db3de81f0915d857d