### PR TITLE
Align Methods tests with route aliases

### DIFF
--- a/tests/Feature/FamiliesControllerTest.php
+++ b/tests/Feature/FamiliesControllerTest.php
@@ -61,7 +61,7 @@ class FamiliesControllerTest extends TestCase
             'methods_services_id' => 1,
         ];
 
-        $response = $this->actingAs($user)->post(route('methods.family.store'), $data);
+        $response = $this->actingAs($user)->post(route('methods.family.create'), $data);
 
         // Vérifier que la redirection fonctionne
         $response->assertRedirect(route('methods.family'));
@@ -87,14 +87,14 @@ class FamiliesControllerTest extends TestCase
             'methods_services_id' => 1,
         ]);
 
-        // Simuler une requête PUT avec des données mises à jour
+        // Simuler une requête POST avec des données mises à jour
         $data = [
             'id' => $family->id,
             'label' => 'Updated Family',
             'methods_services_id' => 2,
         ];
 
-        $response = $this->actingAs($user)->put(route('methods.family.update', $family->id), $data);
+        $response = $this->actingAs($user)->post(route('methods.family.update', ['id' => $family->id]), $data);
 
         // Vérifier que la redirection fonctionne
         $response->assertRedirect(route('methods.family'));

--- a/tests/Feature/LocationsControllerTest.php
+++ b/tests/Feature/LocationsControllerTest.php
@@ -59,7 +59,7 @@ class LocationsControllerTest extends TestCase
             'color' => '#FFFFFF',
         ];
 
-        $response = $this->actingAs($user)->post(route('methods.location.store'), $data);
+        $response = $this->actingAs($user)->post(route('methods.location.create'), $data);
 
         // Vérifier que la redirection fonctionne
         $response->assertRedirect(route('methods.location'));
@@ -87,7 +87,7 @@ class LocationsControllerTest extends TestCase
             'color' => '#000000',
         ]);
 
-        // Simuler une requête PUT avec des données mises à jour
+        // Simuler une requête POST avec des données mises à jour
         $data = [
             'id' => $location->id,
             'label' => 'Updated Location',
@@ -95,7 +95,7 @@ class LocationsControllerTest extends TestCase
             'color' => '#FFFFFF',
         ];
 
-        $response = $this->actingAs($user)->put(route('methods.location.update', $location->id), $data);
+        $response = $this->actingAs($user)->post(route('methods.location.update', ['id' => $location->id]), $data);
 
         // Vérifier que la redirection fonctionne
         $response->assertRedirect(route('methods.location'));

--- a/tests/Feature/RessourcesControllerTest.php
+++ b/tests/Feature/RessourcesControllerTest.php
@@ -38,7 +38,7 @@ class RessourcesControllerTest extends TestCase
     public function test_store_creates_ressource()
     {
         // Simuler une requête POST avec des données valides
-        $response = $this->post(route('methods.ressource.store'), [
+        $response = $this->post(route('methods.ressource.create'), [
             'ordre' => 1,
             'code' => 'R001',
             'label' => 'Ressource 1',
@@ -68,7 +68,7 @@ class RessourcesControllerTest extends TestCase
     public function test_store_fails_without_image()
     {
         // Simuler une requête POST sans image
-        $response = $this->post(route('methods.ressource.store'), [
+        $response = $this->post(route('methods.ressource.create'), [
             'ordre' => 1,
             'code' => 'R002',
             'label' => 'Ressource 2',
@@ -96,12 +96,12 @@ class RessourcesControllerTest extends TestCase
         ]);
 
         // Simuler une requête POST avec des données mises à jour
-        $response = $this->put(route('methods.ressource.update', $ressource->id), [
+        $response = $this->post(route('methods.ressource.update', ['id' => $ressource->id]), [
             'id' => $ressource->id,
             'ordre' => 2,
             'label' => 'Updated Label',
             'capacity' => 20,
-            'mask_time' => true,
+            'mask_time_update' => true,
             'section_id' => 2,
             'color' => '#FF0000',
             'methods_services_id' => 2,
@@ -132,7 +132,7 @@ class RessourcesControllerTest extends TestCase
         $ressource = MethodsRessources::factory()->create();
 
         // Simuler une requête POST avec une image valide
-        $response = $this->post(route('methods.ressource.store_image', $ressource->id), [
+        $response = $this->post(route('methods.ressource.update.picture', ['id' => $ressource->id]), [
             'id' => $ressource->id,
             'picture' => UploadedFile::fake()->image('ressource.jpg'),
         ]);

--- a/tests/Feature/UnitsControllerTest.php
+++ b/tests/Feature/UnitsControllerTest.php
@@ -15,7 +15,7 @@ class UnitsControllerTest extends TestCase
     {
         $units = MethodsUnits::factory()->count(3)->create();
 
-        $response = $this->get(route('methods.unit.index'));
+        $response = $this->get(route('methods.unit'));
 
         $response->assertStatus(200);
         $response->assertViewHas('MethodsUnits');
@@ -31,7 +31,7 @@ class UnitsControllerTest extends TestCase
             'type' => 'Unit Type',
         ];
 
-        $response = $this->post(route('methods.unit.store'), $data);
+        $response = $this->post(route('methods.unit.create'), $data);
 
         $response->assertRedirect(route('methods.unit'));
         $this->assertDatabaseHas('methods_units', $data);
@@ -45,12 +45,13 @@ class UnitsControllerTest extends TestCase
         ]);
 
         $data = [
+            'id' => $unit->id,
             'label' => 'Updated Label',
             'type' => 'Updated Type',
             'default' => 1,
         ];
 
-        $response = $this->put(route('methods.unit.update', $unit->id), $data);
+        $response = $this->post(route('methods.unit.update', ['id' => $unit->id]), $data);
 
         $response->assertRedirect(route('methods.unit'));
         $this->assertDatabaseHas('methods_units', [

--- a/tests/Unit/SectionsControllerTest.php
+++ b/tests/Unit/SectionsControllerTest.php
@@ -63,7 +63,7 @@ class SectionsControllerTest extends TestCase
         $user = User::factory()->create();
 
         // Simuler une requête POST avec des données valides
-        $response = $this->post(route('methods.section.store'), [
+        $response = $this->post(route('methods.section.create'), [
             'ordre' => 1,
             'code' => 'SEC001',
             'label' => 'Section 1',
@@ -100,8 +100,8 @@ class SectionsControllerTest extends TestCase
         // Créer un utilisateur factice
         $user = User::factory()->create();
 
-        // Simuler une requête PUT avec des données mises à jour
-        $response = $this->put(route('methods.section.update', $section->id), [
+        // Simuler une requête POST avec des données mises à jour
+        $response = $this->post(route('methods.section.update', ['id' => $section->id]), [
             'id' => $section->id,
             'ordre' => 2,
             'label' => 'Updated Section',

--- a/tests/Unit/ServicesControllerTest.php
+++ b/tests/Unit/ServicesControllerTest.php
@@ -65,7 +65,7 @@ class ServicesControllerTest extends TestCase
         ];
 
         // Exécute la requête POST
-        $response = $this->post(route('methods.service.store'), $data);
+        $response = $this->post(route('methods.service.create'), $data);
 
         // Vérifie que le service a bien été créé
         $this->assertDatabaseHas('methods_services', ['code' => 'SRV001', 'label' => 'Test Service']);
@@ -94,7 +94,7 @@ class ServicesControllerTest extends TestCase
         ];
 
         // Exécute la requête POST
-        $response = $this->post(route('methods.service.store'), $data);
+        $response = $this->post(route('methods.service.create'), $data);
 
         // Vérifie que l'erreur est retournée
         $response->assertSessionHasErrors(['msg' => 'Error, no image selected']);
@@ -118,8 +118,8 @@ class ServicesControllerTest extends TestCase
             'companies_id' => 2
         ];
 
-        // Exécute la requête PUT
-        $response = $this->put(route('methods.service.update'), $data);
+        // Exécute la requête POST
+        $response = $this->post(route('methods.service.update', ['id' => $service->id]), $data);
 
         // Vérifie que le service a été mis à jour
         $this->assertDatabaseHas('methods_services', ['id' => $service->id, 'label' => 'Updated Service']);
@@ -145,7 +145,7 @@ class ServicesControllerTest extends TestCase
         ];
 
         // Exécute la requête POST pour la mise à jour de l'image
-        $response = $this->post(route('methods.service.storeImage'), $data);
+        $response = $this->post(route('methods.service.update.picture', ['id' => $service->id]), $data);
 
         // Vérifie que l'image a bien été mise à jour
         $this->assertDatabaseHas('methods_services', ['id' => $service->id, 'picture' => $data['picture']->hashName()]);
@@ -170,7 +170,7 @@ class ServicesControllerTest extends TestCase
         ];
 
         // Exécute la requête POST pour la mise à jour de l'image sans image
-        $response = $this->post(route('methods.service.storeImage'), $data);
+        $response = $this->post(route('methods.service.update.picture', ['id' => $service->id]), $data);
 
         // Vérifie que l'erreur est retournée
         $response->assertSessionHasErrors(['msg' => 'Error, no image selected']);

--- a/tests/Unit/StandardNomenclatureControllerTest.php
+++ b/tests/Unit/StandardNomenclatureControllerTest.php
@@ -51,7 +51,7 @@ class StandardNomenclatureControllerTest extends TestCase
         ];
 
         // Act
-        $response = $this->post(route('methods.standard.nomenclature.store'), $data);
+        $response = $this->post(route('methods.standard.nomenclature.create'), $data);
 
         // Assert
         $response->assertRedirect(route('methods.standard.nomenclature'));
@@ -70,7 +70,7 @@ class StandardNomenclatureControllerTest extends TestCase
         ];
 
         // Act
-        $response = $this->post(route('methods.standard.nomenclature.store'), $data);
+        $response = $this->post(route('methods.standard.nomenclature.create'), $data);
 
         // Assert
         $response->assertSessionHasErrors(['code']);
@@ -93,7 +93,7 @@ class StandardNomenclatureControllerTest extends TestCase
         ];
 
         // Act
-        $response = $this->put(route('methods.standard.nomenclature.update', $nomenclature->id), $updateData);
+        $response = $this->post(route('methods.standard.nomenclature.update', ['id' => $nomenclature->id]), $updateData);
 
         // Assert
         $response->assertRedirect(route('methods.standard.nomenclature'));
@@ -112,7 +112,7 @@ class StandardNomenclatureControllerTest extends TestCase
         $nomenclature = MethodsStandardNomenclature::factory()->create();
 
         // Act: Sending invalid update (empty label)
-        $response = $this->put(route('methods.standard.nomenclature.update', $nomenclature->id), [
+        $response = $this->post(route('methods.standard.nomenclature.update', ['id' => $nomenclature->id]), [
             'id' => $nomenclature->id,
             'label' => '',
         ]);

--- a/tests/Unit/ToolsControllerTest.php
+++ b/tests/Unit/ToolsControllerTest.php
@@ -51,7 +51,7 @@ class ToolsControllerTest extends TestCase
     {
         $toolData = MethodsTools::factory()->make()->toArray();
 
-        $response = $this->post(route('methods.tool.store'), array_merge($toolData, [
+        $response = $this->post(route('methods.tool.create'), array_merge($toolData, [
             'picture' => UploadedFile::fake()->image('tool.jpg'),
             'ETAT' => 1
         ]));
@@ -74,7 +74,7 @@ class ToolsControllerTest extends TestCase
     {
         $toolData = MethodsTools::factory()->make()->toArray();
 
-        $response = $this->post(route('methods.tool.store'), array_merge($toolData, ['ETAT' => 1]));
+        $response = $this->post(route('methods.tool.create'), array_merge($toolData, ['ETAT' => 1]));
 
         $response->assertSessionHasErrors('msg', 'Error, no image selected');
     }
@@ -97,7 +97,7 @@ class ToolsControllerTest extends TestCase
             'etat_update' => 1,
         ];
 
-        $response = $this->patch(route('methods.tool.update', $tool->id), $updateData);
+        $response = $this->post(route('methods.tool.update', ['id' => $tool->id]), $updateData);
 
         $this->assertDatabaseHas('methods_tools', [
             'id' => $tool->id,
@@ -121,7 +121,7 @@ class ToolsControllerTest extends TestCase
 
         $tool = MethodsTools::factory()->create();
 
-        $response = $this->post(route('methods.tool.store_image', $tool->id), [
+        $response = $this->post(route('methods.tool.update.picture', ['id' => $tool->id]), [
             'id' => $tool->id,
             'picture' => UploadedFile::fake()->image('tool_image.jpg')
         ]);
@@ -143,7 +143,7 @@ class ToolsControllerTest extends TestCase
     {
         $tool = MethodsTools::factory()->create();
 
-        $response = $this->post(route('methods.tool.store_image', $tool->id), [
+        $response = $this->post(route('methods.tool.update.picture', ['id' => $tool->id]), [
             'id' => $tool->id,
         ]);
 


### PR DESCRIPTION
## Summary
- update Methods feature and unit tests to use the existing route aliases for create and update endpoints
- switch update calls to POST, provide required route parameters, and adjust expectations to match the actual redirects
- align supporting test data (e.g., id fields, mask_time_update flag) with controller requirements

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install cannot reach GitHub due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d30f7e8cb4832d9fc02e5dbd41df0c