### PR TITLE
Configure PHPUnit to use in-memory SQLite database

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,4 +8,9 @@
             <directory>./tests/Unit</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="APP_KEY" value="base64:qRJDlvJWD+XjAG10qaLWo68qC42vtkXaZSRkXA7ekdo="/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- configure phpunit to export environment variables for an in-memory SQLite database
- set a test-only application key so the suite can bootstrap without artisan

## Testing
- not run (vendor dependencies not installed)

------
https://chatgpt.com/codex/tasks/task_e_68d593dec58c832d94f672da6fc22d90