### PR TITLE
refine customer portal views with guest layout parity

### DIFF
--- a/app/Http/Controllers/Customer/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Customer/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Customer\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+
+class AuthenticatedSessionController extends Controller
+{
+    /**
+     * Show the customer login form.
+     */
+    public function create()
+    {
+        return view('customer.auth.login');
+    }
+
+    /**
+     * Handle an incoming authentication request.
+     */
+    public function store(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+            'remember' => ['nullable', 'boolean'],
+        ]);
+
+        $authenticated = Auth::guard('customer')->attempt([
+            'mail' => $credentials['email'],
+            'password' => $credentials['password'],
+        ], $request->boolean('remember'));
+
+        if (! $authenticated) {
+            throw ValidationException::withMessages([
+                'email' => trans('auth.failed'),
+            ]);
+        }
+
+        $request->session()->regenerate();
+
+        $customer = Auth::guard('customer')->user();
+        if ($customer) {
+            $customer->forceFill(['last_login_at' => now()])->save();
+        }
+
+        return redirect()->intended(RouteServiceProvider::CUSTOMER_HOME);
+    }
+
+    /**
+     * Log the customer out of the application.
+     */
+    public function destroy(Request $request)
+    {
+        Auth::guard('customer')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('customer.login');
+    }
+}

--- a/app/Http/Controllers/Customer/PortalController.php
+++ b/app/Http/Controllers/Customer/PortalController.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace App\Http\Controllers\Customer;
+
+use App\Http\Controllers\Controller;
+use App\Models\Workflow\Deliverys;
+use App\Models\Workflow\Invoices;
+use App\Models\Workflow\Orders;
+use App\Services\InvoiceCalculatorService;
+use App\Services\OrderCalculatorService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class PortalController extends Controller
+{
+    private const ORDER_STATUS_LABELS = [
+        1 => 'general_content.open_trans_key',
+        2 => 'general_content.in_progress_trans_key',
+        3 => 'general_content.delivered_trans_key',
+        4 => 'general_content.partly_delivered_trans_key',
+    ];
+
+    private const ORDER_STATUS_BADGES = [
+        1 => 'info',
+        2 => 'warning',
+        3 => 'success',
+        4 => 'danger',
+    ];
+
+    private const INVOICE_STATUS_LABELS = [
+        1 => 'general_content.in_progress_trans_key',
+        2 => 'general_content.send_trans_key',
+        3 => 'general_content.pending_trans_key',
+        4 => 'general_content.unpaid_trans_key',
+        5 => 'general_content.paid_trans_key',
+    ];
+
+    private const INVOICE_STATUS_BADGES = [
+        1 => 'info',
+        2 => 'primary',
+        3 => 'warning',
+        4 => 'danger',
+        5 => 'success',
+    ];
+
+    private const DELIVERY_STATUS_LABELS = [
+        1 => 'general_content.in_progress_trans_key',
+        2 => 'general_content.send_trans_key',
+    ];
+
+    private const DELIVERY_STATUS_BADGES = [
+        1 => 'info',
+        2 => 'warning',
+    ];
+
+    /**
+     * Display the customer dashboard.
+     */
+    public function index(Request $request)
+    {
+        $customer = Auth::guard('customer')->user();
+
+        $ordersBaseQuery = Orders::query()
+            ->where(function ($query) use ($customer) {
+                $query->where('companies_id', $customer->companies_id)
+                    ->orWhere('companies_contacts_id', $customer->getKey());
+            });
+
+        $ordersQuery = (clone $ordersBaseQuery)->with('companie');
+        if ($status = $request->integer('order_status')) {
+            $ordersQuery->where('statu', $status);
+        }
+        if ($search = $request->input('order_search')) {
+            $ordersQuery->where(function ($query) use ($search) {
+                $query->where('code', 'like', "%{$search}%")
+                    ->orWhere('label', 'like', "%{$search}%")
+                    ->orWhere('customer_reference', 'like', "%{$search}%");
+            });
+        }
+
+        $orders = $ordersQuery
+            ->orderByDesc('created_at')
+            ->paginate(10, ['*'], 'orders_page')
+            ->withQueryString();
+
+        $openOrdersCount = (clone $ordersBaseQuery)->whereIn('statu', [1, 2, 4])->count();
+
+        $deliveriesBaseQuery = Deliverys::query()
+            ->where(function ($query) use ($customer) {
+                $query->where('companies_id', $customer->companies_id)
+                    ->orWhere('companies_contacts_id', $customer->getKey());
+            });
+
+        $deliveries = (clone $deliveriesBaseQuery)
+            ->with('Orders')
+            ->orderByDesc('created_at')
+            ->paginate(5, ['*'], 'deliveries_page')
+            ->withQueryString();
+
+        $pendingDeliveriesCount = (clone $deliveriesBaseQuery)->where('statu', 1)->count();
+
+        $invoicesBaseQuery = Invoices::query()
+            ->where(function ($query) use ($customer) {
+                $query->where('companies_id', $customer->companies_id)
+                    ->orWhere('companies_contacts_id', $customer->getKey());
+            });
+
+        $invoicesQuery = (clone $invoicesBaseQuery)->with('companie');
+        if ($status = $request->integer('invoice_status')) {
+            $invoicesQuery->where('statu', $status);
+        }
+        if ($search = $request->input('invoice_search')) {
+            $invoicesQuery->where(function ($query) use ($search) {
+                $query->where('code', 'like', "%{$search}%")
+                    ->orWhere('label', 'like', "%{$search}%");
+            });
+        }
+
+        $invoices = $invoicesQuery
+            ->orderByDesc('created_at')
+            ->paginate(10, ['*'], 'invoices_page')
+            ->withQueryString();
+
+        $unpaidInvoicesCount = (clone $invoicesBaseQuery)->whereIn('statu', [3, 4])->count();
+
+        $notifications = [
+            [
+                'title' => __('general_content.orders_trans_key'),
+                'subtitle' => __('general_content.in_progress_trans_key'),
+                'value' => $openOrdersCount,
+                'variant' => 'info',
+            ],
+            [
+                'title' => __('general_content.delivery_notes_trans_key'),
+                'subtitle' => __('general_content.in_progress_trans_key'),
+                'value' => $pendingDeliveriesCount,
+                'variant' => 'warning',
+            ],
+            [
+                'title' => __('general_content.invoices_trans_key'),
+                'subtitle' => __('general_content.unpaid_trans_key'),
+                'value' => $unpaidInvoicesCount,
+                'variant' => 'danger',
+            ],
+        ];
+
+        return view('customer.dashboard', [
+            'customer' => $customer,
+            'orders' => $orders,
+            'invoices' => $invoices,
+            'deliveries' => $deliveries,
+            'notifications' => $notifications,
+            'orderStatusOptions' => $this->getOrderStatusLabels(),
+            'invoiceStatusOptions' => $this->getInvoiceStatusLabels(),
+            'orderStatusBadges' => self::ORDER_STATUS_BADGES,
+            'invoiceStatusBadges' => self::INVOICE_STATUS_BADGES,
+            'deliveryStatusBadges' => self::DELIVERY_STATUS_BADGES,
+            'deliveryStatusLabels' => $this->getDeliveryStatusLabels(),
+        ]);
+    }
+
+    /**
+     * Display an order.
+     */
+    public function showOrder(string $uuid)
+    {
+        $customer = Auth::guard('customer')->user();
+
+        $order = Orders::where('uuid', $uuid)
+            ->where(function ($query) use ($customer) {
+                $query->where('companies_id', $customer->companies_id)
+                    ->orWhere('companies_contacts_id', $customer->getKey());
+            })
+            ->with([
+                'OrderLines.Unit',
+                'OrderLines.VAT',
+                'OrderLines.OrderLineDetails',
+                'OrderLines.DeliveryLines.delivery',
+                'payment_method',
+                'payment_condition',
+                'delevery_method',
+                'companie',
+                'contact',
+                'adresse',
+                'Rating',
+            ])
+            ->firstOrFail();
+
+        $calculator = new OrderCalculatorService($order);
+
+        return view('customer.orders.show', [
+            'order' => $order,
+            'totalPrices' => $calculator->getTotalPrice(),
+            'subPrice' => $calculator->getSubTotal(),
+            'vatPrice' => $calculator->getVatTotal(),
+            'orderStatusBadges' => self::ORDER_STATUS_BADGES,
+            'orderStatusLabels' => $this->getOrderStatusLabels(),
+        ]);
+    }
+
+    /**
+     * Display a delivery note.
+     */
+    public function showDelivery(string $uuid)
+    {
+        $customer = Auth::guard('customer')->user();
+
+        $delivery = Deliverys::where('uuid', $uuid)
+            ->where(function ($query) use ($customer) {
+                $query->where('companies_id', $customer->companies_id)
+                    ->orWhere('companies_contacts_id', $customer->getKey());
+            })
+            ->with([
+                'DeliveryLines.OrderLine.Unit',
+                'DeliveryLines.OrderLine.order',
+                'DeliveryLines.QualityNonConformity',
+            ])
+            ->firstOrFail();
+
+        return view('customer.deliveries.show', [
+            'delivery' => $delivery,
+            'deliveryStatusBadges' => self::DELIVERY_STATUS_BADGES,
+            'deliveryStatusLabels' => $this->getDeliveryStatusLabels(),
+        ]);
+    }
+
+    /**
+     * Display an invoice.
+     */
+    public function showInvoice(string $uuid)
+    {
+        $customer = Auth::guard('customer')->user();
+
+        $invoice = Invoices::where('uuid', $uuid)
+            ->where(function ($query) use ($customer) {
+                $query->where('companies_id', $customer->companies_id)
+                    ->orWhere('companies_contacts_id', $customer->getKey());
+            })
+            ->with([
+                'invoiceLines.orderLine.Unit',
+                'invoiceLines.orderLine.VAT',
+                'invoiceLines.deliveryLine.delivery',
+                'companie',
+                'contact',
+                'adresse',
+            ])
+            ->firstOrFail();
+
+        $calculator = new InvoiceCalculatorService($invoice);
+
+        return view('customer.invoices.show', [
+            'invoice' => $invoice,
+            'totalPrices' => $calculator->getTotalPrice(),
+            'subPrice' => $calculator->getSubTotal(),
+            'vatPrice' => $calculator->getVatTotal(),
+            'invoiceStatusBadges' => self::INVOICE_STATUS_BADGES,
+            'invoiceStatusLabels' => $this->getInvoiceStatusLabels(),
+        ]);
+    }
+
+    /**
+     * Translate order status labels.
+     */
+    private function getOrderStatusLabels(): array
+    {
+        return $this->translateLabels(self::ORDER_STATUS_LABELS);
+    }
+
+    /**
+     * Translate invoice status labels.
+     */
+    private function getInvoiceStatusLabels(): array
+    {
+        return $this->translateLabels(self::INVOICE_STATUS_LABELS);
+    }
+
+    /**
+     * Translate delivery status labels.
+     */
+    private function getDeliveryStatusLabels(): array
+    {
+        return $this->translateLabels(self::DELIVERY_STATUS_LABELS);
+    }
+
+    /**
+     * Translate status labels with localization support.
+     */
+    private function translateLabels(array $labels): array
+    {
+        $translated = [];
+        foreach ($labels as $status => $translationKey) {
+            $translated[$status] = __($translationKey);
+        }
+
+        return $translated;
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -70,5 +70,6 @@ class Kernel extends HttpKernel
         'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class,
         'check.factory'           => \App\Http\Middleware\CheckFactory::class,
         'check.task.status'       => \App\Http\Middleware\CheckTaskStatus::class,
+        'customer'                => \App\Http\Middleware\EnsureCustomerIsAuthenticated::class,
     ];
 }

--- a/app/Http/Middleware/EnsureCustomerIsAuthenticated.php
+++ b/app/Http/Middleware/EnsureCustomerIsAuthenticated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class EnsureCustomerIsAuthenticated
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (Auth::guard('customer')->check()) {
+            return $next($request);
+        }
+
+        if ($request->expectsJson()) {
+            abort(401, 'Unauthenticated.');
+        }
+
+        return redirect()->guest(route('customer.login'));
+    }
+}

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -15,7 +15,7 @@ class RedirectIfAuthenticated
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  ...$guards
-     * @return \Illuminate\Contracts\View\View
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
     public function handle(Request $request, Closure $next, ...$guards)
     {
@@ -23,6 +23,10 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
+                if ($guard === 'customer') {
+                    return redirect(RouteServiceProvider::CUSTOMER_HOME);
+                }
+
                 return redirect(RouteServiceProvider::HOME);
             }
         }

--- a/app/Models/Customer/Customer.php
+++ b/app/Models/Customer/Customer.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Models\Customer;
+
+use App\Models\Companies\Companies;
+use App\Models\Workflow\Orders;
+use App\Models\Workflow\Deliverys;
+use App\Models\Workflow\Invoices;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Notifications\Notifiable;
+
+class Customer extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    /**
+     * The table associated with the model.
+     */
+    protected $table = 'companies_contacts';
+
+    /**
+     * Indicates if the model should be timestamped.
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'companies_id',
+        'ordre',
+        'civility',
+        'first_name',
+        'name',
+        'function',
+        'number',
+        'mobile',
+        'mail',
+        'default',
+        'password',
+        'last_login_at',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'last_login_at' => 'datetime',
+    ];
+
+    /**
+     * Automatically hash passwords.
+     */
+    public function setPasswordAttribute(?string $value): void
+    {
+        if (! empty($value)) {
+            $this->attributes['password'] = bcrypt($value);
+        }
+    }
+
+    /**
+     * Customer company relation.
+     */
+    public function companie()
+    {
+        return $this->belongsTo(Companies::class, 'companies_id');
+    }
+
+    /**
+     * Orders associated with the customer.
+     */
+    public function orders()
+    {
+        return $this->hasMany(Orders::class, 'companies_contacts_id');
+    }
+
+    /**
+     * Deliveries associated with the customer.
+     */
+    public function deliveries()
+    {
+        return $this->hasMany(Deliverys::class, 'companies_contacts_id');
+    }
+
+    /**
+     * Invoices associated with the customer.
+     */
+    public function invoices()
+    {
+        return $this->hasMany(Invoices::class, 'companies_contacts_id');
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -18,8 +18,10 @@ class RouteServiceProvider extends ServiceProvider
      * @var string
      */
     public const HOME = '/dashboard';
-    
+
     public const WORKSHOP = '/workshop';
+
+    public const CUSTOMER_HOME = '/customer';
 
     /**
      * The controller namespace for the application.

--- a/config/auth.php
+++ b/config/auth.php
@@ -44,6 +44,10 @@ return [
             'driver' => 'session',
             'provider' => 'ldap',
         ],
+        'customer' => [
+            'driver' => 'session',
+            'provider' => 'customers',
+        ],
         'api' => [
             'driver' => 'token',
             'provider' => 'users',
@@ -76,6 +80,10 @@ return [
         'ldap' => [
             'driver' => 'ldap',
             'model' => LdapRecord\Models\ActiveDirectory\User::class,
+        ],
+        'customers' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Customer\Customer::class,
         ],
         // 'users' => [
         //     'driver' => 'database',

--- a/database/migrations/2024_09_10_000000_add_auth_fields_to_companies_contacts_table.php
+++ b/database/migrations/2024_09_10_000000_add_auth_fields_to_companies_contacts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('companies_contacts', function (Blueprint $table) {
+            $table->string('password')->nullable()->after('default');
+            $table->rememberToken()->nullable()->after('password');
+            $table->timestamp('last_login_at')->nullable()->after('remember_token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('companies_contacts', function (Blueprint $table) {
+            $table->dropColumn(['password', 'remember_token', 'last_login_at']);
+        });
+    }
+};

--- a/resources/views/customer/auth/login.blade.php
+++ b/resources/views/customer/auth/login.blade.php
@@ -1,0 +1,48 @@
+<x-guest-layout>
+    <x-auth-card>
+        <x-slot name="logo">
+            <a href="{{ route('customer.login') }}" class="text-center d-block">
+                @if($Factory->picture)
+                    <img src="data:image/png;base64,{{ $Factory->getImageFactoryPath() }}" alt="{{ $Factory->name }}" class="h-16 w-auto mx-auto">
+                @else
+                    <span class="text-2xl font-bold text-gray-800">{{ $Factory->name ?? config('app.name', 'WebErpMesv2') }}</span>
+                @endif
+            </a>
+        </x-slot>
+
+        <x-auth-session-status class="mb-4" :status="session('status')" />
+
+        <form method="POST" action="{{ route('customer.login.store') }}" class="space-y-4">
+            @csrf
+
+            <div>
+                <x-label for="email" value="{{ __('adminlte::adminlte.email') }}" />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="email" />
+                @error('email')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <x-label for="password" value="{{ __('adminlte::adminlte.password') }}" />
+                <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="current-password" />
+                @error('password')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="flex items-center justify-between">
+                <label for="remember" class="inline-flex items-center">
+                    <input id="remember" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="remember" value="1" {{ old('remember') ? 'checked' : '' }}>
+                    <span class="ml-2 text-sm text-gray-600">{{ __('adminlte::adminlte.remember_me') }}</span>
+                </label>
+            </div>
+
+            <div>
+                <x-button class="w-full justify-center">
+                    <i class="fas fa-lock-open mr-2"></i>{{ __('adminlte::adminlte.sign_in') }}
+                </x-button>
+            </div>
+        </form>
+    </x-auth-card>
+</x-guest-layout>

--- a/resources/views/customer/dashboard.blade.php
+++ b/resources/views/customer/dashboard.blade.php
@@ -1,0 +1,227 @@
+@extends('customer.layouts.app')
+
+@section('title', __('general_content.dashboard_trans_key'))
+
+@section('content')
+    <div class="row g-3 mb-4">
+        @foreach($notifications as $notification)
+            <div class="col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex align-items-center justify-content-between">
+                            <div>
+                                <p class="text-muted mb-1">{{ $notification['title'] }}</p>
+                                <h4 class="fw-bold mb-0">{{ $notification['value'] }}</h4>
+                            </div>
+                            <span class="badge bg-{{ $notification['variant'] }}">{{ $notification['subtitle'] }}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="card mb-4 shadow-sm border-0">
+        <div class="card-header bg-white d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
+            <div>
+                <h5 class="mb-0">{{ __('general_content.orders_trans_key') }}</h5>
+                <small class="text-muted">{{ __('general_content.orders_list_trans_key') }}</small>
+            </div>
+            <form method="GET" class="row g-2 align-items-center">
+                <input type="hidden" name="invoice_status" value="{{ request('invoice_status') }}">
+                <input type="hidden" name="invoice_search" value="{{ request('invoice_search') }}">
+                <div class="col-auto">
+                    <select name="order_status" class="form-select form-select-sm">
+                        <option value="">{{ __('general_content.status_trans_key') }}</option>
+                        @foreach($orderStatusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(request('order_status') == $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <input type="search" name="order_search" value="{{ request('order_search') }}" class="form-control form-control-sm" placeholder="{{ __('adminlte::menu.search_trans_key') }}">
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-sm btn-primary">
+                        <i class="fas fa-filter me-1"></i>{{ __('adminlte::menu.search_trans_key') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>{{ __('general_content.code_trans_key') }}</th>
+                            <th>{{ __('general_content.label_trans_key') }}</th>
+                            <th>{{ __('general_content.status_trans_key') }}</th>
+                            <th>{{ __('general_content.created_at_trans_key') }}</th>
+                            <th class="text-end">{{ __('general_content.total_trans_key') }}</th>
+                            <th class="text-end">{{ __('general_content.action_trans_key') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($orders as $order)
+                            <tr>
+                                <td class="fw-semibold">{{ $order->code }}</td>
+                                <td>{{ $order->label }}</td>
+                                <td>
+                                    @php($status = $order->statu)
+                                    <span class="badge bg-{{ $orderStatusBadges[$status] ?? 'secondary' }}">
+                                        {{ $orderStatusOptions[$status] ?? __('general_content.status_trans_key') }}
+                                    </span>
+                                </td>
+                                <td>{{ $order->GetshortCreatedAttribute() }}</td>
+                                <td class="text-end">{{ number_format($order->total_price, 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-outline-primary" href="{{ route('customer.orders.show', $order->uuid) }}">
+                                        <i class="fas fa-eye me-1"></i>{{ __('general_content.view_trans_key') ?? __('general_content.show_trans_key') }}
+                                    </a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-4">{{ __('general_content.no_data_trans_key') }}</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer bg-white">
+            {{ $orders->withQueryString()->links('pagination::bootstrap-4') }}
+        </div>
+    </div>
+
+    <div class="card mb-4 shadow-sm border-0">
+        <div class="card-header bg-white d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
+            <div>
+                <h5 class="mb-0">{{ __('general_content.invoices_trans_key') }}</h5>
+                <small class="text-muted">{{ __('general_content.invoices_list_trans_key') }}</small>
+            </div>
+            <form method="GET" class="row g-2 align-items-center">
+                <input type="hidden" name="order_status" value="{{ request('order_status') }}">
+                <input type="hidden" name="order_search" value="{{ request('order_search') }}">
+                <div class="col-auto">
+                    <select name="invoice_status" class="form-select form-select-sm">
+                        <option value="">{{ __('general_content.status_trans_key') }}</option>
+                        @foreach($invoiceStatusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(request('invoice_status') == $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <input type="search" name="invoice_search" value="{{ request('invoice_search') }}" class="form-control form-control-sm" placeholder="{{ __('adminlte::menu.search_trans_key') }}">
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-sm btn-primary">
+                        <i class="fas fa-filter me-1"></i>{{ __('adminlte::menu.search_trans_key') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>{{ __('general_content.code_trans_key') }}</th>
+                            <th>{{ __('general_content.label_trans_key') }}</th>
+                            <th>{{ __('general_content.status_trans_key') }}</th>
+                            <th>{{ __('general_content.due_date_trans_key') }}</th>
+                            <th class="text-end">{{ __('general_content.total_trans_key') }}</th>
+                            <th class="text-end">{{ __('general_content.action_trans_key') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($invoices as $invoice)
+                            <tr>
+                                <td class="fw-semibold">{{ $invoice->code }}</td>
+                                <td>{{ $invoice->label }}</td>
+                                <td>
+                                    @php($status = $invoice->statu)
+                                    <span class="badge bg-{{ $invoiceStatusBadges[$status] ?? 'secondary' }}">
+                                        {{ $invoiceStatusOptions[$status] ?? __('general_content.status_trans_key') }}
+                                    </span>
+                                </td>
+                                <td>
+                                    @if($invoice->due_date)
+                                        {{ \Illuminate\Support\Carbon::parse($invoice->due_date)->format('d/m/Y') }}
+                                    @else
+                                        {{ __('general_content.undefined_trans_key') }}
+                                    @endif
+                                </td>
+                                <td class="text-end">{{ number_format($invoice->total_price, 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-outline-primary" href="{{ route('customer.invoices.show', $invoice->uuid) }}">
+                                        <i class="fas fa-eye me-1"></i>{{ __('general_content.view_trans_key') ?? __('general_content.show_trans_key') }}
+                                    </a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-4">{{ __('general_content.no_data_trans_key') }}</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer bg-white">
+            {{ $invoices->withQueryString()->links('pagination::bootstrap-4') }}
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-header bg-white">
+            <h5 class="mb-0">{{ __('general_content.delivery_notes_trans_key') }}</h5>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>{{ __('general_content.code_trans_key') }}</th>
+                            <th>{{ __('general_content.status_trans_key') }}</th>
+                            <th>{{ __('general_content.created_at_trans_key') }}</th>
+                            <th>{{ __('general_content.order_trans_key') }}</th>
+                            <th class="text-end">{{ __('general_content.action_trans_key') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($deliveries as $delivery)
+                            <tr>
+                                <td class="fw-semibold">{{ $delivery->code }}</td>
+                                <td>
+                                    @php($status = $delivery->statu)
+                                    <span class="badge bg-{{ $deliveryStatusBadges[$status] ?? 'secondary' }}">
+                                        {{ $deliveryStatusLabels[$status] ?? __('general_content.status_trans_key') }}
+                                    </span>
+                                </td>
+                                <td>{{ $delivery->GetshortCreatedAttribute() }}</td>
+                                <td>
+                                    @if($delivery->Orders)
+                                        <span class="badge bg-light text-dark">#{{ $delivery->Orders->code }}</span>
+                                    @endif
+                                </td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-outline-primary" href="{{ route('customer.deliveries.show', $delivery->uuid) }}">
+                                        <i class="fas fa-eye me-1"></i>{{ __('general_content.view_trans_key') ?? __('general_content.show_trans_key') }}
+                                    </a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="5" class="text-center text-muted py-4">{{ __('general_content.no_data_trans_key') }}</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer bg-white">
+            {{ $deliveries->withQueryString()->links('pagination::bootstrap-4') }}
+        </div>
+    </div>
+@endsection

--- a/resources/views/customer/deliveries/show.blade.php
+++ b/resources/views/customer/deliveries/show.blade.php
@@ -1,0 +1,137 @@
+@extends('customer.layouts.app')
+
+@section('title', __('general_content.delivery_notes_trans_key') . ' #' . $delivery->code)
+
+@section('content')
+    <div class="container-fluid">
+        <div class="container">
+            <div class="d-flex justify-content-between align-items-center py-3">
+                <h2 class="h5 mb-0">{{ __('general_content.delivery_notes_trans_key') }} #{{ $delivery->code }}</h2>
+                <span class="text-muted">{{ $delivery->GetshortCreatedAttribute() }}</span>
+            </div>
+
+            @include('include.alert-result')
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="mb-3 d-flex justify-content-between">
+                        <div>
+                            <span class="me-3">{{ $delivery->GetshortCreatedAttribute() }}</span>
+                            <span class="me-3">#{{ $delivery->code }}</span>
+                            @php($status = $delivery->statu)
+                            @if(isset($deliveryStatusBadges[$status]))
+                                <span class="badge badge-{{ $deliveryStatusBadges[$status] }}">{{ __($deliveryStatusLabels[$status]) }}</span>
+                            @endif
+                        </div>
+                    </div>
+
+                    <table class="table table-borderless">
+                        <thead>
+                            <tr>
+                                <th>{{ __('general_content.order_trans_key') }}</th>
+                                <th>{{ __('general_content.external_id_trans_key') }}</th>
+                                <th>{{ __('general_content.description_trans_key') }}</th>
+                                <th>{{ __('general_content.qty_trans_key') }}</th>
+                                <th>{{ __('general_content.unit_trans_key') }}</th>
+                                <th>{{ __('general_content.delivered_qty_trans_key') }}</th>
+                                <th>{{ __('general_content.remaining_qty_trans_key') }}</th>
+                                <th>{{ __('general_content.invoice_status_trans_key') }}</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($delivery->DeliveryLines as $DocumentLine)
+                                <tr>
+                                    <td>
+                                        @if($DocumentLine->OrderLine->order->uuid)
+                                            <x-ButtonTextView route="{{ route('customer.orders.show', ['order' => $DocumentLine->OrderLine->order->uuid]) }}" />
+                                        @endif
+                                        {{ $DocumentLine->OrderLine->order['code'] }}
+                                    </td>
+                                    <td>{{ $DocumentLine->OrderLine['code'] }}</td>
+                                    <td>{{ $DocumentLine->OrderLine['label'] }}</td>
+                                    <td>{{ $DocumentLine->OrderLine['qty'] }}</td>
+                                    <td>{{ $DocumentLine->OrderLine->Unit['label'] }}</td>
+                                    <td>{{ $DocumentLine->qty }}</td>
+                                    <td>{{ $DocumentLine->OrderLine['delivered_remaining_qty'] }}</td>
+                                    <td>
+                                        @if(1 == $DocumentLine->invoice_status)
+                                            <span class="badge badge-info">{{ __('general_content.chargeable_trans_key') }}</span>
+                                        @endif
+                                        @if(2 == $DocumentLine->invoice_status)
+                                            <span class="badge badge-danger">{{ __('general_content.not_chargeable_trans_key') }}</span>
+                                        @endif
+                                        @if(3 == $DocumentLine->invoice_status)
+                                            <span class="badge badge-warning">{{ __('general_content.partly_invoiced_trans_key') }}</span>
+                                        @endif
+                                        @if(4 == $DocumentLine->invoice_status)
+                                            <span class="badge badge-success">{{ __('general_content.invoiced_trans_key') }}</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($DocumentLine->QualityNonConformity)
+                                            <a class="btn btn-danger btn-sm" href="#">
+                                                <i class="fa fa-light fa-fw fa-exclamation"></i>
+                                                {{ $DocumentLine->QualityNonConformity->label }}
+                                            </a>
+                                            @if($DocumentLine->QualityNonConformity->statu == 1)
+                                                <span class="badge badge-info">{{ __('general_content.in_progress_trans_key') }}</span>
+                                            @endif
+                                            @if($DocumentLine->QualityNonConformity->statu == 2)
+                                                <span class="badge badge-warning">{{ __('general_content.waiting_customer_data_trans_key') }}</span>
+                                            @endif
+                                            @if($DocumentLine->QualityNonConformity->statu == 3)
+                                                <span class="badge badge-success">{{ __('general_content.validate_trans_key') }}</span>
+                                            @endif
+                                            @if($DocumentLine->QualityNonConformity->statu == 4)
+                                                <span class="badge badge-danger">{{ __('general_content.canceled_trans_key') }}</span>
+                                            @endif
+                                        @else
+                                            <a class="btn btn-warning btn-sm" href="{{ route('guest.nonConformitie.create', ['id' => $DocumentLine->id]) }}">
+                                                <i class="fa fa-light fa-fw fa-exclamation"></i>
+                                                {{ __('general_content.new_non_conformitie_trans_key') }}
+                                            </a>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <x-EmptyDataLine col="9" text="{{ __('general_content.no_data_trans_key') }}" />
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <h3 class="h6">{{ $Factory->name }}</h3>
+                            @if($Factory->picture)
+                                <img src="data:image/png;base64,{{ $Factory->getImageFactoryPath() }}" alt="Logo" width="64" class="logo"/>
+                            @endif
+                        </div>
+                        <div class="col-lg-6">
+                            <h3 class="h6">{{ __('general_content.adress_trans_key') }}</h3>
+                            <address class="mb-0">
+                                {{ $Factory->address }}<br/>
+                                {{ $Factory->zipcode }} {{ $Factory->city }}<br/>
+                                {{ __('general_content.phone_trans_key') }} : {{ $Factory->phone_number }}<br/>
+                                {{ __('general_content.email_trans_key') }} : {{ $Factory->mail }}<br/>
+                            </address>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            @if ($delivery->comment)
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="h6">{{ __('general_content.comment_trans_key') }}</h3>
+                        <p class="mb-0">{{ $delivery->comment }}</p>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/customer/invoices/show.blade.php
+++ b/resources/views/customer/invoices/show.blade.php
@@ -1,0 +1,142 @@
+@extends('customer.layouts.app')
+
+@section('title', __('general_content.invoice_trans_key') . ' #' . $invoice->code)
+
+@section('content')
+    <div class="container-fluid">
+        <div class="container">
+            <div class="d-flex justify-content-between align-items-center py-3">
+                <h2 class="h5 mb-0">{{ __('general_content.invoice_trans_key') }} #{{ $invoice->code }}</h2>
+                <span class="text-muted">{{ $invoice->GetshortCreatedAttribute() }}</span>
+            </div>
+
+            <div class="row">
+                <div class="col-lg-8">
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <div class="mb-3 d-flex justify-content-between flex-wrap gap-2">
+                                <div>
+                                    <span class="me-3">{{ $invoice->GetshortCreatedAttribute() }}</span>
+                                    <span class="me-3">#{{ $invoice->code }}</span>
+                                    @php($status = $invoice->statu)
+                                    @if(isset($invoiceStatusBadges[$status]))
+                                        <span class="badge badge-{{ $invoiceStatusBadges[$status] }}">{{ __($invoiceStatusLabels[$status]) }}</span>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <table class="table table-borderless">
+                                <thead>
+                                    <tr>
+                                        <th>{{ __('general_content.description_trans_key') }}</th>
+                                        <th>{{ __('general_content.qty_trans_key') }}</th>
+                                        <th>{{ __('general_content.price_trans_key') }}</th>
+                                        <th>{{ __('general_content.discount_trans_key') }}</th>
+                                        <th>{{ __('general_content.vat_trans_key') }}</th>
+                                        <th>{{ __('general_content.delivery_notes_trans_key') }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($invoice->invoiceLines as $DocumentLine)
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex mb-2">
+                                                    <div class="flex-lg-grow-1">
+                                                        <h6 class="small mb-0">{{ $DocumentLine->orderLine?->label }}</h6>
+                                                        <span class="text-muted">{{ $DocumentLine->orderLine?->code }}</span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td>{{ $DocumentLine->qty }} {{ $DocumentLine->orderLine?->Unit['label'] }}</td>
+                                            <td class="text-end">{{ $DocumentLine->selling_price }} {{ $Factory->curency }}</td>
+                                            <td>{{ $DocumentLine->discount }} %</td>
+                                            <td>{{ $DocumentLine->orderLine?->VAT['rate'] }} %</td>
+                                            <td>
+                                                @if($DocumentLine->deliveryLine?->delivery)
+                                                    <x-ButtonTextView route="{{ route('customer.deliveries.show', ['delivery' => $DocumentLine->deliveryLine->delivery->uuid]) }}" />
+                                                    {{ $DocumentLine->deliveryLine->delivery->code }}
+                                                @endif
+                                            </td>
+                                        </tr>
+                                    @empty
+                                        <x-EmptyDataLine col="6" text="{{ __('general_content.no_data_trans_key') }}" />
+                                    @endforelse
+                                </tbody>
+                                <tfoot>
+                                    <tr>
+                                        <td colspan="2"></td>
+                                        <td colspan="2" class="text-end"><hr></td>
+                                    </tr>
+                                    <tr>
+                                        <td colspan="2">{{ __('general_content.sub_total_trans_key') }}</td>
+                                        <td colspan="2" class="text-end">{{ $subPrice }} {{ $Factory->curency }}</td>
+                                    </tr>
+                                    @forelse($vatPrice as $vatRate)
+                                        <tr>
+                                            <td colspan="2">{{ __('general_content.tax_trans_key') }} {{ $vatRate[0] }}%</td>
+                                            <td colspan="2" class="text-end">{{ number_format($vatRate[1], 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="2">{{ __('general_content.no_tax_trans_key') }}</td>
+                                            <td colspan="2"></td>
+                                        </tr>
+                                    @endforelse
+                                    <tr>
+                                        <td colspan="2">{{ __('general_content.total_trans_key') }}</td>
+                                        <td colspan="2" class="text-end fw-bold">{{ number_format($totalPrices, 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    </div>
+
+                    @if($invoice->comment)
+                        <div class="card mb-4">
+                            <div class="card-body">
+                                <h3 class="h6">{{ __('general_content.comment_trans_key') }}</h3>
+                                <p class="mb-0">{{ $invoice->comment }}</p>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+
+                <div class="col-lg-4">
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <h3 class="h6">{{ __('general_content.customer_trans_key') }}</h3>
+                              <p class="mb-0">
+                                  {{ $invoice->companie?->label }}<br>
+                                  {{ $invoice->contact?->full_name }}<br>
+                                  {{ $invoice->adresse?->adress }}<br>
+                                  {{ $invoice->adresse?->zipcode }} {{ $invoice->adresse?->city }}
+                              </p>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <h3 class="h6">{{ __('general_content.payment_method_trans_key') }}</h3>
+                            <p class="mb-0">{{ $invoice->payment_method?->label }}</p>
+                            <h3 class="h6 mt-3">{{ __('general_content.delivery_notes_trans_key') }}</h3>
+                            <p class="mb-0">{{ $invoice->deliverys_notes }}</p>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card-body">
+                            <h3 class="h6">{{ __('general_content.factory_trans_key') }}</h3>
+                            <p class="mb-0">
+                                {{ $Factory->name }}<br>
+                                {{ $Factory->address }}<br>
+                                {{ $Factory->zipcode }} {{ $Factory->city }}<br>
+                                {{ __('general_content.phone_trans_key') }} : {{ $Factory->phone_number }}<br>
+                                {{ __('general_content.email_trans_key') }} : {{ $Factory->mail }}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/customer/layouts/app.blade.php
+++ b/resources/views/customer/layouts/app.blade.php
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    {{-- Base Meta Tags --}}
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    {{-- Title --}}
+    <title>
+        @hasSection('title')
+            @yield('title') -
+        @endif
+        {{ $Factory->name ?? config('app.name', 'WebErpMesv2') }}
+    </title>
+
+    {{-- Base Stylesheets --}}
+    @if(!config('adminlte.enabled_laravel_mix'))
+        <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
+
+        @if(config('adminlte.google_fonts.allowed', true))
+            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+        @endif
+    @else
+        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+    @endif
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+
+    @stack('styles')
+</head>
+<body class="bg-light">
+    @php($customer = auth('customer')->user())
+    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+        <div class="container">
+            <a class="navbar-brand fw-semibold" href="{{ route('customer.dashboard') }}">
+                {{ $Factory->name ?? config('app.name', 'WebErpMesv2') }}
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#customerNavbar" aria-controls="customerNavbar" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+
+            <div class="collapse navbar-collapse" id="customerNavbar">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <li class="nav-item"><a class="nav-link" href="{{ route('customer.dashboard') }}">{{ __('general_content.dashboard_trans_key') ?? 'Dashboard' }}</a></li>
+                </ul>
+                <div class="d-flex align-items-center gap-3">
+                    @if($customer)
+                        <span class="text-muted small">
+                            <i class="fas fa-user-circle me-1"></i>
+                            {{ trim(($customer->first_name ?? '') . ' ' . ($customer->name ?? '')) ?: $customer->mail }}
+                        </span>
+                    @endif
+                    <form action="{{ route('customer.logout') }}" method="POST" class="d-inline">
+                        @csrf
+                        <button type="submit" class="btn btn-sm btn-outline-secondary">
+                            <i class="fas fa-sign-out-alt me-1"></i>{{ __('adminlte::adminlte.sign_out') }}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main class="py-4">
+        <div class="container">
+            @yield('content')
+        </div>
+    </main>
+
+    <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
+    <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+    @stack('scripts')
+</body>
+</html>

--- a/resources/views/customer/orders/show.blade.php
+++ b/resources/views/customer/orders/show.blade.php
@@ -1,0 +1,263 @@
+@extends('customer.layouts.app')
+
+@section('title', __('general_content.order_trans_key') . ' #' . $order->code)
+
+@section('content')
+    <div class="container-fluid">
+        <div class="container">
+            <div class="d-flex justify-content-between align-items-center py-3">
+                <h2 class="h5 mb-0">{{ __('general_content.order_trans_key') }} #{{ $order->code }}</h2>
+                <span class="text-muted">{{ $order->GetshortCreatedAttribute() }}</span>
+            </div>
+
+            <div class="row">
+                <div class="col-lg-8">
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <div class="mb-3 d-flex justify-content-between flex-wrap gap-2">
+                                <div>
+                                    <span class="me-3">{{ $order->GetshortCreatedAttribute() }}</span>
+                                    <span class="me-3">#{{ $order->code }}</span>
+                                    @php($status = $order->statu)
+                                    @if(isset($orderStatusBadges[$status]))
+                                        <span class="badge badge-{{ $orderStatusBadges[$status] }}">{{ __($orderStatusLabels[$status]) }}</span>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <table class="table table-borderless">
+                                <thead>
+                                    <tr>
+                                        <th>{{ __('general_content.description_trans_key') }}</th>
+                                        <th>{{ __('general_content.qty_trans_key') }}</th>
+                                        <th>{{ __('general_content.price_trans_key') }}</th>
+                                        <th>{{ __('general_content.discount_trans_key') }}</th>
+                                        <th>{{ __('general_content.vat_trans_key') }}</th>
+                                        <th>{{ __('general_content.delivery_status_trans_key') }}</th>
+                                        <th>{{ __('general_content.invoice_status_trans_key') }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($order->OrderLines as $DocumentLine)
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex mb-2">
+                                                    <div class="flex-lg-grow-1">
+                                                        <h6 class="small mb-0">{{ $DocumentLine->label }}</h6>
+                                                        <span class="text-muted">{{ $DocumentLine->code }}</span>
+                                                        @php
+                                                            $guestDetail = $DocumentLine->OrderLineDetails ?? null;
+                                                            $guestCustomRequirements = $guestDetail ? collect($guestDetail->custom_requirements ?? [])->filter(function ($requirement) {
+                                                                return !empty($requirement['label'] ?? null) || !empty($requirement['value'] ?? null);
+                                                            }) : collect();
+                                                        @endphp
+                                                        @if($guestCustomRequirements->isNotEmpty())
+                                                            <ul class="list-unstyled mb-0 small text-muted">
+                                                                @foreach($guestCustomRequirements as $requirement)
+                                                                    <li><strong>{{ $requirement['label'] ?? __('Requirement') }}:</strong> {{ $requirement['value'] ?? '' }}</li>
+                                                                @endforeach
+                                                            </ul>
+                                                        @endif
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td>{{ $DocumentLine->qty }} {{ $DocumentLine->Unit['label'] }}</td>
+                                            <td class="text-end">{{ $DocumentLine->selling_price }} {{ $Factory->curency }}</td>
+                                            <td>{{ $DocumentLine->discount }} %</td>
+                                            <td>{{ $DocumentLine->VAT['rate'] }} %</td>
+                                            <td>
+                                                @if(1 == $DocumentLine->delivery_status)
+                                                    <span class="badge badge-info">{{ __('general_content.not_delivered_trans_key') }}</span>
+                                                @endif
+                                                @if(2 == $DocumentLine->delivery_status)
+                                                    <a href="#" data-toggle="modal" data-target="#modalDeliveryFor{{ $DocumentLine->id }}">
+                                                        <span class="badge badge-warning">{{ __('general_content.partly_delivered_trans_key') }} ({{ $DocumentLine->delivered_qty }})</span>
+                                                    </a>
+                                                @endif
+                                                @if(3 == $DocumentLine->delivery_status)
+                                                    <a href="#" data-toggle="modal" data-target="#modalDeliveryFor{{ $DocumentLine->id }}">
+                                                        <span class="badge badge-success">{{ __('general_content.delivered_trans_key') }} ({{ $DocumentLine->delivered_qty }})</span>
+                                                    </a>
+                                                @endif
+                                                @if(4 == $DocumentLine->delivery_status)
+                                                    <span class="badge badge-primary">{{ __('general_content.delivered_without_dn_trans_key') }} ({{ $DocumentLine->delivered_qty }})</span>
+                                                @endif
+
+                                                <x-adminlte-modal id="modalDeliveryFor{{ $DocumentLine->id }}" title="{{ __('general_content.deliverys_notes_list_trans_key') }}" theme="info" icon="fas fa-bolt" size="lg" disable-animations>
+                                                    <ul class="list-unstyled mb-0">
+                                                        @foreach($DocumentLine->DeliveryLines as $deliveryLine)
+                                                            <li class="mb-3">
+                                                                <div><strong>{{ __('general_content.delivery_notes_trans_key') }}:</strong> {{ $deliveryLine->delivery->code }}</div>
+                                                                <div><strong>{{ __('general_content.qty_trans_key') }}:</strong> {{ $deliveryLine->qty }}</div>
+                                                                <div><strong>{{ __('general_content.created_at_trans_key') }}:</strong> {{ $deliveryLine->GetPrettyCreatedAttribute() }}</div>
+                                                                <x-ButtonTextView route="{{ route('customer.deliveries.show', ['delivery' => $deliveryLine->delivery->uuid]) }}" />
+                                                            </li>
+                                                        @endforeach
+                                                    </ul>
+                                                </x-adminlte-modal>
+                                            </td>
+                                            <td>
+                                                @if(1 == $DocumentLine->invoice_status)
+                                                    <span class="badge badge-info">{{ __('general_content.not_invoiced_trans_key') }}</span>
+                                                @endif
+                                                @if(2 == $DocumentLine->invoice_status)
+                                                    <span class="badge badge-warning">{{ __('general_content.partly_invoiced_trans_key') }}</span>
+                                                @endif
+                                                @if(3 == $DocumentLine->invoice_status)
+                                                    <span class="badge badge-success">{{ __('general_content.invoiced_trans_key') }}</span>
+                                                @endif
+                                            </td>
+                                        </tr>
+                                    @empty
+                                        <x-EmptyDataLine col="7" text="{{ __('general_content.no_data_trans_key') }}" />
+                                    @endforelse
+                                </tbody>
+                                <tfoot>
+                                    <tr>
+                                        <td colspan="3"></td>
+                                        <td colspan="2" class="text-end"><hr></td>
+                                    </tr>
+                                    <tr>
+                                        <td colspan="3">{{ __('general_content.sub_total_trans_key') }}</td>
+                                        <td colspan="2" class="text-end">{{ $subPrice }} {{ $Factory->curency }}</td>
+                                    </tr>
+                                    @forelse($vatPrice as $vatRate)
+                                        <tr>
+                                            <td colspan="3">{{ __('general_content.tax_trans_key') }} {{ $vatRate[0] }}%</td>
+                                            <td colspan="2" class="text-end">{{ number_format($vatRate[1], 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="3">{{ __('general_content.no_tax_trans_key') }}</td>
+                                            <td colspan="2"></td>
+                                        </tr>
+                                    @endforelse
+                                    <tr class="fw-bold">
+                                        <td colspan="3">{{ __('general_content.total_trans_key') }}</td>
+                                        <td colspan="2" class="text-end">{{ number_format($totalPrices, 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-lg-6">
+                                    <h3 class="h6">{{ __('general_content.payment_methods_trans_key') }}</h3>
+                                    <p class="mb-0">{{ $order->payment_method['label'] ?? '-' }}</p>
+                                </div>
+                                <div class="col-lg-6">
+                                    <h3 class="h6">{{ __('general_content.payment_conditions_trans_key') }}</h3>
+                                    <p class="mb-0">{{ $order->payment_condition['label'] ?? '-' }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-lg-6">
+                                    <h3 class="h6">{{ $Factory->name }}</h3>
+                                    @if($Factory->picture)
+                                        <img src="data:image/png;base64,{{ $Factory->getImageFactoryPath() }}" alt="Logo" width="64" class="logo"/>
+                                    @endif
+                                </div>
+                                <div class="col-lg-6">
+                                    <h3 class="h6">{{ __('general_content.adress_trans_key') }}</h3>
+                                    <address class="mb-0">
+                                        {{ $Factory->address }}<br/>
+                                        {{ $Factory->zipcode }} {{ $Factory->city }}<br/>
+                                        {{ __('general_content.phone_trans_key') }} : {{ $Factory->phone_number }}<br/>
+                                        {{ __('general_content.email_trans_key') }} : {{ $Factory->mail }}<br/>
+                                    </address>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-4">
+                    @if ($order->comment)
+                        <div class="card mb-4">
+                            <div class="card-body">
+                                <h3 class="h6">{{ __('general_content.comment_trans_key') }}</h3>
+                                <p class="mb-0">{{ $order->comment }}</p>
+                            </div>
+                        </div>
+                    @endif
+
+                    @if ($order->customer_reference)
+                        <div class="card mb-4">
+                            <div class="card-body">
+                                <h3 class="h6">{{ __('general_content.identifier_trans_key') }}</h3>
+                                <p class="mb-0">{{ $order->customer_reference }}</p>
+                            </div>
+                        </div>
+                    @endif
+
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <h3 class="h6">{{ __('general_content.delevery_method_trans_key') }}</h3>
+                            <strong>{{ $order->delevery_method['label'] ?? '-' }}</strong>
+                            <hr>
+                            <h3 class="h6">{{ __('general_content.adress_trans_key') }}</h3>
+                            <address class="mb-0">
+                                <strong>{{ $order->companie['label'] ?? '-' }}</strong><br>
+                                {{ $order->contact['civility'] ?? '' }} {{ $order->contact['first_name'] ?? '' }} {{ $order->contact['name'] ?? '' }}<br>
+                                {{ $order->adresse['adress'] ?? '' }}<br>
+                                {{ $order->adresse['zipcode'] ?? '' }} {{ $order->adresse['city'] ?? '' }}<br>
+                                {{ $order->adresse['country'] ?? '' }}
+                            </address>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        @if($order->Rating->isEmpty())
+                            <form action="{{ route('order.ratings.store') }}" method="POST">
+                                @csrf
+                                <div class="card-body">
+                                    <input type="hidden" name="orders_id" value="{{ $order->id }}">
+                                    <input type="hidden" name="companies_id" value="{{ $order->companies_id }}">
+                                    <div class="form-group">
+                                        <label for="rating">{{ __('general_content.order_rate_trans_key') }}</label>
+                                        <div class="input-group">
+                                            <div class="input-group-prepend">
+                                                <span class="input-group-text"><i class="fas fa-star-half-alt"></i></span>
+                                            </div>
+                                            <select name="rating" id="rating" class="form-control">
+                                                @for ($i = 1; $i <= 5; $i++)
+                                                    <option value="{{ $i }}">{{ $i }}</option>
+                                                @endfor
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <x-FormTextareaComment comment="" />
+                                    </div>
+                                    <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.submit_trans_key') }}" theme="danger" icon="fas fa-lg fa-save" />
+                                </div>
+                            </form>
+                        @else
+                            @php($Rating = $order->Rating->first())
+                            <div class="card-body">
+                                <label for="rating">{{ __('general_content.order_rate_trans_key') }}</label>
+                                <div>
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        @if ($i <= ($Rating->rating ?? 0))
+                                            <span class="badge badge-warning">&#9733;</span>
+                                        @else
+                                            <span class="badge badge-info">&#9734;</span>
+                                        @endif
+                                    @endfor
+                                </div>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,22 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     //Rating
     Route::post('/order/ratings', 'App\Http\Controllers\Workflow\OrdersRatingController@store')->name('order.ratings.store');
 
+    Route::prefix('customer')->name('customer.')->group(function () {
+        Route::middleware('guest:customer')->group(function () {
+            Route::get('login', 'App\Http\Controllers\Customer\Auth\AuthenticatedSessionController@create')->name('login');
+            Route::post('login', 'App\Http\Controllers\Customer\Auth\AuthenticatedSessionController@store')->name('login.store');
+        });
+
+        Route::middleware('customer')->group(function () {
+            Route::post('logout', 'App\Http\Controllers\Customer\Auth\AuthenticatedSessionController@destroy')->name('logout');
+            Route::get('/', 'App\Http\Controllers\Customer\PortalController@index')->name('dashboard');
+            Route::get('/orders/{order}', 'App\Http\Controllers\Customer\PortalController@showOrder')->name('orders.show');
+            Route::get('/deliveries/{delivery}', 'App\Http\Controllers\Customer\PortalController@showDelivery')->name('deliveries.show');
+            Route::get('/invoices/{invoice}', 'App\Http\Controllers\Customer\PortalController@showInvoice')->name('invoices.show');
+        });
+    });
+
+
     Route::get('/dashboard', 'App\Http\Controllers\HomeController@index')->middleware(['auth', 'check.factory'])->name('dashboard');
 
     Route::group(['prefix' => 'workshop', 'middleware' => ['auth', 'check.factory']], function () {


### PR DESCRIPTION
## Summary
- realigned the authenticated customer order view with the guest layout, reusing status badges, delivery modals, payment details, and rating form
- updated customer delivery note and invoice pages to reuse the established guest presentation, including badge logic and VAT breakdowns

## Testing
- `composer install --ignore-platform-req=ext-ldap` *(fails: GitHub 403 requiring a token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c54ee6d8832d92d9b460010c02d3