### PR TITLE
Add supplier evaluation fields and KPI insights

### DIFF
--- a/app/Http/Controllers/Companies/CompaniesController.php
+++ b/app/Http/Controllers/Companies/CompaniesController.php
@@ -111,6 +111,33 @@ class CompaniesController extends Controller
         $customerProcessingCost = Number::currency($customerProcessingCost, $factory->curency, config('app.locale'));
 
         $Companie = $id;
+
+        $evaluationHistory = $Companie->rating()->orderByDesc('created_at')->get();
+        $latestEvaluation = $evaluationHistory->first();
+        $compositeScores = $evaluationHistory
+            ->pluck('composite_score')
+            ->filter();
+
+        $averageCompositeScore = $compositeScores->isNotEmpty()
+            ? round($compositeScores->avg(), 1)
+            : null;
+
+        $daysUntilNextReview = null;
+        $needsRequalification = false;
+        $nextReviewSoon = false;
+
+        if ($latestEvaluation && $latestEvaluation->next_review_at) {
+            $daysUntilNextReview = Carbon::now()->startOfDay()->diffInDays($latestEvaluation->next_review_at, false);
+            $needsRequalification = $daysUntilNextReview < 0;
+            $nextReviewSoon = $daysUntilNextReview <= 30;
+        }
+
+        $purchasesForEvaluation = $Companie->Purchases()
+            ->with('Rating')
+            ->orderByDesc('created_at')
+            ->take(20)
+            ->get();
+
         return view('companies/companies-show', compact('Companie',
                                                         'userSelect',
                                                         'previousUrl',
@@ -119,7 +146,14 @@ class CompaniesController extends Controller
                                                         'customerProcessingCost',
                                                         'paidInvoices',
                                                         'unpaidInvoices',
-                                                        'data',));
+                                                        'data',
+                                                        'evaluationHistory',
+                                                        'latestEvaluation',
+                                                        'averageCompositeScore',
+                                                        'needsRequalification',
+                                                        'nextReviewSoon',
+                                                        'daysUntilNextReview',
+                                                        'purchasesForEvaluation',));
     }
 
     /**

--- a/app/Http/Controllers/Companies/SupplierRatingController.php
+++ b/app/Http/Controllers/Companies/SupplierRatingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Companies;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Companies\SupplierRating;
 
@@ -13,15 +14,34 @@ class SupplierRatingController extends Controller
      */
     public function store(Request $request)
     {
-        $request->validate([
+        $data = $request->validate([
             'purchases_id' => 'required|exists:purchases,id',
             'companies_id' => 'required|exists:companies,id',
             'rating' => 'required|integer|min:1|max:5',
             'comment' => 'nullable|string',
+            'approved_at' => 'nullable|date',
+            'next_review_at' => 'nullable|date',
+            'evaluation_status' => 'nullable|string|max:191',
+            'evaluation_score_quality' => 'nullable|integer|min:0|max:100',
+            'evaluation_score_logistics' => 'nullable|integer|min:0|max:100',
+            'evaluation_score_service' => 'nullable|integer|min:0|max:100',
+            'action_plan' => 'nullable|string',
         ]);
 
-        SupplierRating::create($request->all());
+        $data['evaluation_status'] = $data['evaluation_status'] ?? 'pending';
 
-        return redirect()->back()->with('success', 'Rate saved successfully');
+        if ($data['evaluation_status'] === 'approved' && empty($data['approved_at'])) {
+            $data['approved_at'] = now();
+        }
+
+        SupplierRating::create($data);
+
+        $message = trans('general_content.supplier_evaluation_saved_trans_key');
+
+        if ($message === 'general_content.supplier_evaluation_saved_trans_key') {
+            $message = 'Supplier evaluation saved successfully';
+        }
+
+        return redirect()->back()->with('success', $message);
     }
 }

--- a/app/Http/Controllers/Purchases/PurchasesController.php
+++ b/app/Http/Controllers/Purchases/PurchasesController.php
@@ -67,6 +67,9 @@ class PurchasesController extends Controller
         $top5FastestSuppliers = $sortedByAvgReceptionDelay->take(5);
         $top5SlowestSuppliers = $sortedByAvgReceptionDelay->reverse()->take(5);
 
+        $compositeIndicators = $this->purchaseKPIService->getSupplierCompositeIndicators();
+        $suppliersToRequalify = $this->purchaseKPIService->getSuppliersToRequalify(30);
+
         $topProducts = $this->purchaseKPIService->getTopProducts();
         $averageAmount = Number::currency($this->purchaseKPIService->getAverageAmount(),$factory->curency, config('app.locale'));
         $totalPurchaseLineCount = $this->purchaseKPIService->getTotalPurchaseCount();
@@ -89,6 +92,8 @@ class PurchasesController extends Controller
                                                     'CompanieSelect' => $CompanieSelect,
                                                     'code' => $LastPurchase,
                                                     'label' => $LastPurchase,
+                                                    'compositeIndicators' => $compositeIndicators,
+                                                    'suppliersToRequalify' => $suppliersToRequalify,
                                                 ])->with('data',$data);
     }
 

--- a/app/Models/Companies/SupplierRating.php
+++ b/app/Models/Companies/SupplierRating.php
@@ -6,13 +6,34 @@ use App\Models\Companies\Companies;
 use App\Models\Purchases\Purchases;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Collection;
 
 class SupplierRating extends Model
 {
     use HasFactory;
 
     // Fillable attributes for mass assignment
-    protected $fillable= ['purchases_id', 'companies_id', 'rating', 'comment'];
+    protected $fillable = [
+        'purchases_id',
+        'companies_id',
+        'rating',
+        'comment',
+        'approved_at',
+        'next_review_at',
+        'evaluation_status',
+        'evaluation_score_quality',
+        'evaluation_score_logistics',
+        'evaluation_score_service',
+        'action_plan',
+    ];
+
+    protected $casts = [
+        'approved_at' => 'datetime',
+        'next_review_at' => 'date',
+        'evaluation_score_quality' => 'integer',
+        'evaluation_score_logistics' => 'integer',
+        'evaluation_score_service' => 'integer',
+    ];
 
     public function purchaseOrder()
     {
@@ -22,5 +43,20 @@ class SupplierRating extends Model
     public function supplier()
     {
         return $this->belongsTo(Companies::class);
+    }
+
+    public function getCompositeScoreAttribute(): ?float
+    {
+        $scores = Collection::make([
+            $this->evaluation_score_quality,
+            $this->evaluation_score_logistics,
+            $this->evaluation_score_service,
+        ])->filter(fn ($value) => $value !== null);
+
+        if ($scores->isEmpty()) {
+            return null;
+        }
+
+        return round($scores->avg(), 1);
     }
 }

--- a/app/Services/PurchaseKPIService.php
+++ b/app/Services/PurchaseKPIService.php
@@ -162,6 +162,95 @@ class PurchaseKPIService
     }
 
     /**
+     * Retrieve suppliers ordered by their composite evaluation score.
+     *
+     * @param int $limit
+     * @return \Illuminate\Support\Collection
+     */
+    public function getSupplierCompositeIndicators(int $limit = 5)
+    {
+        return Companies::where('statu_supplier', 2)
+            ->with(['rating' => function ($query) {
+                $query->select([
+                    'id',
+                    'companies_id',
+                    'evaluation_score_quality',
+                    'evaluation_score_logistics',
+                    'evaluation_score_service',
+                    'next_review_at',
+                    'approved_at',
+                    'evaluation_status',
+                    'created_at',
+                ]);
+            }])
+            ->get()
+            ->map(function ($company) {
+                $compositeScores = $company->rating
+                    ->map(fn ($rating) => $rating->composite_score)
+                    ->filter(fn ($score) => $score !== null);
+
+                $company->composite_score = $compositeScores->isEmpty()
+                    ? null
+                    : round($compositeScores->avg(), 1);
+
+                $company->latest_review = $company->rating->sortByDesc(function ($rating) {
+                    return [$rating->next_review_at ?? Carbon::createFromTimestamp(0), $rating->created_at];
+                })->first();
+
+                return $company;
+            })
+            ->filter(fn ($company) => $company->composite_score !== null)
+            ->sortByDesc('composite_score')
+            ->take($limit)
+            ->values();
+    }
+
+    /**
+     * Retrieve suppliers requiring requalification before a given threshold.
+     *
+     * @param int $withinDays
+     * @return \Illuminate\Support\Collection
+     */
+    public function getSuppliersToRequalify(int $withinDays = 0)
+    {
+        $thresholdDate = Carbon::now()->addDays($withinDays)->endOfDay();
+
+        return Companies::where('statu_supplier', 2)
+            ->whereHas('rating', function ($query) use ($thresholdDate) {
+                $query->whereNotNull('next_review_at')
+                    ->whereDate('next_review_at', '<=', $thresholdDate);
+            })
+            ->with(['rating' => function ($query) {
+                $query->select([
+                    'id',
+                    'companies_id',
+                    'next_review_at',
+                    'evaluation_status',
+                    'evaluation_score_quality',
+                    'evaluation_score_logistics',
+                    'evaluation_score_service',
+                    'created_at',
+                ]);
+            }])
+            ->get()
+            ->map(function ($company) {
+                $latestEvaluation = $company->rating->sortByDesc(function ($rating) {
+                    return [$rating->next_review_at ?? Carbon::createFromTimestamp(0), $rating->created_at];
+                })->first();
+
+                $company->next_review_at = $latestEvaluation?->next_review_at;
+                $company->evaluation_status = $latestEvaluation?->evaluation_status;
+                $company->composite_score = $latestEvaluation?->composite_score;
+
+                return $company;
+            })
+            ->sortBy(function ($company) {
+                return optional($company->next_review_at)->timestamp ?? 0;
+            })
+            ->values();
+    }
+
+    /**
      * Calculate the average purchase amount.
      *
      * This method retrieves the total purchase count and the total purchase amount,

--- a/database/factories/Companies/SupplierRatingFactory.php
+++ b/database/factories/Companies/SupplierRatingFactory.php
@@ -17,6 +17,13 @@ class SupplierRatingFactory extends Factory
             'companies_id' => Companies::all()->random()->id, // Exemple d'ID de compagnie
             'rating' => $this->faker->numberBetween(1, 5),
             'comment' => $this->faker->sentence,
+            'approved_at' => $this->faker->optional()->dateTimeBetween('-6 months', 'now'),
+            'next_review_at' => $this->faker->optional()->dateTimeBetween('now', '+6 months'),
+            'evaluation_status' => $this->faker->randomElement(['pending', 'approved', 'under_review', 'rejected']),
+            'evaluation_score_quality' => $this->faker->numberBetween(0, 100),
+            'evaluation_score_logistics' => $this->faker->numberBetween(0, 100),
+            'evaluation_score_service' => $this->faker->numberBetween(0, 100),
+            'action_plan' => $this->faker->optional()->sentence,
         ];
     }
 }

--- a/database/migrations/2024_06_03_000000_add_evaluation_fields_to_supplier_ratings_table.php
+++ b/database/migrations/2024_06_03_000000_add_evaluation_fields_to_supplier_ratings_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('supplier_ratings', function (Blueprint $table) {
+            $table->timestamp('approved_at')->nullable()->after('comment');
+            $table->date('next_review_at')->nullable()->after('approved_at');
+            $table->string('evaluation_status')->default('pending')->after('next_review_at');
+            $table->unsignedTinyInteger('evaluation_score_quality')->nullable()->after('evaluation_status');
+            $table->unsignedTinyInteger('evaluation_score_logistics')->nullable()->after('evaluation_score_quality');
+            $table->unsignedTinyInteger('evaluation_score_service')->nullable()->after('evaluation_score_logistics');
+            $table->text('action_plan')->nullable()->after('evaluation_score_service');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::table('supplier_ratings', function (Blueprint $table) {
+            $table->dropColumn([
+                'approved_at',
+                'next_review_at',
+                'evaluation_status',
+                'evaluation_score_quality',
+                'evaluation_score_logistics',
+                'evaluation_score_service',
+                'action_plan',
+            ]);
+        });
+    }
+};

--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -20,6 +20,13 @@
       <li class="nav-item"><a class="nav-link" href="#delivery" data-toggle="tab">{{ __('general_content.deliverys_notes_list_trans_key') }} ({{ $Companie->getDeliverysCountAttribute() }})</a></li>
       <li class="nav-item"><a class="nav-link" href="#invoice" data-toggle="tab">{{ __('general_content.invoices_list_trans_key') }} ({{ $Companie->getInvoicesCountAttribute() }})</a></li>
       <li class="nav-item"><a class="nav-link" href="#purchase" data-toggle="tab">{{ __('general_content.purchase_list_trans_key') }} ({{ $Companie->getPurchasesCountAttribute() }})</a></li>
+      @php
+        $evaluationTabLabel = trans('general_content.supplier_evaluations_trans_key');
+        if ($evaluationTabLabel === 'general_content.supplier_evaluations_trans_key') {
+            $evaluationTabLabel = 'Supplier evaluations';
+        }
+      @endphp
+      <li class="nav-item"><a class="nav-link" href="#evaluation" data-toggle="tab">{{ $evaluationTabLabel }}</a></li>
     </ul>
   </div>
   <!-- /.card-header -->
@@ -870,6 +877,209 @@
       </div>
       <div class="tab-pane" id="purchase">
         @livewire('purchases-index' , ['idCompanie' => $Companie->id ])
+      </div>
+      <div class="tab-pane" id="evaluation">
+        @php
+          $newEvaluationLabel = trans('general_content.new_supplier_evaluation_trans_key');
+          if ($newEvaluationLabel === 'general_content.new_supplier_evaluation_trans_key') {
+              $newEvaluationLabel = 'New supplier evaluation';
+          }
+
+          $latestEvaluationLabel = trans('general_content.latest_supplier_evaluation_trans_key');
+          if ($latestEvaluationLabel === 'general_content.latest_supplier_evaluation_trans_key') {
+              $latestEvaluationLabel = 'Latest supplier evaluation';
+          }
+
+          $evaluationHistoryLabel = trans('general_content.supplier_evaluation_history_trans_key');
+          if ($evaluationHistoryLabel === 'general_content.supplier_evaluation_history_trans_key') {
+              $evaluationHistoryLabel = 'Supplier evaluation history';
+          }
+
+          $evaluationScoresLabel = [
+              'quality' => trans('general_content.evaluation_quality_score_trans_key'),
+              'logistics' => trans('general_content.evaluation_logistics_score_trans_key'),
+              'service' => trans('general_content.evaluation_service_score_trans_key'),
+          ];
+
+          foreach ($evaluationScoresLabel as $key => $label) {
+              if ($label === 'general_content.evaluation_' . $key . '_score_trans_key') {
+                  $evaluationScoresLabel[$key] = ucfirst($key) . ' score';
+              }
+          }
+
+          $requalificationAlertLabel = trans('general_content.supplier_requalification_alert_trans_key');
+          if ($requalificationAlertLabel === 'general_content.supplier_requalification_alert_trans_key') {
+              $requalificationAlertLabel = 'Supplier requalification alert';
+          }
+
+          $requalificationSoonLabel = trans('general_content.supplier_requalification_soon_trans_key');
+          if ($requalificationSoonLabel === 'general_content.supplier_requalification_soon_trans_key') {
+              $requalificationSoonLabel = 'Upcoming supplier requalification';
+          }
+        @endphp
+
+        @if($needsRequalification)
+          <x-adminlte-alert theme="danger" title="{{ $requalificationAlertLabel }}">
+            {{ __('The supplier must be requalified since :days day(s).', ['days' => abs($daysUntilNextReview ?? 0)]) }}
+          </x-adminlte-alert>
+        @elseif($nextReviewSoon && !is_null($daysUntilNextReview))
+          <x-adminlte-alert theme="warning" title="{{ $requalificationSoonLabel }}">
+            {{ __('Next review scheduled in :days day(s).', ['days' => $daysUntilNextReview]) }}
+          </x-adminlte-alert>
+        @endif
+
+        <div class="row">
+          <div class="col-md-6">
+            <x-adminlte-card title="{{ $newEvaluationLabel }}" theme="primary" maximizable>
+              @if($purchasesForEvaluation->isEmpty())
+                <p class="text-muted">{{ __('No purchase orders available to evaluate this supplier yet.') }}</p>
+              @else
+                <form method="POST" action="{{ route('companies.ratings.store') }}">
+                  @csrf
+                  <input type="hidden" name="companies_id" value="{{ $Companie->id }}">
+                  <div class="form-group">
+                    <label for="purchases_id">{{ __('Purchase order') }}</label>
+                    <select name="purchases_id" id="purchases_id" class="form-control">
+                      @foreach($purchasesForEvaluation as $purchase)
+                        <option value="{{ $purchase->id }}">
+                          {{ $purchase->code }} - {{ $purchase->label }} ({{ $purchase->GetPrettyCreatedAttribute() }})
+                        </option>
+                      @endforeach
+                    </select>
+                  </div>
+                  <div class="form-group">
+                    <label for="rating">{{ __('Rating') }}</label>
+                    <select name="rating" id="rating" class="form-control">
+                      @for ($i = 1; $i <= 5; $i++)
+                        <option value="{{ $i }}">{{ $i }}</option>
+                      @endfor
+                    </select>
+                  </div>
+                  <div class="form-group">
+                    <label for="evaluation_status">{{ __('Status') }}</label>
+                    <select name="evaluation_status" id="evaluation_status" class="form-control">
+                      @php
+                        $statusOptions = ['pending', 'approved', 'under_review', 'rejected'];
+                      @endphp
+                      @foreach($statusOptions as $statusOption)
+                        <option value="{{ $statusOption }}">{{ ucfirst(str_replace('_', ' ', $statusOption)) }}</option>
+                      @endforeach
+                    </select>
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group col-md-6">
+                      <label for="approved_at">{{ __('Approved at') }}</label>
+                      <input type="datetime-local" name="approved_at" id="approved_at" class="form-control">
+                    </div>
+                    <div class="form-group col-md-6">
+                      <label for="next_review_at">{{ __('Next review at') }}</label>
+                      <input type="date" name="next_review_at" id="next_review_at" class="form-control">
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group col-md-4">
+                      <label for="evaluation_score_quality">{{ $evaluationScoresLabel['quality'] }}</label>
+                      <input type="number" class="form-control" name="evaluation_score_quality" id="evaluation_score_quality" min="0" max="100" step="1">
+                    </div>
+                    <div class="form-group col-md-4">
+                      <label for="evaluation_score_logistics">{{ $evaluationScoresLabel['logistics'] }}</label>
+                      <input type="number" class="form-control" name="evaluation_score_logistics" id="evaluation_score_logistics" min="0" max="100" step="1">
+                    </div>
+                    <div class="form-group col-md-4">
+                      <label for="evaluation_score_service">{{ $evaluationScoresLabel['service'] }}</label>
+                      <input type="number" class="form-control" name="evaluation_score_service" id="evaluation_score_service" min="0" max="100" step="1">
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label for="comment">{{ __('Comment') }}</label>
+                    <textarea name="comment" id="comment" rows="3" class="form-control"></textarea>
+                  </div>
+                  <div class="form-group">
+                    <label for="action_plan">{{ __('Action plan') }}</label>
+                    <textarea name="action_plan" id="action_plan" rows="3" class="form-control"></textarea>
+                  </div>
+                  <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.submit_trans_key') }}" theme="danger" icon="fas fa-lg fa-save" />
+                </form>
+              @endif
+            </x-adminlte-card>
+          </div>
+          <div class="col-md-6">
+            <x-adminlte-card title="{{ $latestEvaluationLabel }}" theme="secondary" maximizable>
+              @if($latestEvaluation)
+                <ul class="list-unstyled mb-0">
+                  <li><strong>{{ __('Last updated') }}:</strong> {{ optional($latestEvaluation->created_at)->format('d/m/Y H:i') }}</li>
+                  <li><strong>{{ __('Status') }}:</strong> {{ ucfirst(str_replace('_', ' ', $latestEvaluation->evaluation_status ?? ''))) }}</li>
+                  <li><strong>{{ __('Rating') }}:</strong>
+                    @for ($i = 1; $i <= 5; $i++)
+                      @if ($i <= ($latestEvaluation->rating ?? 0))
+                        <span class="badge badge-warning">&#9733;</span>
+                      @else
+                        <span class="badge badge-info">&#9734;</span>
+                      @endif
+                    @endfor
+                  </li>
+                  <li><strong>{{ __('Composite score') }}:</strong> {{ $latestEvaluation->composite_score ?? __('N/A') }}</li>
+                  <li><strong>{{ $evaluationScoresLabel['quality'] }}:</strong> {{ $latestEvaluation->evaluation_score_quality ?? __('N/A') }}</li>
+                  <li><strong>{{ $evaluationScoresLabel['logistics'] }}:</strong> {{ $latestEvaluation->evaluation_score_logistics ?? __('N/A') }}</li>
+                  <li><strong>{{ $evaluationScoresLabel['service'] }}:</strong> {{ $latestEvaluation->evaluation_score_service ?? __('N/A') }}</li>
+                  <li><strong>{{ __('Next review at') }}:</strong> {{ optional($latestEvaluation->next_review_at)->format('d/m/Y') ?? __('N/A') }}</li>
+                  <li><strong>{{ __('Approved at') }}:</strong> {{ optional($latestEvaluation->approved_at)->format('d/m/Y H:i') ?? __('N/A') }}</li>
+                  <li><strong>{{ __('Action plan') }}:</strong> {{ $latestEvaluation->action_plan ?? __('N/A') }}</li>
+                </ul>
+              @else
+                <p class="text-muted">{{ __('No evaluation has been recorded for this supplier yet.') }}</p>
+              @endif
+              <hr>
+              <ul class="list-unstyled mb-0">
+                <li><strong>{{ __('Average composite score') }}:</strong> {{ $averageCompositeScore ?? __('N/A') }}</li>
+                <li><strong>{{ __('Average rating') }}:</strong> {{ $Companie->averageRating() ? number_format($Companie->averageRating(), 2) : __('N/A') }}</li>
+              </ul>
+            </x-adminlte-card>
+          </div>
+        </div>
+
+        <x-adminlte-card title="{{ $evaluationHistoryLabel }}" theme="info" maximizable>
+          @if($evaluationHistory->isEmpty())
+            <p class="text-muted">{{ __('No supplier evaluation history available yet.') }}</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>{{ __('Date') }}</th>
+                    <th>{{ __('Purchase order') }}</th>
+                    <th>{{ __('Rating') }}</th>
+                    <th>{{ __('Composite score') }}</th>
+                    <th>{{ __('Status') }}</th>
+                    <th>{{ $evaluationScoresLabel['quality'] }}</th>
+                    <th>{{ $evaluationScoresLabel['logistics'] }}</th>
+                    <th>{{ $evaluationScoresLabel['service'] }}</th>
+                    <th>{{ __('Next review at') }}</th>
+                    <th>{{ __('Approved at') }}</th>
+                    <th>{{ __('Action plan') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($evaluationHistory as $evaluation)
+                    <tr>
+                      <td>{{ optional($evaluation->created_at)->format('d/m/Y') }}</td>
+                      <td>{{ optional($evaluation->purchaseOrder)->code }}</td>
+                      <td>{{ $evaluation->rating }}</td>
+                      <td>{{ $evaluation->composite_score ?? __('N/A') }}</td>
+                      <td>{{ ucfirst(str_replace('_', ' ', $evaluation->evaluation_status ?? '')) }}</td>
+                      <td>{{ $evaluation->evaluation_score_quality ?? '-' }}</td>
+                      <td>{{ $evaluation->evaluation_score_logistics ?? '-' }}</td>
+                      <td>{{ $evaluation->evaluation_score_service ?? '-' }}</td>
+                      <td>{{ optional($evaluation->next_review_at)->format('d/m/Y') ?? '-' }}</td>
+                      <td>{{ optional($evaluation->approved_at)->format('d/m/Y H:i') ?? '-' }}</td>
+                      <td>{{ $evaluation->action_plan ? \Illuminate\Support\Str::limit($evaluation->action_plan, 60) : '-' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </x-adminlte-card>
       </div>
     </div>
   </div>

--- a/resources/views/purchases/purchases-index.blade.php
+++ b/resources/views/purchases/purchases-index.blade.php
@@ -31,8 +31,82 @@
           <x-adminlte-card title="{{ __('general_content.statistiques_trans_key') }}" theme="warning" icon="fas fa-chart-bar text-white" collapsible removable maximizable>
             <canvas id="barChart" style="min-height: 250px; height: 250px; max-height: 250px; max-width: 100%;"></canvas>
           </x-adminlte-card>
+      </div>
+
+      <div class="row mt-3">
+        <div class="col-md-6">
+          @php
+            $compositeIndicatorsLabel = trans('general_content.supplier_composite_indicator_trans_key');
+            if ($compositeIndicatorsLabel === 'general_content.supplier_composite_indicator_trans_key') {
+                $compositeIndicatorsLabel = 'Top supplier composite indicators';
+            }
+          @endphp
+          <x-adminlte-card title="{{ $compositeIndicatorsLabel }}" theme="info" maximizable>
+            @if($compositeIndicators->isEmpty())
+              <p class="text-muted">{{ __('No supplier evaluations have been recorded yet.') }}</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-hover">
+                  <thead>
+                    <tr>
+                      <th>{{ __('general_content.supplier_trans_key') }}</th>
+                      <th>{{ __('Composite score') }}</th>
+                      <th>{{ __('Next review at') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($compositeIndicators as $supplier)
+                      <tr>
+                        <td>{{ $supplier->label }}</td>
+                        <td>{{ $supplier->composite_score }}</td>
+                        <td>{{ optional(optional($supplier->latest_review)->next_review_at)->format('d/m/Y') ?? '-' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </x-adminlte-card>
         </div>
-        
+        <div class="col-md-6">
+          @php
+            $suppliersToRequalifyLabel = trans('general_content.suppliers_to_requalify_trans_key');
+            if ($suppliersToRequalifyLabel === 'general_content.suppliers_to_requalify_trans_key') {
+                $suppliersToRequalifyLabel = 'Suppliers to requalify soon';
+            }
+          @endphp
+          <x-adminlte-card title="{{ $suppliersToRequalifyLabel }}" theme="danger" maximizable>
+            @if($suppliersToRequalify->isEmpty())
+              <p class="text-muted">{{ __('No suppliers require requalification within the next 30 days.') }}</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-hover">
+                  <thead>
+                    <tr>
+                      <th>{{ __('general_content.supplier_trans_key') }}</th>
+                      <th>{{ __('Status') }}</th>
+                      <th>{{ __('Composite score') }}</th>
+                      <th>{{ __('Next review at') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($suppliersToRequalify as $supplier)
+                      <tr>
+                        <td>{{ $supplier->label }}</td>
+                        <td>{{ ucfirst(str_replace('_', ' ', $supplier->evaluation_status ?? '')) }}</td>
+                        <td>{{ $supplier->composite_score ?? __('N/A') }}</td>
+                        <td>{{ optional($supplier->next_review_at)->format('d/m/Y') ?? '-' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </x-adminlte-card>
+        </div>
+
+      </div>
+
         <div class="col-md-3">
           <x-adminlte-small-box title=" {{ __('general_content.lines_count_trans_key') }}" text="{{ $totalPurchaseLineCount }}" icon="fas fa-shopping-cart text-white"
             theme="purple"/>
@@ -189,6 +263,80 @@
         </div>
 
       </div>
+
+      <div class="row mt-3">
+        <div class="col-md-6">
+          @php
+            $compositeIndicatorsLabel = trans('general_content.supplier_composite_indicator_trans_key');
+            if ($compositeIndicatorsLabel === 'general_content.supplier_composite_indicator_trans_key') {
+                $compositeIndicatorsLabel = 'Top supplier composite indicators';
+            }
+          @endphp
+          <x-adminlte-card title="{{ $compositeIndicatorsLabel }}" theme="info" maximizable>
+            @if($compositeIndicators->isEmpty())
+              <p class="text-muted">{{ __('No supplier evaluations have been recorded yet.') }}</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-hover">
+                  <thead>
+                    <tr>
+                      <th>{{ __('general_content.supplier_trans_key') }}</th>
+                      <th>{{ __('Composite score') }}</th>
+                      <th>{{ __('Next review at') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($compositeIndicators as $supplier)
+                      <tr>
+                        <td>{{ $supplier->label }}</td>
+                        <td>{{ $supplier->composite_score }}</td>
+                        <td>{{ optional(optional($supplier->latest_review)->next_review_at)->format('d/m/Y') ?? '-' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </x-adminlte-card>
+        </div>
+        <div class="col-md-6">
+          @php
+            $suppliersToRequalifyLabel = trans('general_content.suppliers_to_requalify_trans_key');
+            if ($suppliersToRequalifyLabel === 'general_content.suppliers_to_requalify_trans_key') {
+                $suppliersToRequalifyLabel = 'Suppliers to requalify soon';
+            }
+          @endphp
+          <x-adminlte-card title="{{ $suppliersToRequalifyLabel }}" theme="danger" maximizable>
+            @if($suppliersToRequalify->isEmpty())
+              <p class="text-muted">{{ __('No suppliers require requalification within the next 30 days.') }}</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-hover">
+                  <thead>
+                    <tr>
+                      <th>{{ __('general_content.supplier_trans_key') }}</th>
+                      <th>{{ __('Status') }}</th>
+                      <th>{{ __('Composite score') }}</th>
+                      <th>{{ __('Next review at') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($suppliersToRequalify as $supplier)
+                      <tr>
+                        <td>{{ $supplier->label }}</td>
+                        <td>{{ ucfirst(str_replace('_', ' ', $supplier->evaluation_status ?? '')) }}</td>
+                        <td>{{ $supplier->composite_score ?? __('N/A') }}</td>
+                        <td>{{ optional($supplier->next_review_at)->format('d/m/Y') ?? '-' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </x-adminlte-card>
+        </div>
+      </div>
+
     </div>
     <div class="tab-pane" id="List">
       @livewire('purchases-index')


### PR DESCRIPTION
## Summary
- add migration columns to supplier ratings for evaluation scheduling and scoring
- expand supplier rating handling across models, controllers, and company view with evaluation forms and history
- extend purchase KPIs and dashboard to surface composite indicators and requalification alerts

## Testing
- php -l app/Models/Companies/SupplierRating.php
- php -l app/Http/Controllers/Companies/SupplierRatingController.php
- php -l app/Http/Controllers/Companies/CompaniesController.php
- php -l app/Http/Controllers/Purchases/PurchasesController.php
- php -l app/Services/PurchaseKPIService.php
- php -l database/factories/Companies/SupplierRatingFactory.php
- php -l database/migrations/2024_06_03_000000_add_evaluation_fields_to_supplier_ratings_table.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c762f798832d9b7095b2bb8fc04e