### PR TITLE
Add translations for review tracking fields

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -381,6 +381,7 @@ return [
     'select_vat_trans_key'                  => 'اختر الضريبة المضافة',
     'select_product_trans_key'              => 'اختر المنتج',
     'user_management_trans_key'             => 'إدارة المستخدمين',
+    'select_user_trans_key'                 => 'اختر مستخدم',
     'select_user_management_trans_key'      => 'اختر إدارة المستخدمين',
     'select_company_trans_key'              => 'اختر جهة ثالثة',
     'select_address_trans_key'              => 'اختر العنوان',
@@ -423,6 +424,17 @@ return [
     'no_role_trans_key'                     => 'لا توجد دور، يرجى إضافته قبل ذلك',
     'no_permissions_trans_key'              => 'لا توجد أذونات، يرجى إضافتها قبل ذلك',
     'no_stock_location_trans_key'           => 'لا توجد موقع مخزني، يرجى إضافته قبل ذلك',
+
+    //REVIEW & CHANGE
+    'review_change_tracking_trans_key'      => 'تتبع المراجعات والتغييرات',
+    'review_timeline_trans_key'             => 'سجل المراجعة',
+    'reviewed_by_trans_key'                 => 'تمت المراجعة بواسطة',
+    'review_date_trans_key'                 => 'تاريخ المراجعة',
+    'decision_trans_key'                    => 'القرار',
+    'change_requested_by_trans_key'         => 'التغيير المطلوب من قبل',
+    'change_reason_trans_key'               => 'سبب التغيير',
+    'change_approved_at_trans_key'          => 'تمت الموافقة على التغيير في',
+    'changes_trans_key'                     => 'التغييرات',
 
     //LINK
     'back_trans_key'                    => 'الرجوع',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -429,6 +429,7 @@ return [
     'select_vat_trans_key'                     => 'Select VAT',
     'select_product_trans_key'                 => 'Select Product',
     'user_management_trans_key'                => 'User management',
+    'select_user_trans_key'                    => 'Select user',
     'select_user_management_trans_key'         => 'Select user management',
     'select_company_trans_key'                 => 'Select third party',
     'select_address_trans_key'                 => 'Select address',
@@ -472,6 +473,17 @@ return [
     'no_role_trans_key'                        => 'No role, please add before',
     'no_permissions_trans_key'                 => 'No permissions, please add before',
     'no_stock_location_trans_key'              => 'No stock location, please add before',
+
+    //REVIEW & CHANGE
+    'review_change_tracking_trans_key'         => 'Review & change tracking',
+    'review_timeline_trans_key'                => 'Review timeline',
+    'reviewed_by_trans_key'                    => 'Reviewed by',
+    'review_date_trans_key'                    => 'Review date',
+    'decision_trans_key'                       => 'Decision',
+    'change_requested_by_trans_key'            => 'Change requested by',
+    'change_reason_trans_key'                  => 'Change reason',
+    'change_approved_at_trans_key'             => 'Change approved at',
+    'changes_trans_key'                        => 'Changes',
 
     //LINK
     'back_trans_key'                           => 'Back',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -379,6 +379,7 @@ return [
     'select_vat_trans_key'                     => 'Seleccionar IVA',
     'select_product_trans_key'                 => 'Seleccionar Producto',
     'user_management_trans_key'                => 'Gestión de usuarios',
+    'select_user_trans_key'                    => 'Seleccionar usuario',
     'select_user_management_trans_key'         => 'Seleccionar gestión de usuarios',
     'select_company_trans_key'                 => 'Seleccionar tercero',
     'select_address_trans_key'                 => 'Seleccionar dirección',
@@ -421,6 +422,17 @@ return [
     'no_role_trans_key'                        => 'Ningún rol, por favor añadir antes',
     'no_permissions_trans_key'                 => 'Ningunos permisos, por favor añadir antes',
     'no_stock_location_trans_key'              => 'Ninguna ubicación de stock, por favor añadir antes',
+
+    //REVIEW & CHANGE
+    'review_change_tracking_trans_key'         => 'Seguimiento de revisiones y cambios',
+    'review_timeline_trans_key'                => 'Historial de revisión',
+    'reviewed_by_trans_key'                    => 'Revisado por',
+    'review_date_trans_key'                    => 'Fecha de revisión',
+    'decision_trans_key'                       => 'Decisión',
+    'change_requested_by_trans_key'            => 'Cambio solicitado por',
+    'change_reason_trans_key'                  => 'Motivo del cambio',
+    'change_approved_at_trans_key'             => 'Cambio aprobado en',
+    'changes_trans_key'                        => 'Cambios',
 
 
     //LINK

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -429,6 +429,7 @@ return [
     'select_vat_trans_key'                     => 'Selectionner TVA',
     'select_product_trans_key'                 => 'Selectionner produit',
     'user_management_trans_key'                => 'Utilisateur responsable',
+    'select_user_trans_key'                    => 'Sélectionner un utilisateur',
     'select_user_management_trans_key'         => 'Selectionner l\'utilisateur',
     'select_company_trans_key'                 => 'Selectionner tiers',
     'select_address_trans_key'                 => 'Selectionner adresse',
@@ -472,6 +473,17 @@ return [
     'no_role_trans_key'                        => 'Aucun role, veuillez ajouter un role',
     'no_permissions_trans_key'                 => 'Aucune permission, veuillez ajouter une permission',
     'no_stock_location_trans_key'              => 'Aucune location de stock',
+
+    //REVIEW & CHANGE
+    'review_change_tracking_trans_key'         => 'Suivi des revues et changements',
+    'review_timeline_trans_key'                => 'Historique de revue',
+    'reviewed_by_trans_key'                    => 'Revu par',
+    'review_date_trans_key'                    => 'Date de revue',
+    'decision_trans_key'                       => 'Décision',
+    'change_requested_by_trans_key'            => 'Changement demandé par',
+    'change_reason_trans_key'                  => 'Motif du changement',
+    'change_approved_at_trans_key'             => 'Changement approuvé le',
+    'changes_trans_key'                        => 'Modifications',
 
     //LINK
     'back_trans_key'                           => 'Retour',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -177,4 +177,16 @@ return [
     'custom_fields_options_placeholder_trans_key' => 'Mỗi dòng một tùy chọn',
     'custom_fields_options_help_trans_key'     => 'Được hiển thị như các giá trị có thể chọn trong danh sách.',
     'custom_fields_select_placeholder_trans_key' => 'Chọn một tùy chọn',
+    'select_user_trans_key'                    => 'Chọn người dùng',
+
+    //REVIEW & CHANGE
+    'review_change_tracking_trans_key'         => 'Theo dõi xem xét và thay đổi',
+    'review_timeline_trans_key'                => 'Dòng thời gian xem xét',
+    'reviewed_by_trans_key'                    => 'Người duyệt',
+    'review_date_trans_key'                    => 'Ngày duyệt',
+    'decision_trans_key'                       => 'Quyết định',
+    'change_requested_by_trans_key'            => 'Người yêu cầu thay đổi',
+    'change_reason_trans_key'                  => 'Lý do thay đổi',
+    'change_approved_at_trans_key'             => 'Thời gian phê duyệt thay đổi',
+    'changes_trans_key'                        => 'Thay đổi',
 ];

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -429,6 +429,7 @@ return [
     'select_vat_trans_key'                     => '选择增值税',
     'select_product_trans_key'                 => '选择产品',
     'user_management_trans_key'                => '负责人',
+    'select_user_trans_key'                    => '选择用户',
     'select_user_management_trans_key'         => '选择用户',
     'select_company_trans_key'                 => '选择第三方',
     'select_address_trans_key'                 => '选择地址',
@@ -472,6 +473,17 @@ return [
     'no_role_trans_key'                        => '暂无角色，请添加角色。',
     'no_permissions_trans_key'                 => '暂无权限，请添加权限。',
     'no_stock_location_trans_key'              => '暂无库存地点',
+
+    //REVIEW & CHANGE
+    'review_change_tracking_trans_key'         => '审核与变更跟踪',
+    'review_timeline_trans_key'                => '审核时间线',
+    'reviewed_by_trans_key'                    => '审核人',
+    'review_date_trans_key'                    => '审核日期',
+    'decision_trans_key'                       => '决策',
+    'change_requested_by_trans_key'            => '变更请求人',
+    'change_reason_trans_key'                  => '变更原因',
+    'change_approved_at_trans_key'             => '变更批准时间',
+    'changes_trans_key'                        => '变更',
 
     //LINK
     'back_trans_key'                           => '返回',

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -140,14 +140,14 @@
                 </div>
                 <div class="row mt-3">
                   <div class="col-12">
-                    <h5 class="text-info">{{ __('Review & change tracking') }}</h5>
+                    <h5 class="text-info">{{ __('general_content.review_change_tracking_trans_key') }}</h5>
                   </div>
                 </div>
                 <div class="row">
                   <div class="form-group col-md-6">
-                    <label for="reviewed_by">{{ __('Reviewed by') }}</label>
+                    <label for="reviewed_by">{{ __('general_content.reviewed_by_trans_key') }}</label>
                     <select class="form-control" name="reviewed_by" id="reviewed_by">
-                      <option value="">{{ __('Select user') }}</option>
+                      <option value="">{{ __('general_content.select_user_trans_key') }}</option>
                       @foreach($Reviewers as $user)
                         <option value="{{ $user->id }}" @selected(old('reviewed_by', $Order->reviewed_by) == $user->id)>{{ $user->name }}</option>
                       @endforeach
@@ -157,7 +157,7 @@
                     @enderror
                   </div>
                   <div class="form-group col-md-6">
-                    <label for="reviewed_at">{{ __('Review date') }}</label>
+                    <label for="reviewed_at">{{ __('general_content.review_date_trans_key') }}</label>
                     <input type="datetime-local" class="form-control" name="reviewed_at" id="reviewed_at" value="{{ old('reviewed_at', optional($Order->reviewed_at)->format('Y-m-d\\TH:i')) }}">
                     @error('reviewed_at')
                       <span class="text-danger">{{ $message }}</span>
@@ -166,7 +166,7 @@
                 </div>
                 <div class="row">
                   <div class="form-group col-md-6">
-                    <label for="review_decision">{{ __('Decision') }}</label>
+                    <label for="review_decision">{{ __('general_content.decision_trans_key') }}</label>
                     <select class="form-control" name="review_decision" id="review_decision">
                       <option value="">{{ __('general_content.undefined_trans_key') }}</option>
                       <option value="pending" @selected(old('review_decision', $Order->review_decision) === 'pending')>{{ __('general_content.pending_trans_key') }}</option>
@@ -178,9 +178,9 @@
                     @enderror
                   </div>
                   <div class="form-group col-md-6">
-                    <label for="change_requested_by">{{ __('Change requested by') }}</label>
+                    <label for="change_requested_by">{{ __('general_content.change_requested_by_trans_key') }}</label>
                     <select class="form-control" name="change_requested_by" id="change_requested_by">
-                      <option value="">{{ __('Select user') }}</option>
+                      <option value="">{{ __('general_content.select_user_trans_key') }}</option>
                       @foreach($Reviewers as $user)
                         <option value="{{ $user->id }}" @selected(old('change_requested_by', $Order->change_requested_by) == $user->id)>{{ $user->name }}</option>
                       @endforeach
@@ -192,7 +192,7 @@
                 </div>
                 <div class="row">
                   <div class="form-group col-md-12">
-                    <label for="change_reason">{{ __('Change reason') }}</label>
+                    <label for="change_reason">{{ __('general_content.change_reason_trans_key') }}</label>
                     <textarea class="form-control" name="change_reason" id="change_reason" rows="3">{{ old('change_reason', $Order->change_reason) }}</textarea>
                     @error('change_reason')
                       <span class="text-danger">{{ $message }}</span>
@@ -201,7 +201,7 @@
                 </div>
                 <div class="row">
                   <div class="form-group col-md-6">
-                    <label for="change_approved_at">{{ __('Change approved at') }}</label>
+                    <label for="change_approved_at">{{ __('general_content.change_approved_at_trans_key') }}</label>
                     <input type="datetime-local" class="form-control" name="change_approved_at" id="change_approved_at" value="{{ old('change_approved_at', optional($Order->change_approved_at)->format('Y-m-d\\TH:i')) }}">
                     @error('change_approved_at')
                       <span class="text-danger">{{ $message }}</span>
@@ -576,16 +576,16 @@
       </div>
 
       <div class="tab-pane " id="Logs">
-        <x-adminlte-card title="{{ __('Review timeline') }}" theme="info" icon="fas fa-history" class="mb-4">
+        <x-adminlte-card title="{{ __('general_content.review_timeline_trans_key') }}" theme="info" icon="fas fa-history" class="mb-4">
           @php
             $reviewersById = $Reviewers->keyBy('id');
             $fieldLabels = [
-              'reviewed_by' => __('Reviewed by'),
-              'reviewed_at' => __('Review date'),
-              'review_decision' => __('Decision'),
-              'change_requested_by' => __('Change requested by'),
-              'change_reason' => __('Change reason'),
-              'change_approved_at' => __('Change approved at'),
+              'reviewed_by' => __('general_content.reviewed_by_trans_key'),
+              'reviewed_at' => __('general_content.review_date_trans_key'),
+              'review_decision' => __('general_content.decision_trans_key'),
+              'change_requested_by' => __('general_content.change_requested_by_trans_key'),
+              'change_reason' => __('general_content.change_reason_trans_key'),
+              'change_approved_at' => __('general_content.change_approved_at_trans_key'),
             ];
             $formatReviewValue = function ($field, $value) use ($reviewersById) {
                 if (is_null($value) || $value === '') {
@@ -626,7 +626,7 @@
                     <th>{{ __('general_content.created_trans_key') }}</th>
                     <th>{{ __('general_content.user_trans_key') }}</th>
                     <th>{{ __('general_content.description_trans_key') }}</th>
-                    <th>{{ __('Changes') }}</th>
+                    <th>{{ __('general_content.changes_trans_key') }}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -113,14 +113,14 @@
                 </div>
                 <div class="row mt-3">
                   <div class="col-12">
-                    <h5 class="text-info">{{ __('Review & change tracking') }}</h5>
+                    <h5 class="text-info">{{ __('general_content.review_change_tracking_trans_key') }}</h5>
                   </div>
                 </div>
                 <div class="row">
                   <div class="form-group col-md-6">
-                    <label for="reviewed_by">{{ __('Reviewed by') }}</label>
+                    <label for="reviewed_by">{{ __('general_content.reviewed_by_trans_key') }}</label>
                     <select class="form-control" name="reviewed_by" id="reviewed_by">
-                      <option value="">{{ __('Select user') }}</option>
+                      <option value="">{{ __('general_content.select_user_trans_key') }}</option>
                       @foreach($Reviewers as $user)
                         <option value="{{ $user->id }}" @selected(old('reviewed_by', $Quote->reviewed_by) == $user->id)>{{ $user->name }}</option>
                       @endforeach
@@ -130,7 +130,7 @@
                     @enderror
                   </div>
                   <div class="form-group col-md-6">
-                    <label for="reviewed_at">{{ __('Review date') }}</label>
+                    <label for="reviewed_at">{{ __('general_content.review_date_trans_key') }}</label>
                     <input type="datetime-local" class="form-control" name="reviewed_at" id="reviewed_at" value="{{ old('reviewed_at', optional($Quote->reviewed_at)->format('Y-m-d\\TH:i')) }}">
                     @error('reviewed_at')
                       <span class="text-danger">{{ $message }}</span>
@@ -139,7 +139,7 @@
                 </div>
                 <div class="row">
                   <div class="form-group col-md-6">
-                    <label for="review_decision">{{ __('Decision') }}</label>
+                    <label for="review_decision">{{ __('general_content.decision_trans_key') }}</label>
                     <select class="form-control" name="review_decision" id="review_decision">
                       <option value="">{{ __('general_content.undefined_trans_key') }}</option>
                       <option value="pending" @selected(old('review_decision', $Quote->review_decision) === 'pending')>{{ __('general_content.pending_trans_key') }}</option>
@@ -151,9 +151,9 @@
                     @enderror
                   </div>
                   <div class="form-group col-md-6">
-                    <label for="change_requested_by">{{ __('Change requested by') }}</label>
+                    <label for="change_requested_by">{{ __('general_content.change_requested_by_trans_key') }}</label>
                     <select class="form-control" name="change_requested_by" id="change_requested_by">
-                      <option value="">{{ __('Select user') }}</option>
+                      <option value="">{{ __('general_content.select_user_trans_key') }}</option>
                       @foreach($Reviewers as $user)
                         <option value="{{ $user->id }}" @selected(old('change_requested_by', $Quote->change_requested_by) == $user->id)>{{ $user->name }}</option>
                       @endforeach
@@ -165,7 +165,7 @@
                 </div>
                 <div class="row">
                   <div class="form-group col-md-12">
-                    <label for="change_reason">{{ __('Change reason') }}</label>
+                    <label for="change_reason">{{ __('general_content.change_reason_trans_key') }}</label>
                     <textarea class="form-control" name="change_reason" id="change_reason" rows="3">{{ old('change_reason', $Quote->change_reason) }}</textarea>
                     @error('change_reason')
                       <span class="text-danger">{{ $message }}</span>
@@ -174,7 +174,7 @@
                 </div>
                 <div class="row">
                   <div class="form-group col-md-6">
-                    <label for="change_approved_at">{{ __('Change approved at') }}</label>
+                    <label for="change_approved_at">{{ __('general_content.change_approved_at_trans_key') }}</label>
                     <input type="datetime-local" class="form-control" name="change_approved_at" id="change_approved_at" value="{{ old('change_approved_at', optional($Quote->change_approved_at)->format('Y-m-d\\TH:i')) }}">
                     @error('change_approved_at')
                       <span class="text-danger">{{ $message }}</span>
@@ -535,16 +535,16 @@
         @endif
       </div>
       <div class="tab-pane " id="Logs">
-        <x-adminlte-card title="{{ __('Review timeline') }}" theme="info" icon="fas fa-history" class="mb-4">
+        <x-adminlte-card title="{{ __('general_content.review_timeline_trans_key') }}" theme="info" icon="fas fa-history" class="mb-4">
           @php
             $reviewersById = $Reviewers->keyBy('id');
             $fieldLabels = [
-              'reviewed_by' => __('Reviewed by'),
-              'reviewed_at' => __('Review date'),
-              'review_decision' => __('Decision'),
-              'change_requested_by' => __('Change requested by'),
-              'change_reason' => __('Change reason'),
-              'change_approved_at' => __('Change approved at'),
+              'reviewed_by' => __('general_content.reviewed_by_trans_key'),
+              'reviewed_at' => __('general_content.review_date_trans_key'),
+              'review_decision' => __('general_content.decision_trans_key'),
+              'change_requested_by' => __('general_content.change_requested_by_trans_key'),
+              'change_reason' => __('general_content.change_reason_trans_key'),
+              'change_approved_at' => __('general_content.change_approved_at_trans_key'),
             ];
             $formatReviewValue = function ($field, $value) use ($reviewersById) {
                 if (is_null($value) || $value === '') {
@@ -585,7 +585,7 @@
                     <th>{{ __('general_content.created_trans_key') }}</th>
                     <th>{{ __('general_content.user_trans_key') }}</th>
                     <th>{{ __('general_content.description_trans_key') }}</th>
-                    <th>{{ __('Changes') }}</th>
+                    <th>{{ __('general_content.changes_trans_key') }}</th>
                   </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## Summary
- localize review and change tracking labels for quotes and orders
- add translation keys for review workflow fields across supported locales

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac9e049ac832daf3c318fd702f9fa)