### PR TITLE
Add whiteboard routes and controllers

### DIFF
--- a/app/Http/Controllers/Api/Collaboration/WhiteboardController.php
+++ b/app/Http/Controllers/Api/Collaboration/WhiteboardController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api\Collaboration;
+
+use App\Http\Controllers\Controller;
+use App\Models\Collaboration\Whiteboard;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WhiteboardController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $whiteboards = Whiteboard::query()
+            ->latest()
+            ->get();
+
+        return response()->json($whiteboards);
+    }
+
+    public function show(Whiteboard $whiteboard): JsonResponse
+    {
+        $whiteboard->load(['snapshots' => fn ($query) => $query->latest(), 'files' => fn ($query) => $query->latest()]);
+
+        return response()->json($whiteboard);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validateWhiteboard($request);
+        $userId = optional($request->user())->id;
+
+        $whiteboard = new Whiteboard();
+        $whiteboard->fill($data);
+        $whiteboard->created_by = $userId;
+        $whiteboard->updated_by = $userId;
+        $whiteboard->save();
+
+        $whiteboard = $whiteboard->fresh();
+        $whiteboard->load(['snapshots' => fn ($query) => $query->latest(), 'files' => fn ($query) => $query->latest()]);
+
+        return response()->json($whiteboard);
+    }
+
+    public function update(Request $request, Whiteboard $whiteboard): JsonResponse
+    {
+        $data = $this->validateWhiteboard($request);
+        $userId = optional($request->user())->id;
+
+        $whiteboard->fill($data);
+        $whiteboard->updated_by = $userId;
+        $whiteboard->save();
+
+        $whiteboard = $whiteboard->fresh();
+        $whiteboard->load(['snapshots' => fn ($query) => $query->latest(), 'files' => fn ($query) => $query->latest()]);
+
+        return response()->json($whiteboard);
+    }
+
+    protected function validateWhiteboard(Request $request): array
+    {
+        $validated = $request->validate([
+            'title' => ['nullable', 'string', 'max:255'],
+            'state' => ['nullable'],
+        ]);
+
+        if (!array_key_exists('title', $validated)) {
+            $validated['title'] = $request->input('title');
+        }
+
+        if (!array_key_exists('state', $validated)) {
+            $validated['state'] = $request->input('state');
+        }
+
+        if (!$validated['title']) {
+            $validated['title'] = 'Nouveau tableau';
+        }
+
+        return $validated;
+    }
+}

--- a/app/Http/Controllers/Api/Collaboration/WhiteboardFileController.php
+++ b/app/Http/Controllers/Api/Collaboration/WhiteboardFileController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\Collaboration;
+
+use App\Http\Controllers\Controller;
+use App\Models\Collaboration\Whiteboard;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WhiteboardFileController extends Controller
+{
+    public function index(Whiteboard $whiteboard): JsonResponse
+    {
+        $files = $whiteboard->files()
+            ->latest()
+            ->get();
+
+        return response()->json($files);
+    }
+
+    public function store(Request $request, Whiteboard $whiteboard): JsonResponse
+    {
+        $request->validate([
+            'files' => ['required', 'array'],
+            'files.*' => ['file', 'max:10240'],
+        ]);
+
+        $userId = optional($request->user())->id;
+        $savedFiles = [];
+
+        foreach ($request->file('files', []) as $uploadedFile) {
+            $path = $uploadedFile->store('whiteboards', ['disk' => 'public']);
+
+            $file = $whiteboard->files()->create([
+                'original_name' => $uploadedFile->getClientOriginalName(),
+                'path' => $path,
+                'mime_type' => $uploadedFile->getClientMimeType(),
+                'size' => $uploadedFile->getSize(),
+                'uploaded_by' => $userId,
+            ]);
+
+            $savedFiles[] = $file;
+        }
+
+        return response()->json($savedFiles, 201);
+    }
+}

--- a/app/Http/Controllers/Api/Collaboration/WhiteboardSnapshotController.php
+++ b/app/Http/Controllers/Api/Collaboration/WhiteboardSnapshotController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api\Collaboration;
+
+use App\Http\Controllers\Controller;
+use App\Models\Collaboration\Whiteboard;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WhiteboardSnapshotController extends Controller
+{
+    public function index(Whiteboard $whiteboard): JsonResponse
+    {
+        $snapshots = $whiteboard->snapshots()
+            ->latest()
+            ->get();
+
+        return response()->json($snapshots);
+    }
+
+    public function store(Request $request, Whiteboard $whiteboard): JsonResponse
+    {
+        $data = $request->validate([
+            'state' => ['required'],
+        ]);
+
+        $snapshot = $whiteboard->snapshots()->create([
+            'state' => $data['state'],
+            'created_by' => optional($request->user())->id,
+        ]);
+
+        return response()->json($snapshot, 201);
+    }
+}

--- a/app/Http/Controllers/Collaboration/WhiteboardController.php
+++ b/app/Http/Controllers/Collaboration/WhiteboardController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Collaboration;
+
+use App\Http\Controllers\Controller;
+use App\Models\Collaboration\Whiteboard;
+use Illuminate\Contracts\View\View;
+
+class WhiteboardController extends Controller
+{
+    public function show(?Whiteboard $whiteboard = null): View
+    {
+        $board = $whiteboard
+            ? $whiteboard->load(['snapshots' => fn ($query) => $query->latest()->limit(20), 'files' => fn ($query) => $query->latest()])
+            : Whiteboard::with(['snapshots' => fn ($query) => $query->latest()->limit(20), 'files' => fn ($query) => $query->latest()])
+                ->latest()
+                ->first();
+
+        return view('collaboration.whiteboard-index', [
+            'whiteboard' => $board,
+            'snapshots' => $board?->snapshots ?? [],
+            'files' => $board?->files ?? [],
+            'endpoints' => [],
+        ]);
+    }
+}

--- a/app/Models/Collaboration/Whiteboard.php
+++ b/app/Models/Collaboration/Whiteboard.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Collaboration;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Whiteboard extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'state',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'state' => 'array',
+    ];
+
+    public function snapshots()
+    {
+        return $this->hasMany(WhiteboardSnapshot::class);
+    }
+
+    public function files()
+    {
+        return $this->hasMany(WhiteboardFile::class);
+    }
+}

--- a/app/Models/Collaboration/WhiteboardFile.php
+++ b/app/Models/Collaboration/WhiteboardFile.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models\Collaboration;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+class WhiteboardFile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'whiteboard_id',
+        'original_name',
+        'path',
+        'mime_type',
+        'size',
+        'uploaded_by',
+    ];
+
+    protected $appends = [
+        'url',
+    ];
+
+    protected $hidden = [
+        'path',
+    ];
+
+    public function whiteboard()
+    {
+        return $this->belongsTo(Whiteboard::class);
+    }
+
+    public function getUrlAttribute(): ?string
+    {
+        if (!$this->path) {
+            return null;
+        }
+
+        return Storage::disk('public')->url($this->path);
+    }
+}

--- a/app/Models/Collaboration/WhiteboardSnapshot.php
+++ b/app/Models/Collaboration/WhiteboardSnapshot.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Collaboration;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WhiteboardSnapshot extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'whiteboard_id',
+        'state',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'state' => 'array',
+    ];
+
+    public function whiteboard()
+    {
+        return $this->belongsTo(Whiteboard::class);
+    }
+}

--- a/database/migrations/2025_10_05_000000_create_whiteboards_table.php
+++ b/database/migrations/2025_10_05_000000_create_whiteboards_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('whiteboards', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->json('state')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('whiteboards');
+    }
+};

--- a/database/migrations/2025_10_05_000100_create_whiteboard_snapshots_table.php
+++ b/database/migrations/2025_10_05_000100_create_whiteboard_snapshots_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('whiteboard_snapshots', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('whiteboard_id')->constrained('whiteboards')->cascadeOnDelete();
+            $table->json('state');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('whiteboard_snapshots');
+    }
+};

--- a/database/migrations/2025_10_05_000200_create_whiteboard_files_table.php
+++ b/database/migrations/2025_10_05_000200_create_whiteboard_files_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('whiteboard_files', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('whiteboard_id')->constrained('whiteboards')->cascadeOnDelete();
+            $table->string('original_name');
+            $table->string('path');
+            $table->string('mime_type')->nullable();
+            $table->unsignedBigInteger('size')->nullable();
+            $table->unsignedBigInteger('uploaded_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('uploaded_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('whiteboard_files');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,9 @@ use App\Http\Controllers\Api\QuoteController;
 use App\Http\Controllers\Api\CompanyController;
 use App\Http\Controllers\Api\EnergyConsumptionController;
 use App\Http\Controllers\Api\ExportSalesOrderController;
+use App\Http\Controllers\Api\Collaboration\WhiteboardController as ApiWhiteboardController;
+use App\Http\Controllers\Api\Collaboration\WhiteboardSnapshotController;
+use App\Http\Controllers\Api\Collaboration\WhiteboardFileController;
 
 /*
 |--------------------------------------------------------------------------
@@ -37,3 +40,17 @@ Route::apiResource('order',OrderController::class);
 Route::apiResource('tasks', TaskController::class);
 Route::apiResource('energy-consumptions', EnergyConsumptionController::class)->only(['index','store']);
 Route::get('/exports/sales-orders', ExportSalesOrderController::class);
+
+Route::prefix('collaboration/whiteboards')->name('api.collaboration.whiteboards.')->group(function () {
+    Route::get('/', [ApiWhiteboardController::class, 'index'])->name('index');
+    Route::post('/', [ApiWhiteboardController::class, 'store'])->name('store');
+    Route::get('/{whiteboard}', [ApiWhiteboardController::class, 'show'])->name('show');
+    Route::put('/{whiteboard}', [ApiWhiteboardController::class, 'update'])->name('update');
+
+    Route::get('/{whiteboard}/snapshots', [WhiteboardSnapshotController::class, 'index'])->name('snapshots.index');
+    Route::post('/{whiteboard}/snapshots', [WhiteboardSnapshotController::class, 'store'])->name('snapshots.store');
+
+    Route::get('/{whiteboard}/files', [WhiteboardFileController::class, 'index'])->name('files.index');
+    Route::post('/{whiteboard}/files', [WhiteboardFileController::class, 'store'])->name('files.store');
+});
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Livewire\Livewire;
+use App\Http\Controllers\Collaboration\WhiteboardController as CollaborationWhiteboardController;
 use Illuminate\Support\Facades\Route;
 use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 use App\Http\Controllers\ProductionTraceController;
@@ -29,6 +30,11 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     Route::post('/order/ratings', 'App\Http\Controllers\Workflow\OrdersRatingController@store')->name('order.ratings.store');
 
     Route::get('/dashboard', 'App\Http\Controllers\HomeController@index')->middleware(['auth', 'check.factory'])->name('dashboard');
+    Route::group(['prefix' => 'collaboration', 'middleware' => ['auth', 'check.factory']], function () {
+        Route::get('/whiteboards', [CollaborationWhiteboardController::class, 'show'])->name('collaboration.whiteboards.index');
+        Route::get('/whiteboards/{whiteboard}', [CollaborationWhiteboardController::class, 'show'])->name('collaboration.whiteboards.show');
+    });
+
 
     Route::group(['prefix' => 'workshop', 'middleware' => ['auth', 'check.factory']], function () {
         Route::get('/', 'App\Http\Controllers\Workshop\WorkshopController@index')->middleware(['auth', 'check.factory'])->name('workshop');


### PR DESCRIPTION
## Summary
- add web and API routes for the collaborative whiteboard module
- implement controllers and models to manage whiteboards, snapshots, and file uploads
- introduce database tables for whiteboards, snapshots, and stored files

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d45c073d84832d8e011353b01777cd