### PR TITLE
Fix task resources pivot table usage

### DIFF
--- a/app/Models/Methods/MethodsRessources.php
+++ b/app/Models/Methods/MethodsRessources.php
@@ -23,7 +23,7 @@ class MethodsRessources extends Model
     }
 
     public function tasks() {
-        return $this->belongsToMany(Task::class)
+        return $this->belongsToMany(Task::class, 'task_resources')
                     ->withPivot(['autoselected_ressource', 'userforced_ressource'])
                     ->withTimestamps();
     }

--- a/database/migrations/2023_11_25_202535_create_task_resources_table.php
+++ b/database/migrations/2023_11_25_202535_create_task_resources_table.php
@@ -30,6 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('leads');
+        Schema::dropIfExists('task_resources');
     }
 };


### PR DESCRIPTION
## Summary
- point the MethodsRessources tasks relationship to the existing task_resources pivot table
- correct the task_resources migration rollback to drop the proper table

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae341ddcc832da77f60cfbec0f309)