### PR TITLE
Ensure methods controller tests authenticate and seed factory

### DIFF
--- a/tests/Unit/SectionsControllerTest.php
+++ b/tests/Unit/SectionsControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use App\Models\User;
+use App\Models\Admin\Factory;
 use App\Models\Methods\MethodsSection;
 use App\Services\SelectDataService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -14,10 +15,18 @@ class SectionsControllerTest extends TestCase
     use RefreshDatabase;
 
     protected $selectDataServiceMock;
+    protected $user;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        Factory::create([
+            'name' => 'Test Factory',
+        ]);
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
 
         // Mocking the SelectDataService for the dependency injection
         $this->selectDataServiceMock = Mockery::mock(SelectDataService::class);

--- a/tests/Unit/ServicesControllerTest.php
+++ b/tests/Unit/ServicesControllerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\Http\Controllers\Methods;
 
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Admin\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -14,10 +16,18 @@ class ServicesControllerTest extends TestCase
     use RefreshDatabase;
 
     protected $mockSelectDataService;
+    protected $user;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        Factory::create([
+            'name' => 'Test Factory',
+        ]);
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
 
         // Mock le service SelectDataService
         $this->mockSelectDataService = $this->createMock(SelectDataService::class);

--- a/tests/Unit/StandardNomenclatureControllerTest.php
+++ b/tests/Unit/StandardNomenclatureControllerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\Http\Controllers\Methods;
 
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Admin\Factory;
 use App\Models\Methods\MethodsStandardNomenclature;
 use App\Services\SelectDataService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -16,10 +18,17 @@ class StandardNomenclatureControllerTest extends TestCase
     use RefreshDatabase;
 
     protected $selectDataService;
+    protected $user;
 
     public function setUp(): void
     {
         parent::setUp();
+        Factory::create([
+            'name' => 'Test Factory',
+        ]);
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
         $this->selectDataService = $this->createMock(SelectDataService::class);
         $this->app->instance(SelectDataService::class, $this->selectDataService);
     }

--- a/tests/Unit/ToolsControllerTest.php
+++ b/tests/Unit/ToolsControllerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\Controllers\Methods;
 
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Admin\Factory;
 use App\Models\Methods\MethodsTools;
 use App\Services\SelectDataService;
 use Illuminate\Http\UploadedFile;
@@ -14,10 +16,18 @@ class ToolsControllerTest extends TestCase
     use RefreshDatabase;
 
     protected $selectDataService;
+    protected $user;
 
     public function setUp(): void
     {
         parent::setUp();
+
+        Factory::create([
+            'name' => 'Test Factory',
+        ]);
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
 
         // Mock du service SelectDataService
         $this->selectDataService = $this->createMock(SelectDataService::class);


### PR DESCRIPTION
## Summary
- seed a factory record and authenticate a user in the methods-related unit tests so middleware checks pass
- continue registering the SelectDataService mocks after establishing the authenticated context

## Testing
- php artisan test --testsuite=Unit *(fails: Fatal error: Class "Illuminate\\Foundation\\Application" not found; composer install cannot finish due to network-restricted downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d30f7c50f4832d94ff62ddd4328451