### PR TITLE
Add inspection tracking to purchase receipt lines

### DIFF
--- a/app/Http/Controllers/Purchases/PurchasesReceiptController.php
+++ b/app/Http/Controllers/Purchases/PurchasesReceiptController.php
@@ -8,10 +8,13 @@ use App\Models\Purchases\Purchases;
 use App\Services\SelectDataService;
 use App\Http\Controllers\Controller;
 use App\Services\CustomFieldService;
+use App\Services\DocumentCodeGenerator;
 use App\Services\PurchaseKPIService;
+use App\Services\QualityNonConformityService;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Products\StockLocation;
 use App\Models\Purchases\PurchaseReceipt;
+use App\Models\Quality\QualityNonConformity;
 use App\Models\Products\StockLocationProducts;
 use App\Models\Purchases\PurchaseReceiptLines;
 use App\Http\Requests\Purchases\UpdatePurchaseRequest;
@@ -25,6 +28,8 @@ class PurchasesReceiptController extends Controller
     protected $purchaseKPIService;
     protected $customFieldService;
     protected $purchaseOrderService;
+    protected $qualityNonConformityService;
+    protected $documentCodeGenerator;
 
     /**
      * Constructor to initialize services.
@@ -34,13 +39,17 @@ class PurchasesReceiptController extends Controller
      * @param CustomFieldService $customFieldService
      */
     public function __construct(
-            SelectDataService $SelectDataService, 
+            SelectDataService $SelectDataService,
             PurchaseKPIService $purchaseKPIService,
             CustomFieldService $customFieldService,
+            QualityNonConformityService $qualityNonConformityService,
+            DocumentCodeGenerator $documentCodeGenerator,
         ){
         $this->SelectDataService = $SelectDataService;
         $this->purchaseKPIService = $purchaseKPIService;
         $this->customFieldService = $customFieldService;
+        $this->qualityNonConformityService = $qualityNonConformityService;
+        $this->documentCodeGenerator = $documentCodeGenerator;
     }
     
     
@@ -65,6 +74,8 @@ class PurchasesReceiptController extends Controller
         
         $StockLocationList = StockLocation::all();
         $StockLocationProductList = StockLocationProducts::all();
+        $userSelect = $this->SelectDataService->getUsers();
+        $nonConformities = $this->SelectDataService->getQualityNonConformity();
         list($previousUrl, $nextUrl) = $this->getNextPrevious(new PurchaseReceipt(), $id->id);
 
         $averageReceptionDelay = PurchaseReceiptLines::join('purchase_lines', 'purchase_receipt_lines.purchase_line_id', '=', 'purchase_lines.id')
@@ -78,7 +89,9 @@ class PurchasesReceiptController extends Controller
             'nextUrl' =>  $nextUrl,
             'StockLocationList' =>  $StockLocationList,
             'StockLocationProductList' =>  $StockLocationProductList,
-            'averageReceptionDelay' => $averageReceptionDelay->avg_reception_delay
+            'averageReceptionDelay' => $averageReceptionDelay->avg_reception_delay,
+            'userSelect' => $userSelect,
+            'nonConformities' => $nonConformities,
         ]);
     }
 
@@ -144,8 +157,99 @@ class PurchasesReceiptController extends Controller
      * @return \Illuminate\Contracts\View\View
      */
     public function receipt()
-    {    
+    {
         $data['PurchaseReciepCountDataRate'] = $this->purchaseKPIService->getPurchaseReciepCountDataRate();
         return view('purchases/purchases-receipt')->with('data',$data);
+    }
+
+    /**
+     * Update inspection related data for a purchase receipt line.
+     */
+    public function updateLineInspection(Request $request, PurchaseReceiptLines $purchaseReceiptLine)
+    {
+        $validated = $request->validate([
+            'inspected_by' => 'nullable|exists:users,id',
+            'inspection_date' => 'nullable|date',
+            'accepted_qty' => 'nullable|integer|min:0',
+            'rejected_qty' => 'nullable|integer|min:0',
+            'inspection_result' => 'nullable|string|max:255',
+            'quality_non_conformity_id' => 'nullable|exists:quality_non_conformities,id',
+            'create_non_conformity' => 'nullable|boolean',
+            'new_nc_label' => 'nullable|string|max:255',
+            'new_nc_comment' => 'nullable|string|max:1000',
+        ]);
+
+        $purchaseReceiptLine->loadMissing('purchaseLines.purchase', 'purchaseLines.tasks.OrderLines');
+
+        $acceptedQty = array_key_exists('accepted_qty', $validated)
+            ? (int) ($validated['accepted_qty'] ?? 0)
+            : ($purchaseReceiptLine->accepted_qty ?? 0);
+
+        $rejectedQty = array_key_exists('rejected_qty', $validated)
+            ? (int) ($validated['rejected_qty'] ?? 0)
+            : ($purchaseReceiptLine->rejected_qty ?? 0);
+
+        $totalInspected = $acceptedQty + $rejectedQty;
+
+        if ($totalInspected > $purchaseReceiptLine->receipt_qty) {
+            return redirect()->back()->withErrors([
+                'accepted_qty' => __('general_content.inspection_qty_error_trans_key', [
+                    'receipt' => $purchaseReceiptLine->receipt_qty,
+                ]),
+            ])->withInput();
+        }
+
+        if ($request->boolean('create_non_conformity') && empty($validated['quality_non_conformity_id'])) {
+            $qualityNonConformity = $this->createQuickNonConformity(
+                $purchaseReceiptLine,
+                $validated['new_nc_label'] ?? null,
+                $validated['new_nc_comment'] ?? null,
+                $rejectedQty
+            );
+
+            $validated['quality_non_conformity_id'] = $qualityNonConformity->id;
+        }
+
+        $purchaseReceiptLine->update([
+            'inspected_by' => $validated['inspected_by'] ?? null,
+            'inspection_date' => $validated['inspection_date'] ?? null,
+            'accepted_qty' => $acceptedQty,
+            'rejected_qty' => $rejectedQty,
+            'inspection_result' => $validated['inspection_result'] ?? null,
+            'quality_non_conformity_id' => $validated['quality_non_conformity_id'] ?? null,
+        ]);
+
+        return redirect()->back()->with('success', __('general_content.inspection_update_success_trans_key'));
+    }
+
+    protected function createQuickNonConformity(
+        PurchaseReceiptLines $purchaseReceiptLine,
+        ?string $label,
+        ?string $comment,
+        ?int $rejectedQty
+    ): QualityNonConformity {
+        $lastNonConformity = QualityNonConformity::latest('id')->first();
+        $code = $this->documentCodeGenerator->generateDocumentCode('non-conformities', $lastNonConformity?->id ?? 0);
+        $label = $label ?: $code;
+
+        $data = [
+            'code' => $code,
+            'label' => $label,
+            'statu' => 1,
+            'user_id' => Auth::id(),
+            'companie_id' => optional($purchaseReceiptLine->purchaseLines->purchase)->companies_id,
+            'qty' => $rejectedQty ?? $purchaseReceiptLine->receipt_qty,
+        ];
+
+        if ($comment) {
+            $data['failure_comment'] = $comment;
+        }
+
+        $orderLine = optional($purchaseReceiptLine->purchaseLines->tasks)->OrderLines;
+        if ($orderLine) {
+            $data['order_lines_id'] = $orderLine->id;
+        }
+
+        return $this->qualityNonConformityService->createNonConformity($data);
     }
 }

--- a/app/Livewire/PurchasesWaintingReceipt.php
+++ b/app/Livewire/PurchasesWaintingReceipt.php
@@ -49,6 +49,12 @@ class PurchasesWaintingReceipt extends Component
             'label' =>'required',
             'companies_id'=>'required',
             'user_id'=>'required',
+            'data.*.accepted_qty' => 'nullable|integer|min:0',
+            'data.*.rejected_qty' => 'nullable|integer|min:0',
+            'data.*.inspection_result' => 'nullable|string|max:255',
+            'data.*.inspection_date' => 'nullable|date',
+            'data.*.inspected_by' => 'nullable|exists:users,id',
+            'data.*.quality_non_conformity_id' => 'nullable|exists:quality_non_conformities,id',
         ];
     }
     

--- a/app/Models/Purchases/PurchaseReceiptLines.php
+++ b/app/Models/Purchases/PurchaseReceiptLines.php
@@ -5,8 +5,10 @@ namespace App\Models\Purchases;
 use App\Models\Products\StockMove;
 use App\Models\Purchases\PurchaseLines;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Quality\QualityNonConformity;
 use App\Models\Products\StockLocationProducts;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\User;
 
 class PurchaseReceiptLines extends Model
 {
@@ -19,6 +21,21 @@ class PurchaseReceiptLines extends Model
         'ordre',
         'receipt_qty',
         'stock_location_products_id',
+        'inspected_by',
+        'inspection_date',
+        'accepted_qty',
+        'rejected_qty',
+        'inspection_result',
+        'quality_non_conformity_id',
+    ];
+
+    /**
+     * Cast attributes to common representations.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'inspection_date' => 'date',
     ];
 
     public function purchaseReceipt()
@@ -39,6 +56,16 @@ class PurchaseReceiptLines extends Model
     public function StockMove()
     {
         return $this->hasMany(StockMove::class);
+    }
+
+    public function inspector()
+    {
+        return $this->belongsTo(User::class, 'inspected_by');
+    }
+
+    public function qualityNonConformity()
+    {
+        return $this->belongsTo(QualityNonConformity::class, 'quality_non_conformity_id');
     }
 
     /**

--- a/app/Services/PurchaseKPIService.php
+++ b/app/Services/PurchaseKPIService.php
@@ -108,9 +108,28 @@ class PurchaseKPIService
         $averageReceptionDelayBySupplier = PurchaseReceiptLines::join('purchase_lines', 'purchase_receipt_lines.purchase_line_id', '=', 'purchase_lines.id')
             ->join('purchases', 'purchase_lines.purchases_id', '=', 'purchases.id')
             ->join('companies', 'purchases.companies_id', '=', 'companies.id')
-            ->selectRaw('companies.label AS supplier_name, AVG(DATEDIFF(purchase_receipt_lines.created_at, purchase_lines.created_at)) AS avg_reception_delay')
+            ->selectRaw('
+                companies.label AS supplier_name,
+                AVG(DATEDIFF(purchase_receipt_lines.created_at, purchase_lines.created_at)) AS avg_reception_delay,
+                SUM(COALESCE(purchase_receipt_lines.accepted_qty, purchase_receipt_lines.receipt_qty, 0)) AS total_accepted_qty,
+                SUM(COALESCE(purchase_receipt_lines.rejected_qty, 0)) AS total_rejected_qty,
+                SUM(COALESCE(purchase_receipt_lines.accepted_qty, purchase_receipt_lines.receipt_qty, 0) + COALESCE(purchase_receipt_lines.rejected_qty, 0)) AS total_inspected_qty,
+                CASE
+                    WHEN SUM(COALESCE(purchase_receipt_lines.accepted_qty, purchase_receipt_lines.receipt_qty, 0) + COALESCE(purchase_receipt_lines.rejected_qty, 0)) > 0
+                        THEN SUM(COALESCE(purchase_receipt_lines.accepted_qty, purchase_receipt_lines.receipt_qty, 0)) /
+                             SUM(COALESCE(purchase_receipt_lines.accepted_qty, purchase_receipt_lines.receipt_qty, 0) + COALESCE(purchase_receipt_lines.rejected_qty, 0))
+                    ELSE NULL
+                END AS compliance_rate'
+            )
             ->groupBy('companies.label')
-            ->get();
+            ->get()
+            ->map(function ($supplier) {
+                $supplier->compliance_rate = is_null($supplier->compliance_rate)
+                    ? null
+                    : (float) $supplier->compliance_rate;
+
+                return $supplier;
+            });
 
         return $averageReceptionDelayBySupplier->sortBy('avg_reception_delay');
     }

--- a/database/migrations/2025_09_23_161656_add_inspection_fields_to_purchase_receipt_lines_table.php
+++ b/database/migrations/2025_09_23_161656_add_inspection_fields_to_purchase_receipt_lines_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('purchase_receipt_lines', function (Blueprint $table) {
+            $table->foreignId('inspected_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->date('inspection_date')->nullable();
+            $table->integer('accepted_qty')->default(0);
+            $table->integer('rejected_qty')->default(0);
+            $table->string('inspection_result')->nullable();
+            $table->foreignId('quality_non_conformity_id')->nullable()->constrained('quality_non_conformities')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('purchase_receipt_lines', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('quality_non_conformity_id');
+            $table->dropColumn('inspection_result');
+            $table->dropColumn('rejected_qty');
+            $table->dropColumn('accepted_qty');
+            $table->dropColumn('inspection_date');
+            $table->dropConstrainedForeignId('inspected_by');
+        });
+    }
+};

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -796,6 +796,16 @@ return [
     //PURCHASE RECIEPT
     'po_receipt_trans_key'                => 'استلام أمر الشراء',
     'name_purchase_reciept_trans_key'     => 'اسم الاستلام',
+    'po_receipt_note_trans_key'           => 'استلام بانتظار الفحص',
+    'validate_control_trans_key'          => 'تأكيد الفحص',
+    'inspection_details_trans_key'        => 'تفاصيل الفحص',
+    'inspection_result_trans_key'         => 'نتيجة الفحص',
+    'inspection_date_trans_key'           => 'تاريخ الفحص',
+    'inspected_by_trans_key'              => 'تم الفحص بواسطة',
+    'select_option_trans_key'             => 'اختر خياراً',
+    'quick_nc_creation_trans_key'         => 'إنشاء سريع لعدم المطابقة',
+    'inspection_qty_error_trans_key'      => 'لا يمكن أن تتجاوز الكميات المقبولة والمرفوضة الكمية المستلمة (:receipt).',
+    'inspection_update_success_trans_key' => 'تم تحديث بيانات الفحص بنجاح.',
 
     'waiting_to_invoice_trans_key'        => 'في انتظار الفاتورة',
 

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -930,6 +930,14 @@ return [
     'name_purchase_reciept_trans_key'          => 'Name of receipt',
     'po_receipt_note_trans_key'                => 'Reception awaiting inspection',
     'validate_control_trans_key'               => 'Validate inspection',
+    'inspection_details_trans_key'             => 'Inspection details',
+    'inspection_result_trans_key'              => 'Inspection result',
+    'inspection_date_trans_key'                => 'Inspection date',
+    'inspected_by_trans_key'                   => 'Inspected by',
+    'select_option_trans_key'                  => 'Select an option',
+    'quick_nc_creation_trans_key'              => 'Quick NC creation',
+    'inspection_qty_error_trans_key'           => 'Accepted and rejected quantities cannot exceed the received quantity (:receipt).',
+    'inspection_update_success_trans_key'      => 'Inspection data updated successfully.',
 
     'waiting_to_invoice_trans_key'             => 'Waiting to invoice',
 

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -797,6 +797,16 @@ return [
     //PURCHASE RECEIPT
     'po_receipt_trans_key'                     => 'Recibo de la orden de compra',
     'name_purchase_reciept_trans_key'          => 'Nombre del recibo',
+    'po_receipt_note_trans_key'                => 'Recepción en espera de control',
+    'validate_control_trans_key'               => 'Validar control',
+    'inspection_details_trans_key'             => 'Detalles de inspección',
+    'inspection_result_trans_key'              => 'Resultado de la inspección',
+    'inspection_date_trans_key'                => 'Fecha de inspección',
+    'inspected_by_trans_key'                   => 'Inspeccionado por',
+    'select_option_trans_key'                  => 'Seleccione una opción',
+    'quick_nc_creation_trans_key'              => 'Creación rápida de NC',
+    'inspection_qty_error_trans_key'           => 'Las cantidades aceptadas y rechazadas no pueden superar la cantidad recibida (:receipt).',
+    'inspection_update_success_trans_key'      => 'Datos de inspección actualizados correctamente.',
 
     'waiting_to_invoice_trans_key'             => 'Esperando factura',
 

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -930,6 +930,14 @@ return [
     'name_purchase_reciept_trans_key'          => 'Nom du reçu',
     'po_receipt_note_trans_key'                => 'Reception en attente de controle',
     'validate_control_trans_key'               => 'Valider le contrôle',
+    'inspection_details_trans_key'             => "Détails d'inspection",
+    'inspection_result_trans_key'              => "Résultat d'inspection",
+    'inspection_date_trans_key'                => "Date d'inspection",
+    'inspected_by_trans_key'                   => 'Inspecté par',
+    'select_option_trans_key'                  => 'Sélectionner une option',
+    'quick_nc_creation_trans_key'              => "Création rapide d'une NC",
+    'inspection_qty_error_trans_key'           => 'Les quantités acceptées et rejetées ne peuvent pas dépasser la quantité reçue (:receipt).',
+    'inspection_update_success_trans_key'      => "Les données d'inspection ont été mises à jour avec succès.",
 
     'waiting_to_invoice_trans_key'             => 'Attente de facturation',
 

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -922,9 +922,17 @@ return [
 
     //PURCHASE RECIEPT
     'po_receipt_trans_key'                     => '采购收货',
-    'name_purchase_reciept_trans_key'          => '收据名称',
-    'po_receipt_note_trans_key'                => '收货等待检验',
-    'validate_control_trans_key'               => '确认检验',
+   'name_purchase_reciept_trans_key'          => '收据名称',
+   'po_receipt_note_trans_key'                => '收货等待检验',
+   'validate_control_trans_key'               => '确认检验',
+    'inspection_details_trans_key'             => '检验详情',
+    'inspection_result_trans_key'              => '检验结果',
+    'inspection_date_trans_key'                => '检验日期',
+    'inspected_by_trans_key'                   => '检验人',
+    'select_option_trans_key'                  => '请选择一个选项',
+    'quick_nc_creation_trans_key'              => '快速创建不合格项',
+    'inspection_qty_error_trans_key'           => '合格与拒收数量之和不能超过收货数量(:receipt)。',
+    'inspection_update_success_trans_key'      => '检验数据已成功更新。',
 
     'waiting_to_invoice_trans_key'             => '待开票',
 

--- a/resources/views/purchases/purchases-receipt-show.blade.php
+++ b/resources/views/purchases/purchases-receipt-show.blade.php
@@ -132,6 +132,12 @@
                   <th>{{ __('general_content.qty_trans_key') }}</th>
                   <th>{{ __('general_content.qty_purchase_trans_key') }}</th>
                   <th>{{ __('general_content.qty_reciept_trans_key') }}</th>
+                  <th>{{ __('general_content.qty_accepted_trans_key') }}</th>
+                  <th>{{ __('general_content.quantity_rejected_trans_key') }}</th>
+                  <th>{{ __('general_content.inspection_result_trans_key') }}</th>
+                  <th>{{ __('general_content.inspection_date_trans_key') }}</th>
+                  <th>{{ __('general_content.inspected_by_trans_key') }}</th>
+                  <th>{{ __('general_content.non_conformitie_trans_key') }}</th>
                   <th>{{__('general_content.action_trans_key') }}</th>
                 </tr>
               </thead>
@@ -196,8 +202,101 @@
                     </td>
                     <td>{{ number_format($PurchaseReceiptLine->purchaseLines->qty, 0, '', ' ') }}</td>
                     <td>{{ number_format($PurchaseReceiptLine->receipt_qty, 0, '', ' ') }}</td>
-                    
+                    <td>{{ number_format($PurchaseReceiptLine->accepted_qty ?? 0, 0, '', ' ') }}</td>
+                    <td>{{ number_format($PurchaseReceiptLine->rejected_qty ?? 0, 0, '', ' ') }}</td>
+                    <td>{{ $PurchaseReceiptLine->inspection_result ?? __('general_content.no_data_trans_key') }}</td>
                     <td>
+                      @if($PurchaseReceiptLine->inspection_date)
+                        {{ $PurchaseReceiptLine->inspection_date->format('d/m/Y') }}
+                      @else
+                        {{ __('general_content.no_data_trans_key') }}
+                      @endif
+                    </td>
+                    <td>{{ optional($PurchaseReceiptLine->inspector)->name ?? __('general_content.no_data_trans_key') }}</td>
+                    <td>
+                      @if($PurchaseReceiptLine->qualityNonConformity)
+                        {{ $PurchaseReceiptLine->qualityNonConformity->code }}
+                      @else
+                        {{ __('general_content.no_data_trans_key') }}
+                      @endif
+                    </td>
+
+                    <td>
+                      <div class="mb-2">
+                        <button type="button" class="btn btn-outline-primary btn-sm" data-toggle="modal" data-target="#purchaseReceiptLineInspection{{ $PurchaseReceiptLine->id }}">
+                          <i class="fas fa-clipboard-check"></i> {{ __('general_content.inspection_details_trans_key') }}
+                        </button>
+                      </div>
+                      <x-adminlte-modal id="purchaseReceiptLineInspection{{ $PurchaseReceiptLine->id }}" title="{{ __('general_content.inspection_details_trans_key') }}" theme="teal" icon="fas fa-clipboard-check" size='lg' disable-animations>
+                        <form method="POST" action="{{ route('purchase.receipts.lines.update', $PurchaseReceiptLine->id) }}">
+                          @csrf
+                          <div class="form-row">
+                            <div class="form-group col-md-6">
+                              <label for="inspected_by_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.inspected_by_trans_key') }}</label>
+                              <select class="form-control" name="inspected_by" id="inspected_by_{{ $PurchaseReceiptLine->id }}">
+                                <option value="">{{ __('general_content.select_option_trans_key') }}</option>
+                                @foreach ($userSelect as $user)
+                                  <option value="{{ $user->id }}" @if($PurchaseReceiptLine->inspected_by == $user->id) selected @endif>{{ $user->name }}</option>
+                                @endforeach
+                              </select>
+                            </div>
+                            <div class="form-group col-md-6">
+                              <label for="inspection_date_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.inspection_date_trans_key') }}</label>
+                              <input type="date" class="form-control" name="inspection_date" id="inspection_date_{{ $PurchaseReceiptLine->id }}" value="{{ optional($PurchaseReceiptLine->inspection_date)->format('Y-m-d') }}">
+                            </div>
+                          </div>
+                          <div class="form-row">
+                            <div class="form-group col-md-4">
+                              <label for="accepted_qty_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.qty_accepted_trans_key') }}</label>
+                              <input type="number" min="0" class="form-control" name="accepted_qty" id="accepted_qty_{{ $PurchaseReceiptLine->id }}" value="{{ $PurchaseReceiptLine->accepted_qty }}">
+                              @error('accepted_qty') <span class="text-danger">{{ $message }}</span> @enderror
+                            </div>
+                            <div class="form-group col-md-4">
+                              <label for="rejected_qty_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.quantity_rejected_trans_key') }}</label>
+                              <input type="number" min="0" class="form-control" name="rejected_qty" id="rejected_qty_{{ $PurchaseReceiptLine->id }}" value="{{ $PurchaseReceiptLine->rejected_qty }}">
+                              @error('rejected_qty') <span class="text-danger">{{ $message }}</span> @enderror
+                            </div>
+                            <div class="form-group col-md-4">
+                              <label for="quality_non_conformity_id_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.non_conformitie_trans_key') }}</label>
+                              <select class="form-control" name="quality_non_conformity_id" id="quality_non_conformity_id_{{ $PurchaseReceiptLine->id }}">
+                                <option value="">{{ __('general_content.select_option_trans_key') }}</option>
+                                @foreach ($nonConformities as $nonConformity)
+                                  <option value="{{ $nonConformity->id }}" @if($PurchaseReceiptLine->quality_non_conformity_id == $nonConformity->id) selected @endif>{{ $nonConformity->code }}</option>
+                                @endforeach
+                              </select>
+                            </div>
+                          </div>
+                          <div class="form-row">
+                            <div class="form-group col-md-12">
+                              <label for="inspection_result_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.inspection_result_trans_key') }}</label>
+                              <input type="text" class="form-control" name="inspection_result" id="inspection_result_{{ $PurchaseReceiptLine->id }}" value="{{ $PurchaseReceiptLine->inspection_result }}">
+                            </div>
+                          </div>
+                          <div class="form-row">
+                            <div class="col-md-12">
+                              <div class="border rounded p-3">
+                                <div class="custom-control custom-switch mb-3">
+                                  <input type="checkbox" class="custom-control-input" id="create_nc_{{ $PurchaseReceiptLine->id }}" name="create_non_conformity" value="1">
+                                  <label class="custom-control-label" for="create_nc_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.quick_nc_creation_trans_key') }}</label>
+                                </div>
+                                <div class="form-row">
+                                  <div class="form-group col-md-6">
+                                    <label for="new_nc_label_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.label_trans_key') }}</label>
+                                    <input type="text" class="form-control" name="new_nc_label" id="new_nc_label_{{ $PurchaseReceiptLine->id }}" placeholder="{{ __('general_content.label_trans_key') }}">
+                                  </div>
+                                  <div class="form-group col-md-6">
+                                    <label for="new_nc_comment_{{ $PurchaseReceiptLine->id }}">{{ __('general_content.comment_trans_key') }}</label>
+                                    <textarea class="form-control" rows="2" name="new_nc_comment" id="new_nc_comment_{{ $PurchaseReceiptLine->id }}" placeholder="{{ __('general_content.comment_trans_key') }}"></textarea>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="modal-footer">
+                            <button type="submit" class="btn btn-success">{{ __('general_content.update_trans_key') }}</button>
+                          </div>
+                        </form>
+                      </x-adminlte-modal>
                         @if($PurchaseReceiptLine->purchaseLines->tasks->component_id ?? null || $PurchaseReceiptLine->purchaseLines->product_id ?? null)
                           @if(empty($PurchaseReceiptLine->stock_location_products_id))
                             @php
@@ -292,6 +391,12 @@
                     <th>{{ __('general_content.qty_trans_key') }}</th>
                     <th>{{ __('general_content.qty_purchase_trans_key') }}</th>
                     <th>{{ __('general_content.qty_reciept_trans_key') }}</th>
+                    <th>{{ __('general_content.qty_accepted_trans_key') }}</th>
+                    <th>{{ __('general_content.quantity_rejected_trans_key') }}</th>
+                    <th>{{ __('general_content.inspection_result_trans_key') }}</th>
+                    <th>{{ __('general_content.inspection_date_trans_key') }}</th>
+                    <th>{{ __('general_content.inspected_by_trans_key') }}</th>
+                    <th>{{ __('general_content.non_conformitie_trans_key') }}</th>
                     <th>{{__('general_content.action_trans_key') }}</th>
                   </tr>
                 </tfoot>

--- a/routes/web.php
+++ b/routes/web.php
@@ -191,6 +191,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/quotation/edit/{id}', 'App\Http\Controllers\Purchases\PurchasesRFQController@updatePurchaseQuotation')->middleware(['auth'])->name('quotation.update');
         Route::post('/receipt/edit/{id}', 'App\Http\Controllers\Purchases\PurchasesReceiptController@updatePurchaseReceipt')->middleware(['auth'])->name('receipt.update');
         Route::post('/receipt/control/{id}', 'App\Http\Controllers\Purchases\PurchasesReceiptController@updateReceiptControl')->middleware(['auth'])->name('purchase.receipts.reception_control');
+        Route::post('/receipt/line/{purchaseReceiptLine}/inspection', 'App\Http\Controllers\Purchases\PurchasesReceiptController@updateLineInspection')->middleware(['auth'])->name('purchase.receipts.lines.update');
         Route::post('/invoice/edit/{id}', 'App\Http\Controllers\Purchases\PurchasesInvoiceController@updatePurchaseInvoice')->middleware(['auth'])->name('invoice.update');
 
         Route::get('/{id}', 'App\Http\Controllers\Purchases\PurchasesController@showPurchase')->middleware(['auth'])->name('purchases.show');


### PR DESCRIPTION
## Summary
- add a migration and model updates to store inspection, quantities and NC links on purchase receipt lines
- extend purchase receipt UI and controller logic to edit inspection details and trigger quick non-conformity creation per line
- update KPI calculations, Livewire validation, routes and translations to expose new inspection metrics and compliance rates

## Testing
- not run (dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2c7962c34832db9396ff3ebe93c16