### PR TITLE
Improve notification dropdown text wrapping

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -153,29 +153,22 @@
     max-width: calc(100vw - 2rem);
 }
 
-#my-notification .dropdown-menu .notification-item {
+#my-notification .dropdown-menu .dropdown-item {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: start;
+    column-gap: 0.75rem;
+    row-gap: 0.25rem;
     white-space: normal;
-    gap: 0.75rem;
+    overflow-wrap: anywhere;
 }
 
-#my-notification .dropdown-menu .notification-icon {
-    font-size: 1.1rem;
-    line-height: 1;
-    margin-top: 0.15rem;
+#my-notification .dropdown-menu .dropdown-item i {
+    margin-right: 0;
+    line-height: 1.1;
 }
 
-#my-notification .dropdown-menu .notification-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    min-width: 0;
-}
-
-#my-notification .dropdown-menu .notification-text {
-    font-weight: 500;
-    word-break: break-word;
-}
-
-#my-notification .dropdown-menu .notification-time {
-    font-size: 0.75rem;
+#my-notification .dropdown-menu .dropdown-item .text-muted.text-sm {
+    margin-left: 0.5rem;
+    white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- update notification dropdown layout styles to prevent long text from overflowing the menu
- align icons and timestamps with a grid layout while allowing content to wrap within available space

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949694417ec832daf7ad6c204862547)