### PR TITLE
Add supplier evaluations translation key

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -563,6 +563,7 @@ return [
     'dashboard_trans_key'                      => 'لوحة القيادة',
     'client_trans_key'                         => 'العملاء',
     'suppliers_trans_key'                      => 'الموردين',
+    'supplier_evaluations_trans_key'           => 'تقييمات الموردين',
     'view_details_trans_key'                   => 'عرض التفاصيل',
     'monthly_recap_report_trans_key'           => 'تقرير شهري ملخص',
     'monthly_recap_task_trans_key'             => 'مهمة ملخص شهري',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -622,6 +622,7 @@ return [
     'client_trans_key'                         => 'Clients',
     'new_client_trans_key'                     => 'New names',
     'suppliers_trans_key'                      => 'Suppliers',
+    'supplier_evaluations_trans_key'           => 'Supplier evaluations',
     'suppliers_client_trans_key'               => 'Clients / Suppliers',
     'view_details_trans_key'                   => 'View details',
     'monthly_recap_report_trans_key'           => 'Monthly Recap Report',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -563,6 +563,7 @@ return [
     'dashboard_trans_key'                      => 'Panel de control',
     'client_trans_key'                         => 'Clientes',
     'suppliers_trans_key'                      => 'Proveedores',
+    'supplier_evaluations_trans_key'           => 'Evaluaciones de proveedores',
     'view_details_trans_key'                   => 'Ver detalles',
     'monthly_recap_report_trans_key'           => 'Informe mensual de resumen',
     'monthly_recap_task_trans_key'             => 'Tarea mensual de resumen',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -622,6 +622,7 @@ return [
     'client_trans_key'                         => 'Clients',
     'new_client_trans_key'                     => 'Nouveaux client',
     'suppliers_trans_key'                      => 'Fournisseurs',
+    'supplier_evaluations_trans_key'           => 'Évaluations fournisseurs',
     'suppliers_client_trans_key'               => 'Client / Fournisseurs',
     'view_details_trans_key'                   => 'Voir détail',
     'monthly_recap_report_trans_key'           => 'Rapport récapitulatif mensuel',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -27,6 +27,7 @@ return [
     'dashboard_trans_key'                      => 'Bảng điều khiển',
     'client_trans_key'                         => 'Khách hàng',
     'suppliers_trans_key'                      => 'Nhà cung cấp',
+    'supplier_evaluations_trans_key'           => 'Đánh giá nhà cung cấp',
     'view_details_trans_key'                   => 'Xem chi tiết',
     'monthly_recap_report_trans_key'           => 'Monthly Recap Report',
     'monthly_recap_task_trans_key'             => 'Monthly Recap Task',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -617,6 +617,7 @@ return [
     'client_trans_key'                         => '客户',
     'new_client_trans_key'                     => '新增客户',
     'suppliers_trans_key'                      => '供应商',
+    'supplier_evaluations_trans_key'           => '供应商评估',
     'suppliers_client_trans_key'               => '客户/供应商',
     'view_details_trans_key'                   => '查看详情',
     'monthly_recap_report_trans_key'           => '月度汇总报告',


### PR DESCRIPTION
## Summary
- add the `supplier_evaluations_trans_key` string to the dashboard sections of the general content translations in English, French, Spanish, Arabic, Vietnamese, and Simplified Chinese

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d44e44a918832da0e8085a47bcc178