### PR TITLE
Add whiteboard link to top navigation

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -228,11 +228,16 @@ return [
         // Navbar items:
         [
             'type'          => 'navbar-search',
-            'text'          => 'search_trans_key',        
+            'text'          => 'search_trans_key',
             'topnav'        => true,
             'url'           => 'navbar/search',
-            'method'        => 'post', 
+            'method'        => 'post',
             'input_name'    => 'searchVal' ,
+        ],
+        [
+            'text'            => 'whiteboard_trans_key',
+            'url'             => 'collaboration/whiteboards',
+            'topnav_right'    => true,
         ],
         [
             'text'            => 'Iframe mode',

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -887,6 +887,7 @@ return [
     'new_expense_categories_trans_key'       => 'فئات مصاريف جديدة',
     
     //USER
+    'whiteboard_trans_key'               => 'لوحة بيضاء',
     'users_trans_key'                    => 'المستخدمين',
     'users_list_trans_key'               => 'قائمة المستخدمين',
     'about_trans_key'                    => 'حول',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1045,6 +1045,7 @@ return [
     'corrective_actions_class_trans_key'       => 'Corrective Actions',
     
     //USER
+    'whiteboard_trans_key'                     => 'Whiteboard',
     'users_trans_key'                          => 'Users',
     'users_list_trans_key'                     => 'Users list',
     'about_trans_key'                          => 'About',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -888,6 +888,7 @@ return [
     'new_expense_categories_trans_key'         => 'Nueva categoría de gastos',
 
     //USUARIO
+    'whiteboard_trans_key'                     => 'Pizarra',
     'users_trans_key'                          => 'Usuarios',
     'users_list_trans_key'                     => 'Lista de usuarios',
     'about_trans_key'                          => 'Acerca de',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1045,6 +1045,7 @@ return [
     'corrective_actions_class_trans_key'       => 'Actions Correctives',
 
     //USER
+    'whiteboard_trans_key'                     => 'Tableau blanc',
     'users_trans_key'                          => 'Utilisateur',
     'users_list_trans_key'                     => 'Liste des utilisateurs',
     'about_trans_key'                          => 'A propos',

--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -73,6 +73,7 @@ return [
     'risques_trans_key'                        => 'Risks',
     'formations_trans_key'                     => 'Trainings',
     'conformites_trans_key'                    => 'Conformities',
+    'whiteboard_trans_key'                     => 'Whiteboard',
     'users_trans_key'                          => 'Users',
     'your_company_trans_key'                   => 'Your company',
     'factory_settings_trans_key'               => 'Factory settings',

--- a/resources/lang/vendor/adminlte/es/menu.php
+++ b/resources/lang/vendor/adminlte/es/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Importante',
     'warning'                       => 'Advertencia',
     'information'                   => 'Información',
+    'whiteboard_trans_key'          => 'Pizarra',
 ];

--- a/resources/lang/vendor/adminlte/fr/menu.php
+++ b/resources/lang/vendor/adminlte/fr/menu.php
@@ -73,6 +73,7 @@ return [
     'risques_trans_key'                        => 'Risque',
     'formations_trans_key'                     => 'Formations',
     'conformites_trans_key'                    => 'Conformités',
+    'whiteboard_trans_key'                     => 'Tableau blanc',
     'users_trans_key'                          => 'Utilisateurs',
     'your_company_trans_key'                   => 'Votre entreprise',
     'factory_settings_trans_key'               => 'Réglage société',

--- a/resources/lang/vendor/adminlte/zh-CN/menu.php
+++ b/resources/lang/vendor/adminlte/zh-CN/menu.php
@@ -73,6 +73,7 @@ return [
     'risques_trans_key'                        => '风险',
     'formations_trans_key'                     => '培训',
     'conformites_trans_key'                    => '合规',
+    'whiteboard_trans_key'                     => '白板',
     'users_trans_key'                          => '用户',
     'your_company_trans_key'                   => '您的公司',
     'factory_settings_trans_key'               => '公司设置',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -1040,6 +1040,7 @@ return [
     'corrective_actions_class_trans_key'       => '纠正措施',
 
     //USER
+    'whiteboard_trans_key'                     => '白板',
     'users_trans_key'                          => '用户',
     'users_list_trans_key'                     => '用户列表',
     'about_trans_key'                          => '关于',


### PR DESCRIPTION
## Summary
- add a whiteboard entry to the top navigation before the iframe mode link
- provide translations for the new menu label in the supported languages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d454465588832da9e7e8628fdcdbd2