### PR TITLE
feat(workflow): add review metadata for quotes and orders

### DIFF
--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -13,6 +13,7 @@ use App\Services\OrderCalculatorService;
 use App\Services\OrderInvoiceDataService;
 use App\Services\OrderBusinessBalanceService;
 use App\Http\Requests\Workflow\UpdateOrderRequest;
+use Spatie\Activitylog\Models\Activity;
 
 class OrdersController extends Controller
 {
@@ -95,6 +96,7 @@ class OrdersController extends Controller
         $AccountingConditionSelect = $this->SelectDataService->getAccountingPaymentConditions();
         $AccountingMethodsSelect = $this->SelectDataService->getAccountingPaymentMethod();
         $AccountingDeleveriesSelect = $this->SelectDataService->getAccountingDelivery();
+        $Reviewers = $this->SelectDataService->getUsers();
 
         // Initialize OrderCalculatorService with the order ID
         $OrderCalculatorService = new OrderCalculatorService($id);
@@ -145,6 +147,34 @@ class OrdersController extends Controller
         $currentMarginPercentageFormatted = number_format($currentMarginPercentage, 2, '.', ',') . ' %';
 
         $leadTime = $this->orderKPIService->getLeadTime($id);
+        $reviewFields = ['reviewed_by', 'reviewed_at', 'review_decision', 'change_requested_by', 'change_reason', 'change_approved_at'];
+        $ReviewTimeline = Activity::query()
+            ->where('subject_type', Orders::class)
+            ->where('subject_id', $id->id)
+            ->with('causer')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function (Activity $activity) use ($reviewFields) {
+                $properties = $activity->properties?->toArray() ?? [];
+                $attributes = array_intersect_key(data_get($properties, 'attributes', []), array_flip($reviewFields));
+                $old = array_intersect_key(data_get($properties, 'old', []), array_flip($reviewFields));
+
+                return [
+                    'id' => $activity->id,
+                    'description' => $activity->description,
+                    'causer' => $activity->causer?->name,
+                    'created_at' => $activity->created_at,
+                    'changes' => collect($attributes)->map(function ($newValue, $field) use ($old) {
+                        return [
+                            'field' => $field,
+                            'old' => $old[$field] ?? null,
+                            'new' => $newValue,
+                        ];
+                    })->values()->all(),
+                ];
+            })
+            ->filter(fn ($entry) => !empty($entry['changes']))
+            ->values();
 
         return view('workflow/orders-show', data: [
             'Order' => $id,
@@ -154,6 +184,8 @@ class OrdersController extends Controller
             'AccountingConditionSelect' => $AccountingConditionSelect,
             'AccountingMethodsSelect' => $AccountingMethodsSelect,
             'AccountingDeleveriesSelect' => $AccountingDeleveriesSelect,
+            'Reviewers' => $Reviewers,
+            'ReviewTimeline' => $ReviewTimeline,
             'totalPrices' => $totalPrice,
             'subPrice' => $subPrice, 
             'vatPrice' => $vatPrice,

--- a/app/Http/Controllers/Workflow/QuotesController.php
+++ b/app/Http/Controllers/Workflow/QuotesController.php
@@ -15,6 +15,7 @@ use App\Services\QuoteCalculatorService;
 use App\Models\Workflow\QuoteProjectEstimate;
 use App\Http\Requests\Workflow\UpdateQuoteRequest;
 use App\Http\Requests\Workflow\ProjectEstimateRequest;
+use Spatie\Activitylog\Models\Activity;
 
 class QuotesController extends Controller
 {
@@ -74,6 +75,7 @@ class QuotesController extends Controller
         $AccountingConditionSelect = $this->SelectDataService->getAccountingPaymentConditions();
         $AccountingMethodsSelect = $this->SelectDataService->getAccountingPaymentMethod();
         $AccountingDeleveriesSelect =  $this->SelectDataService->getAccountingDelivery();
+        $Reviewers = $this->SelectDataService->getUsers();
         $QuoteCalculatorService = new QuoteCalculatorService($id);
         $totalPrice =  Number::currency($QuoteCalculatorService->getTotalPrice(), $factory->curency, config('app.locale'));
         $subPrice = Number::currency($QuoteCalculatorService->getSubTotal(), $factory->curency, config('app.locale'));
@@ -85,6 +87,34 @@ class QuotesController extends Controller
         list($previousUrl, $nextUrl) = $this->getNextPrevious(new Quotes(), $id->id);
         $CustomFields = $this->customFieldService->getCustomFieldsWithValues('quote', $id->id);
         $projectEstimate = QuoteProjectEstimate::where('quotes_id', $id->id)->first();
+        $reviewFields = ['reviewed_by', 'reviewed_at', 'review_decision', 'change_requested_by', 'change_reason', 'change_approved_at'];
+        $ReviewTimeline = Activity::query()
+            ->where('subject_type', Quotes::class)
+            ->where('subject_id', $id->id)
+            ->with('causer')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function (Activity $activity) use ($reviewFields) {
+                $properties = $activity->properties?->toArray() ?? [];
+                $attributes = array_intersect_key(data_get($properties, 'attributes', []), array_flip($reviewFields));
+                $old = array_intersect_key(data_get($properties, 'old', []), array_flip($reviewFields));
+
+                return [
+                    'id' => $activity->id,
+                    'description' => $activity->description,
+                    'causer' => $activity->causer?->name,
+                    'created_at' => $activity->created_at,
+                    'changes' => collect($attributes)->map(function ($newValue, $field) use ($old) {
+                        return [
+                            'field' => $field,
+                            'old' => $old[$field] ?? null,
+                            'new' => $newValue,
+                        ];
+                    })->values()->all(),
+                ];
+            })
+            ->filter(fn ($entry) => !empty($entry['changes']))
+            ->values();
         return view('workflow/quotes-show', [
             'Quote' => $id,
             'CompanieSelect' => $CompanieSelect,
@@ -93,8 +123,10 @@ class QuotesController extends Controller
             'AccountingConditionSelect' => $AccountingConditionSelect,
             'AccountingMethodsSelect' => $AccountingMethodsSelect,
             'AccountingDeleveriesSelect' => $AccountingDeleveriesSelect,
+            'Reviewers' => $Reviewers,
+            'ReviewTimeline' => $ReviewTimeline,
             'totalPrices' => $totalPrice,
-            'subPrice' => $subPrice, 
+            'subPrice' => $subPrice,
             'vatPrice' => $vatPrice,
             'TotalServiceProductTime'=> $TotalServiceProductTime,
             'TotalServiceSettingTime'=> $TotalServiceSettingTime,

--- a/app/Http/Requests/Workflow/UpdateOrderRequest.php
+++ b/app/Http/Requests/Workflow/UpdateOrderRequest.php
@@ -34,6 +34,12 @@ class UpdateOrderRequest extends FormRequest
             'accounting_payment_methods_id' => 'required_if:type,1|nullable|exists:accounting_payment_methods,id',
             'accounting_deliveries_id' => 'required_if:type,1|nullable|exists:accounting_deliveries,id',
             'comment' => 'nullable|string',
+            'reviewed_by' => 'nullable|exists:users,id',
+            'reviewed_at' => 'nullable|date',
+            'review_decision' => 'nullable|in:pending,approved,rejected',
+            'change_requested_by' => 'nullable|exists:users,id',
+            'change_reason' => 'nullable|string',
+            'change_approved_at' => 'nullable|date',
         ];
     }
 }

--- a/app/Http/Requests/Workflow/UpdateQuoteRequest.php
+++ b/app/Http/Requests/Workflow/UpdateQuoteRequest.php
@@ -34,6 +34,12 @@ class UpdateQuoteRequest extends FormRequest
             'accounting_payment_methods_id' => 'required|exists:accounting_payment_methods,id',
             'accounting_deliveries_id' => 'required|exists:accounting_deliveries,id',
             'comment' => 'nullable|string',
+            'reviewed_by' => 'nullable|exists:users,id',
+            'reviewed_at' => 'nullable|date',
+            'review_decision' => 'nullable|in:pending,approved,rejected',
+            'change_requested_by' => 'nullable|exists:users,id',
+            'change_reason' => 'nullable|string',
+            'change_approved_at' => 'nullable|date',
         ];
     }
 }

--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -30,23 +30,34 @@ class Orders extends Model
 
     // Fillable attributes for mass assignment
     protected $fillable= ['uuid',
-                            'code', 
-                            'label', 
+                            'code',
+                            'label',
                             'customer_reference',
-                            'companies_id', 
-                            'companies_contacts_id',   
-                            'companies_addresses_id',  
-                            'validity_date',  
-                            'statu',  
-                            'user_id',  
-                            'accounting_payment_conditions_id',  
-                            'accounting_payment_methods_id',  
-                            'accounting_deliveries_id',  
+                            'companies_id',
+                            'companies_contacts_id',
+                            'companies_addresses_id',
+                            'validity_date',
+                            'statu',
+                            'user_id',
+                            'accounting_payment_conditions_id',
+                            'accounting_payment_methods_id',
+                            'accounting_deliveries_id',
                             'comment',
                             'quotes_id',
                             'type',
                             'csv_file_name',
+                            'reviewed_by',
+                            'reviewed_at',
+                            'review_decision',
+                            'change_requested_by',
+                            'change_reason',
+                            'change_approved_at',
                         ];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
+        'change_approved_at' => 'datetime',
+    ];
 
     // Only log changes
     protected static $logOnlyDirty = true;
@@ -110,6 +121,16 @@ class Orders extends Model
     public function OrderLines()
     {
         return $this->hasMany(OrderLines::class)->orderBy('ordre');
+    }
+
+    public function reviewer()
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    public function changeRequester()
+    {
+        return $this->belongsTo(User::class, 'change_requested_by');
     }
 
     public function OrderSite()
@@ -249,22 +270,28 @@ class Orders extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()->logOnly([
-                                                'code', 
-                                                'label', 
+                                                'code',
+                                                'label',
                                                 'customer_reference',
-                                                'companies_id', 
-                                                'companies_contacts_id',   
-                                                'companies_addresses_id',  
-                                                'validity_date',  
-                                                'statu',  
-                                                'user_id',  
-                                                'accounting_payment_conditions_id',  
-                                                'accounting_payment_methods_id',  
-                                                'accounting_deliveries_id',  
+                                                'companies_id',
+                                                'companies_contacts_id',
+                                                'companies_addresses_id',
+                                                'validity_date',
+                                                'statu',
+                                                'user_id',
+                                                'accounting_payment_conditions_id',
+                                                'accounting_payment_methods_id',
+                                                'accounting_deliveries_id',
                                                 'comment',
                                                 'quotes_id',
                                                 'type',
-                                                'csv_file_name']);
+                                                'csv_file_name',
+                                                'reviewed_by',
+                                                'reviewed_at',
+                                                'review_decision',
+                                                'change_requested_by',
+                                                'change_reason',
+                                                'change_approved_at']);
         // Chain fluent methods for configuration options
     }
 }

--- a/app/Models/Workflow/Quotes.php
+++ b/app/Models/Workflow/Quotes.php
@@ -29,21 +29,32 @@ class Quotes extends Model
 
     // Fillable attributes for mass assignment
     protected $fillable= ['uuid',
-                            'code', 
-                            'label', 
+                            'code',
+                            'label',
                             'customer_reference',
-                            'companies_id', 
-                            'companies_contacts_id',   
-                            'companies_addresses_id',  
-                            'validity_date',  
-                            'statu',  
-                            'user_id',  
-                            'opportunities_id',  
-                            'accounting_payment_conditions_id',  
-                            'accounting_payment_methods_id',  
-                            'accounting_deliveries_id',  
-                            'comment', 
-                            'csv_file_name',];
+                            'companies_id',
+                            'companies_contacts_id',
+                            'companies_addresses_id',
+                            'validity_date',
+                            'statu',
+                            'user_id',
+                            'opportunities_id',
+                            'accounting_payment_conditions_id',
+                            'accounting_payment_methods_id',
+                            'accounting_deliveries_id',
+                            'comment',
+                            'csv_file_name',
+                            'reviewed_by',
+                            'reviewed_at',
+                            'review_decision',
+                            'change_requested_by',
+                            'change_reason',
+                            'change_approved_at',];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
+        'change_approved_at' => 'datetime',
+    ];
 
     // Only log changes
     protected static $logOnlyDirty = true;
@@ -102,6 +113,16 @@ class Quotes extends Model
     public function QuoteLines()
     {
         return $this->hasMany(QuoteLines::class)->orderBy('ordre');
+    }
+
+    public function reviewer()
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    public function changeRequester()
+    {
+        return $this->belongsTo(User::class, 'change_requested_by');
     }
 
     // Relationship with the files associated with the Quote
@@ -187,20 +208,26 @@ class Quotes extends Model
 
     public function getActivitylogOptions(): LogOptions
     {
-        return LogOptions::defaults()->logOnly(['code', 
-                                                'label', 
+        return LogOptions::defaults()->logOnly(['code',
+                                                'label',
                                                 'customer_reference',
-                                                'companies_id', 
-                                                'companies_contacts_id',   
-                                                'companies_addresses_id',  
-                                                'validity_date',  
-                                                'statu',  
-                                                'user_id',  
-                                                'opportunities_id',  
-                                                'accounting_payment_conditions_id',  
-                                                'accounting_payment_methods_id',  
-                                                'accounting_deliveries_id',  
-                                                'comment', ]);
+                                                'companies_id',
+                                                'companies_contacts_id',
+                                                'companies_addresses_id',
+                                                'validity_date',
+                                                'statu',
+                                                'user_id',
+                                                'opportunities_id',
+                                                'accounting_payment_conditions_id',
+                                                'accounting_payment_methods_id',
+                                                'accounting_deliveries_id',
+                                                'comment',
+                                                'reviewed_by',
+                                                'reviewed_at',
+                                                'review_decision',
+                                                'change_requested_by',
+                                                'change_reason',
+                                                'change_approved_at', ]);
         // Chain fluent methods for configuration options
     }
 }

--- a/database/migrations/2024_10_10_000000_add_review_fields_to_quotes_and_orders_tables.php
+++ b/database/migrations/2024_10_10_000000_add_review_fields_to_quotes_and_orders_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->foreignId('reviewed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->string('review_decision')->nullable();
+            $table->foreignId('change_requested_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('change_reason')->nullable();
+            $table->timestamp('change_approved_at')->nullable();
+        });
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->foreignId('reviewed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->string('review_decision')->nullable();
+            $table->foreignId('change_requested_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('change_reason')->nullable();
+            $table->timestamp('change_approved_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->dropForeign(['reviewed_by']);
+            $table->dropForeign(['change_requested_by']);
+            $table->dropColumn([
+                'reviewed_by',
+                'reviewed_at',
+                'review_decision',
+                'change_requested_by',
+                'change_reason',
+                'change_approved_at',
+            ]);
+        });
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropForeign(['reviewed_by']);
+            $table->dropForeign(['change_requested_by']);
+            $table->dropColumn([
+                'reviewed_by',
+                'reviewed_at',
+                'review_decision',
+                'change_requested_by',
+                'change_reason',
+                'change_approved_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -131,6 +131,76 @@
                 <div class="row">
                   <x-FormTextareaComment  comment="{{ $Order->comment }}" />
                 </div>
+                <div class="row mt-3">
+                  <div class="col-12">
+                    <h5 class="text-info">{{ __('Review & change tracking') }}</h5>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-6">
+                    <label for="reviewed_by">{{ __('Reviewed by') }}</label>
+                    <select class="form-control" name="reviewed_by" id="reviewed_by">
+                      <option value="">{{ __('Select user') }}</option>
+                      @foreach($Reviewers as $user)
+                        <option value="{{ $user->id }}" @selected(old('reviewed_by', $Order->reviewed_by) == $user->id)>{{ $user->name }}</option>
+                      @endforeach
+                    </select>
+                    @error('reviewed_by')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-6">
+                    <label for="reviewed_at">{{ __('Review date') }}</label>
+                    <input type="datetime-local" class="form-control" name="reviewed_at" id="reviewed_at" value="{{ old('reviewed_at', optional($Order->reviewed_at)->format('Y-m-d\\TH:i')) }}">
+                    @error('reviewed_at')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-6">
+                    <label for="review_decision">{{ __('Decision') }}</label>
+                    <select class="form-control" name="review_decision" id="review_decision">
+                      <option value="">{{ __('general_content.undefined_trans_key') }}</option>
+                      <option value="pending" @selected(old('review_decision', $Order->review_decision) === 'pending')>{{ __('general_content.pending_trans_key') }}</option>
+                      <option value="approved" @selected(old('review_decision', $Order->review_decision) === 'approved')>{{ __('general_content.approved_trans_key') }}</option>
+                      <option value="rejected" @selected(old('review_decision', $Order->review_decision) === 'rejected')>{{ __('general_content.rejected_trans_key') }}</option>
+                    </select>
+                    @error('review_decision')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-6">
+                    <label for="change_requested_by">{{ __('Change requested by') }}</label>
+                    <select class="form-control" name="change_requested_by" id="change_requested_by">
+                      <option value="">{{ __('Select user') }}</option>
+                      @foreach($Reviewers as $user)
+                        <option value="{{ $user->id }}" @selected(old('change_requested_by', $Order->change_requested_by) == $user->id)>{{ $user->name }}</option>
+                      @endforeach
+                    </select>
+                    @error('change_requested_by')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-12">
+                    <label for="change_reason">{{ __('Change reason') }}</label>
+                    <textarea class="form-control" name="change_reason" id="change_reason" rows="3">{{ old('change_reason', $Order->change_reason) }}</textarea>
+                    @error('change_reason')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-6">
+                    <label for="change_approved_at">{{ __('Change approved at') }}</label>
+                    <input type="datetime-local" class="form-control" name="change_approved_at" id="change_approved_at" value="{{ old('change_approved_at', optional($Order->change_approved_at)->format('Y-m-d\\TH:i')) }}">
+                    @error('change_approved_at')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
                 <x-slot name="footerSlot">
                   <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="info" icon="fas fa-lg fa-save"/>
                 </x-slot>
@@ -497,9 +567,97 @@
         </x-adminlte-alert>
         @endif
       </div>
+
       <div class="tab-pane " id="Logs">
+        <x-adminlte-card title="{{ __('Review timeline') }}" theme="info" icon="fas fa-history" class="mb-4">
+          @php
+            $reviewersById = $Reviewers->keyBy('id');
+            $fieldLabels = [
+              'reviewed_by' => __('Reviewed by'),
+              'reviewed_at' => __('Review date'),
+              'review_decision' => __('Decision'),
+              'change_requested_by' => __('Change requested by'),
+              'change_reason' => __('Change reason'),
+              'change_approved_at' => __('Change approved at'),
+            ];
+            $formatReviewValue = function ($field, $value) use ($reviewersById) {
+                if (is_null($value) || $value === '') {
+                    return __('general_content.undefined_trans_key');
+                }
+
+                if (in_array($field, ['reviewed_by', 'change_requested_by'], true)) {
+                    return optional($reviewersById->get((int) $value))->name ?? __('general_content.undefined_trans_key');
+                }
+
+                if (in_array($field, ['reviewed_at', 'change_approved_at'], true)) {
+                    try {
+                        return \Carbon\Carbon::parse($value)->format('d/m/Y H:i');
+                    } catch (\Exception $e) {
+                        return $value;
+                    }
+                }
+
+                if ($field === 'review_decision') {
+                    return match ($value) {
+                        'approved' => __('general_content.approved_trans_key'),
+                        'rejected' => __('general_content.rejected_trans_key'),
+                        'pending' => __('general_content.pending_trans_key'),
+                        default => $value,
+                    };
+                }
+
+                return $value;
+            };
+          @endphp
+          @if($ReviewTimeline->isEmpty())
+            <p class="mb-0 text-muted">{{ __('general_content.no_data_trans_key') }}</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>{{ __('general_content.created_trans_key') }}</th>
+                    <th>{{ __('general_content.user_trans_key') }}</th>
+                    <th>{{ __('general_content.description_trans_key') }}</th>
+                    <th>{{ __('Changes') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($ReviewTimeline as $entry)
+                    <tr>
+                      <td>{{ optional($entry['created_at'])->format('d/m/Y H:i') }}</td>
+                      <td>{{ $entry['causer'] ?? __('general_content.undefined_trans_key') }}</td>
+                      <td>{{ $entry['description'] }}</td>
+                      <td>
+                        <table class="table table-sm mb-0">
+                          <thead>
+                            <tr>
+                              <th>{{ __('general_content.label_trans_key') }}</th>
+                              <th>{{ __('general_content.previous_trans_key') }}</th>
+                              <th>{{ __('general_content.new_trans_key') }}</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            @foreach($entry['changes'] as $change)
+                              <tr>
+                                <td>{{ $fieldLabels[$change['field']] ?? \Illuminate\Support\Str::headline($change['field']) }}</td>
+                                <td>{{ $formatReviewValue($change['field'], $change['old']) }}</td>
+                                <td>{{ $formatReviewValue($change['field'], $change['new']) }}</td>
+                              </tr>
+                            @endforeach
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </x-adminlte-card>
         @livewire('logs-viewer', ['subjectType' => 'App\Models\Workflow\Orders', 'subjectId' => $Order->id])
       </div>
+
   </div>
   <!-- /.card-body -->
 </div>

--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -111,6 +111,76 @@
                 <div class="row">
                   <x-FormTextareaComment  comment="{{ $Quote->comment }}" />
                 </div>
+                <div class="row mt-3">
+                  <div class="col-12">
+                    <h5 class="text-info">{{ __('Review & change tracking') }}</h5>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-6">
+                    <label for="reviewed_by">{{ __('Reviewed by') }}</label>
+                    <select class="form-control" name="reviewed_by" id="reviewed_by">
+                      <option value="">{{ __('Select user') }}</option>
+                      @foreach($Reviewers as $user)
+                        <option value="{{ $user->id }}" @selected(old('reviewed_by', $Quote->reviewed_by) == $user->id)>{{ $user->name }}</option>
+                      @endforeach
+                    </select>
+                    @error('reviewed_by')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-6">
+                    <label for="reviewed_at">{{ __('Review date') }}</label>
+                    <input type="datetime-local" class="form-control" name="reviewed_at" id="reviewed_at" value="{{ old('reviewed_at', optional($Quote->reviewed_at)->format('Y-m-d\\TH:i')) }}">
+                    @error('reviewed_at')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-6">
+                    <label for="review_decision">{{ __('Decision') }}</label>
+                    <select class="form-control" name="review_decision" id="review_decision">
+                      <option value="">{{ __('general_content.undefined_trans_key') }}</option>
+                      <option value="pending" @selected(old('review_decision', $Quote->review_decision) === 'pending')>{{ __('general_content.pending_trans_key') }}</option>
+                      <option value="approved" @selected(old('review_decision', $Quote->review_decision) === 'approved')>{{ __('general_content.approved_trans_key') }}</option>
+                      <option value="rejected" @selected(old('review_decision', $Quote->review_decision) === 'rejected')>{{ __('general_content.rejected_trans_key') }}</option>
+                    </select>
+                    @error('review_decision')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-6">
+                    <label for="change_requested_by">{{ __('Change requested by') }}</label>
+                    <select class="form-control" name="change_requested_by" id="change_requested_by">
+                      <option value="">{{ __('Select user') }}</option>
+                      @foreach($Reviewers as $user)
+                        <option value="{{ $user->id }}" @selected(old('change_requested_by', $Quote->change_requested_by) == $user->id)>{{ $user->name }}</option>
+                      @endforeach
+                    </select>
+                    @error('change_requested_by')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-12">
+                    <label for="change_reason">{{ __('Change reason') }}</label>
+                    <textarea class="form-control" name="change_reason" id="change_reason" rows="3">{{ old('change_reason', $Quote->change_reason) }}</textarea>
+                    @error('change_reason')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-6">
+                    <label for="change_approved_at">{{ __('Change approved at') }}</label>
+                    <input type="datetime-local" class="form-control" name="change_approved_at" id="change_approved_at" value="{{ old('change_approved_at', optional($Quote->change_approved_at)->format('Y-m-d\\TH:i')) }}">
+                    @error('change_approved_at')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                  </div>
+                </div>
                 <x-slot name="footerSlot">
                   <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="info" icon="fas fa-lg fa-save"/>
                 </x-slot>
@@ -465,6 +535,92 @@
         @endif
       </div>
       <div class="tab-pane " id="Logs">
+        <x-adminlte-card title="{{ __('Review timeline') }}" theme="info" icon="fas fa-history" class="mb-4">
+          @php
+            $reviewersById = $Reviewers->keyBy('id');
+            $fieldLabels = [
+              'reviewed_by' => __('Reviewed by'),
+              'reviewed_at' => __('Review date'),
+              'review_decision' => __('Decision'),
+              'change_requested_by' => __('Change requested by'),
+              'change_reason' => __('Change reason'),
+              'change_approved_at' => __('Change approved at'),
+            ];
+            $formatReviewValue = function ($field, $value) use ($reviewersById) {
+                if (is_null($value) || $value === '') {
+                    return __('general_content.undefined_trans_key');
+                }
+
+                if (in_array($field, ['reviewed_by', 'change_requested_by'], true)) {
+                    return optional($reviewersById->get((int) $value))->name ?? __('general_content.undefined_trans_key');
+                }
+
+                if (in_array($field, ['reviewed_at', 'change_approved_at'], true)) {
+                    try {
+                        return \Carbon\Carbon::parse($value)->format('d/m/Y H:i');
+                    } catch (\Exception $e) {
+                        return $value;
+                    }
+                }
+
+                if ($field === 'review_decision') {
+                    return match ($value) {
+                        'approved' => __('general_content.approved_trans_key'),
+                        'rejected' => __('general_content.rejected_trans_key'),
+                        'pending' => __('general_content.pending_trans_key'),
+                        default => $value,
+                    };
+                }
+
+                return $value;
+            };
+          @endphp
+          @if($ReviewTimeline->isEmpty())
+            <p class="mb-0 text-muted">{{ __('general_content.no_data_trans_key') }}</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>{{ __('general_content.created_trans_key') }}</th>
+                    <th>{{ __('general_content.user_trans_key') }}</th>
+                    <th>{{ __('general_content.description_trans_key') }}</th>
+                    <th>{{ __('Changes') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($ReviewTimeline as $entry)
+                    <tr>
+                      <td>{{ optional($entry['created_at'])->format('d/m/Y H:i') }}</td>
+                      <td>{{ $entry['causer'] ?? __('general_content.undefined_trans_key') }}</td>
+                      <td>{{ $entry['description'] }}</td>
+                      <td>
+                        <table class="table table-sm mb-0">
+                          <thead>
+                            <tr>
+                              <th>{{ __('general_content.label_trans_key') }}</th>
+                              <th>{{ __('general_content.previous_trans_key') }}</th>
+                              <th>{{ __('general_content.new_trans_key') }}</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            @foreach($entry['changes'] as $change)
+                              <tr>
+                                <td>{{ $fieldLabels[$change['field']] ?? \Illuminate\Support\Str::headline($change['field']) }}</td>
+                                <td>{{ $formatReviewValue($change['field'], $change['old']) }}</td>
+                                <td>{{ $formatReviewValue($change['field'], $change['new']) }}</td>
+                              </tr>
+                            @endforeach
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </x-adminlte-card>
         @livewire('logs-viewer', ['subjectType' => 'App\Models\Workflow\Quotes', 'subjectId' => $Quote->id])
       </div>
   </div>


### PR DESCRIPTION
## Summary
- add database support for review and change tracking on quotes and orders
- expose and validate the new workflow fields in the Eloquent models, controllers, and form requests
- extend quote and order detail pages with review inputs and an activity-based review timeline

## Testing
- php -l app/Models/Workflow/Quotes.php
- php -l app/Models/Workflow/Orders.php
- php -l app/Http/Controllers/Workflow/QuotesController.php
- php -l app/Http/Controllers/Workflow/OrdersController.php
- php -l app/Http/Requests/Workflow/UpdateQuoteRequest.php
- php -l app/Http/Requests/Workflow/UpdateOrderRequest.php
- php -l database/migrations/2024_10_10_000000_add_review_fields_to_quotes_and_orders_tables.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c75cf758832db6c4a89cafbd4c1e