### PR TITLE
Add comment and hashtag support to file uploads

### DIFF
--- a/app/Http/Controllers/FileUpload.php
+++ b/app/Http/Controllers/FileUpload.php
@@ -51,6 +51,8 @@ class FileUpload extends Controller
         $originalFileName = $request->file->getClientOriginalName();
         $type = $request->file->getClientMimeType();
         $size = $request->file->getSize();
+        $comment = $request->input('comment');
+        $hashtags = $this->normalizeHashtags($request->input('hashtags'));
 
         $request->file->move(public_path($directory), $fileName);
 
@@ -61,6 +63,15 @@ class FileUpload extends Controller
             'type' => $type,
             'size' => $size,
         ];
+
+        if ($comment !== null) {
+            $trimmedComment = trim($comment);
+            $fileData['comment'] = $trimmedComment === '' ? null : $trimmedComment;
+        }
+
+        if (!empty($hashtags)) {
+            $fileData['hashtags'] = $hashtags;
+        }
 
         if ($asPhoto) {
             $fileData['as_photo'] = 1;
@@ -92,5 +103,49 @@ class FileUpload extends Controller
         }
 
         return back()->with('success', 'File has been uploaded.')->with('file', $fileName);
+    }
+
+    /**
+     * Normalize a raw hashtags string into an array of unique tags.
+     *
+     * @param string|null $rawHashtags
+     * @return array<int, string>
+     */
+    private function normalizeHashtags(?string $rawHashtags): array
+    {
+        if ($rawHashtags === null) {
+            return [];
+        }
+
+        $parts = preg_split('/[\s,]+/u', $rawHashtags);
+
+        if ($parts === false) {
+            return [];
+        }
+
+        $hashtags = [];
+
+        foreach ($parts as $part) {
+            $tag = trim($part);
+
+            if ($tag === '') {
+                continue;
+            }
+
+            $tag = trim(ltrim($tag, "#＃"));
+
+            if ($tag === '') {
+                continue;
+            }
+
+            $tag = mb_substr($tag, 0, 50);
+            $normalizedKey = mb_strtolower($tag);
+
+            if (!array_key_exists($normalizedKey, $hashtags)) {
+                $hashtags[$normalizedKey] = $tag;
+            }
+        }
+
+        return array_values($hashtags);
     }
 }

--- a/app/Http/Requests/StoreFileRequest.php
+++ b/app/Http/Requests/StoreFileRequest.php
@@ -24,7 +24,9 @@ class StoreFileRequest extends FormRequest
     public function rules()
     {
         return [
-            'file' => 'required|file|mimes:jpg,jpeg,bmp,png,doc,docx,csv,rtf,xlsx,xls,txt,pdf,zip|max:10240'
+            'file' => 'required|file|mimes:jpg,jpeg,bmp,png,doc,docx,csv,rtf,xlsx,xls,txt,pdf,zip|max:10240',
+            'comment' => 'nullable|string|max:65535',
+            'hashtags' => 'nullable|string|max:1024',
         ];
     }
 }

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -22,13 +22,24 @@ class File extends Model
     use HasFactory;
 
     // Fillable attributes for mass assignment
-    protected $fillable= [
+    protected $fillable = [
         'user_id',
         'name',
         'original_file_name',
         'type',
         'size',
+        'comment',
+        'hashtags',
         'as_photo',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'hashtags' => 'array',
     ];
 
     /**

--- a/database/migrations/2025_09_22_220100_add_comment_to_files_table.php
+++ b/database/migrations/2025_09_22_220100_add_comment_to_files_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->text('comment')->nullable()->after('size');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropColumn('comment');
+        });
+    }
+};

--- a/database/migrations/2025_09_22_220200_add_hashtags_to_files_table.php
+++ b/database/migrations/2025_09_22_220200_add_hashtags_to_files_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->json('hashtags')->nullable()->after('comment');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropColumn('hashtags');
+        });
+    }
+};

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -446,6 +446,7 @@ return [
     'email_trans_key'               => 'البريد الإلكتروني',
     'date_trans_key'                => 'التاريخ',
     'comment_trans_key'             => 'التعليق',
+    'hashtags_trans_key'            => 'الوسوم',
     'internal_comment_trans_key'    => 'التعليق الداخلي',
     'external_comment_trans_key'    => 'التعليق الخارجي',
     'identifier_trans_key'          => 'المعرف',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -490,6 +490,7 @@ return [
     'message_trans_key'                        => 'Message',
     'object_trans_key'                         => 'Object',
     'comment_trans_key'                        => 'Comment',
+    'hashtags_trans_key'                       => 'Hashtags',
     'internal_comment_trans_key'               => 'Internal comment',
     'external_comment_trans_key'               => 'External comment',
     'identifier_trans_key'                     => 'Identifier',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -445,6 +445,7 @@ return [
     'email_trans_key'                          => 'Correo electrónico',
     'date_trans_key'                           => 'Fecha',
     'comment_trans_key'                        => 'Comentario',
+    'hashtags_trans_key'                       => 'Hashtags',
 
         'internal_comment_trans_key'               => 'Comentario interno',
         'external_comment_trans_key'               => 'Comentario externo',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -490,6 +490,7 @@ return [
     'message_trans_key'                        => 'Message',
     'object_trans_key'                         => 'Objet',
     'comment_trans_key'                        => 'Commentaire',
+    'hashtags_trans_key'                       => 'Hashtags',
     'internal_comment_trans_key'               => 'Commentaire interne',
     'external_comment_trans_key'               => 'Commentaire externe',
     'identifier_trans_key'                     => 'Référence',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -128,6 +128,7 @@ return [
     'total_cost_trans_key'                     => 'Tổng chi phí',
 
     'search_results_trans_key'                 => 'Kết quả tìm kiếm',
+    'hashtags_trans_key'                       => 'Hashtags',
     'customer_processing_cost_trans_key'       => 'Chi phí xử lý khách hàng',
     'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',
     'order_site_trans_key'                     => 'Công trường',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -485,6 +485,7 @@ return [
     'message_trans_key'                        => '消息',
     'object_trans_key'                         => '主题',
     'comment_trans_key'                        => '评论',
+    'hashtags_trans_key'                       => '话题标签',
     'internal_comment_trans_key'               => '内部备注',
     'external_comment_trans_key'               => '外部备注',
     'identifier_trans_key'                     => '参考号',

--- a/resources/views/include/file-store.blade.php
+++ b/resources/views/include/file-store.blade.php
@@ -15,6 +15,16 @@
                 <button type="submit" name="submit" class="btn btn-success">{{ __('general_content.upload_trans_key') }}</button>
             </div>
         </div>
+
+        <div class="form-group mt-3">
+            <label for="file-comment-{{ $inputName }}-{{ $inputValue }}">{{ __('general_content.comment_trans_key') }}</label>
+            <textarea name="comment" id="file-comment-{{ $inputName }}-{{ $inputValue }}" class="form-control" rows="2" placeholder="{{ __('general_content.comment_trans_key') }}">{{ old('comment') }}</textarea>
+        </div>
+
+        <div class="form-group">
+            <label for="file-hashtags-{{ $inputName }}-{{ $inputValue }}">{{ __('general_content.hashtags_trans_key') }}</label>
+            <input type="text" name="hashtags" id="file-hashtags-{{ $inputName }}-{{ $inputValue }}" class="form-control" value="{{ old('hashtags') }}" placeholder="#tag1 #tag2" />
+        </div>
     </form>
 
     <h5 class="mt-5 text-muted">{{ __('general_content.attached_file_trans_key') }} </h5>
@@ -22,6 +32,17 @@
         @forelse ( $filesList as $file)
         <li>
             <a href="{{ asset('/file/'. $file->name) }}" download="{{ $file->original_file_name }}" class="btn-link text-secondary">{{ $file->original_file_name }} -  <small>{{ $file->getFormattedSizeAttribute() }}</small></a>
+            @if(!empty($file->comment))
+                <div class="text-muted small">{!! nl2br(e($file->comment)) !!}</div>
+            @endif
+            @php($hashtags = $file->hashtags ?? [])
+            @if(!empty($hashtags))
+                <div class="mt-1">
+                    @foreach($hashtags as $hashtag)
+                        <span class="badge badge-info">#{{ $hashtag }}</span>
+                    @endforeach
+                </div>
+            @endif
         </li>
         @empty
             {{ __('general_content.no_data_trans_key') }}


### PR DESCRIPTION
## Summary
- add a migration that introduces an optional `comment` column on the `files` table
- allow storing the comment via the `File` model, validation rules, and the upload controller
- expose a comment field in the shared file upload form and render saved comments beside each attachment
- add hashtag capture and normalization during upload so tags can be stored and displayed with files across the app

## Testing
- php artisan migrate --pretend *(fails: the Laravel autoloader is missing because Composer dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c513aa68832d897f4fb13b603aa8