### PR TITLE
Add migration for task user relation

### DIFF
--- a/database/migrations/2025_09_22_210000_add_user_id_to_tasks_table.php
+++ b/database/migrations/2025_09_22_210000_add_user_id_to_tasks_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            if (!Schema::hasColumn('tasks', 'user_id')) {
+                $table->foreignId('user_id')
+                    ->nullable()
+                    ->after('status_id')
+                    ->constrained('users')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('tasks', 'user_id')) {
+            Schema::table('tasks', function (Blueprint $table) {
+                $table->dropForeign(['user_id']);
+                $table->dropColumn('user_id');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a follow-up migration that introduces a nullable `user_id` foreign key on the `tasks` table with `nullOnDelete()` semantics

## Testing
- php artisan migrate *(fails: missing Composer vendor tree in the execution environment, so artisan cannot bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b76ca638832da567777e875b102b