### PR TITLE
Refactor whiteboard state payload structure

### DIFF
--- a/resources/js/components/Whiteboard.vue
+++ b/resources/js/components/Whiteboard.vue
@@ -779,17 +779,35 @@ export default {
       this.whiteboardTitle = 'Nouveau tableau';
     },
     serializeState() {
+      const notes = this.notes.map(note => ({
+        id: note.id,
+        text: note.text,
+        x: note.x,
+        y: note.y,
+        color: note.color
+      }));
+      const images = this.images.map(image => ({
+        id: image.id,
+        src: image.src,
+        name: image.name,
+        x: image.x,
+        y: image.y,
+        width: image.width,
+        height: image.height
+      }));
+
       return {
-        id: this.selectedWhiteboardId,
         title: this.whiteboardTitle,
         canvas: this.canvasElement ? this.canvasElement.toDataURL('image/png') : null,
-        notes: this.notes,
-        images: this.images
+        notes,
+        images
       };
     },
     async saveWhiteboard() {
-      const payload = this.serializeState();
-      payload.title = this.whiteboardTitle;
+      const payload = {
+        title: this.whiteboardTitle,
+        state: this.serializeState()
+      };
 
       let request;
       let url;


### PR DESCRIPTION
## Summary
- ensure the serialized board state contains canvas, notes, images and title only inside the state object
- update whiteboard save flow to send the serialized state under payload.state alongside the title metadata

## Testing
- npm run production

------
https://chatgpt.com/codex/tasks/task_e_68d5a7a9b4bc832da1256e7d5a7ee128