### PR TITLE
Fix modals closing when adding custom requirement lines

### DIFF
--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -165,7 +165,7 @@
                                             <i class="fas fa-info-circle"></i>
                                         </button>
                                         <!-- Modal {{ $OrderLine->id }} -->
-                                        <x-adminlte-modal id="OrderLine{{ $OrderLine->id }}" title="Update detail information for {{ $OrderLine->label }}" theme="teal" icon="fa fa-pen" size='lg' disable-animations>
+                                        <x-adminlte-modal wire:ignore.self id="OrderLine{{ $OrderLine->id }}" title="Update detail information for {{ $OrderLine->label }}" theme="teal" icon="fa fa-pen" size='lg' disable-animations>
                                             <form method="POST" action="{{ route('orders.update.detail.line', ['idOrder'=>  $OrderLine->orders_id, 'id' => $OrderLine->OrderLineDetails->id]) }}" enctype="multipart/form-data">
                                             @csrf
                                             <div class="card-body">

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -85,7 +85,7 @@
                                             <i class="fas fa-info-circle"></i>
                                         </button>
                                         <!-- Modal {{ $QuoteLine->id }} -->
-                                        <x-adminlte-modal id="QuoteLine{{ $QuoteLine->id }}" title="Update detail information for {{ $QuoteLine->label }}" theme="teal" icon="fa fa-pen" size='lg' disable-animations>
+                                        <x-adminlte-modal wire:ignore.self id="QuoteLine{{ $QuoteLine->id }}" title="Update detail information for {{ $QuoteLine->label }}" theme="teal" icon="fa fa-pen" size='lg' disable-animations>
                                             <form method="POST" action="{{ route('quotes.update.detail.line', ['idQuote'=>  $QuoteLine->quotes_id, 'id' => $QuoteLine->QuoteLineDetails->id]) }}" enctype="multipart/form-data">
                                             @csrf
                                             <div class="card-body">


### PR DESCRIPTION
## Summary
- keep quote line detail modal mounted while Livewire updates by adding `wire:ignore.self`
- do the same for the order line detail modal to avoid unintended closes

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d1b74e0524832d9f3b3e66b4bfa51f