### PR TITLE
Remove hardcoded APP_KEY from PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="APP_KEY" value="base64:qRJDlvJWD+XjAG10qaLWo68qC42vtkXaZSRkXA7ekdo="/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
     </php>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -13,6 +13,13 @@ trait CreatesApplication
      */
     public function createApplication()
     {
+        if (empty($_ENV['APP_KEY']) && empty($_SERVER['APP_KEY']) && getenv('APP_KEY') === false) {
+            $key = 'base64:'.base64_encode(random_bytes(32));
+
+            $_ENV['APP_KEY'] = $_SERVER['APP_KEY'] = $key;
+            putenv('APP_KEY='.$key);
+        }
+
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();


### PR DESCRIPTION
## Summary
- remove the committed Laravel APP_KEY from `phpunit.xml`
- generate a random APP_KEY during test bootstrap when none is provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a19d51e4832d96272ca5e67ab8de