### PR TITLE
Fix methods location data for order view

### DIFF
--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -96,6 +96,7 @@ class OrdersController extends Controller
         $AccountingConditionSelect = $this->SelectDataService->getAccountingPaymentConditions();
         $AccountingMethodsSelect = $this->SelectDataService->getAccountingPaymentMethod();
         $AccountingDeleveriesSelect = $this->SelectDataService->getAccountingDelivery();
+        $MethodsLocationsSelect = $this->SelectDataService->getMethodsLocations();
         $Reviewers = $this->SelectDataService->getUsers();
 
         // Initialize OrderCalculatorService with the order ID
@@ -184,6 +185,7 @@ class OrdersController extends Controller
             'AccountingConditionSelect' => $AccountingConditionSelect,
             'AccountingMethodsSelect' => $AccountingMethodsSelect,
             'AccountingDeleveriesSelect' => $AccountingDeleveriesSelect,
+            'MethodsLocationsSelect' => $MethodsLocationsSelect,
             'Reviewers' => $Reviewers,
             'ReviewTimeline' => $ReviewTimeline,
             'totalPrices' => $totalPrice,


### PR DESCRIPTION
## Summary
- retrieve methods locations select options when showing an order
- pass the locations list to the order view to avoid undefined variable errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69493d803ddc832d84fe63ef711bbdd5)