### PR TITLE
Fix methods location include path in order view

### DIFF
--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -130,7 +130,7 @@
                 @endif
                 <div class="row">
                   <div class="form-group col-md-6">
-                    @include('include.form.form-select-methods-location',[
+                    @include('include.form-select-methods-location',[
                         'methodsLocationId' => $Order->methods_locations_id,
                         'MethodsLocationsSelect' => $MethodsLocationsSelect])
                   </div>


### PR DESCRIPTION
## Summary
- update the order show view to load the existing methods location select partial from the correct path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69493f3de1b0832d9a4673ba052f15de)