### PR TITLE
Improve notification dropdown layout

### DIFF
--- a/app/Http/Controllers/NotificationsController.php
+++ b/app/Http/Controllers/NotificationsController.php
@@ -61,10 +61,12 @@ class NotificationsController extends Controller
         // Now, we create the notification dropdown main content.
         $dropdownHtml = '';
         foreach ($notifications as $key => $not) {
-            $icon = "<i class='mr-2 {$not['icon']}'></i>";
-            $time = "<span class='float-right text-muted text-sm'>{$not['time']}</span>";
-            $dropdownHtml .= "<a href='{$not['route']}' class='dropdown-item'>{$icon}{$not['text']}{$time}</a>";
-    
+            $icon = "<span class='notification-icon mr-2'><i class='{$not['icon']} fa-fw'></i></span>";
+            $text = "<span class='notification-text'>{$not['text']}</span>";
+            $time = "<span class='notification-time text-muted text-sm'>{$not['time']}</span>";
+            $content = "<div class='notification-content flex-fill'>{$text}{$time}</div>";
+            $dropdownHtml .= "<a href='{$not['route']}' class='dropdown-item notification-item d-flex align-items-start'>{$icon}{$content}</a>";
+
             if ($key < count($notifications) - 1) {
                 $dropdownHtml .= "<div class='dropdown-divider'></div>";
             }

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -133,3 +133,36 @@
 .place-3 {
     background-color: bronze;
 }
+
+/* Notifications dropdown */
+#my-notification .dropdown-menu {
+    width: 22rem;
+    max-width: calc(100vw - 2rem);
+}
+
+#my-notification .dropdown-menu .notification-item {
+    white-space: normal;
+    gap: 0.75rem;
+}
+
+#my-notification .dropdown-menu .notification-icon {
+    font-size: 1.1rem;
+    line-height: 1;
+    margin-top: 0.15rem;
+}
+
+#my-notification .dropdown-menu .notification-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+#my-notification .dropdown-menu .notification-text {
+    font-weight: 500;
+    word-break: break-word;
+}
+
+#my-notification .dropdown-menu .notification-time {
+    font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- rework the notification dropdown HTML structure to better handle long texts and align metadata
- add custom styles to constrain the dropdown width and improve notification spacing

## Testing
- phpunit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d45d6d7e08832d992ee8e4309e6420