### PR TITLE
Add status checkbox filter to task list

### DIFF
--- a/app/Livewire/TaskLines.php
+++ b/app/Livewire/TaskLines.php
@@ -17,11 +17,11 @@ class TaskLines extends Component
 
     public $search = '';
     public $searchIdService = '';
-    public $searchIdStatus = '';
     public $searchIdRessource = '';
     public $sortField = 'end_date'; // default sorting field
     public $sortAsc = true; // default sort direction
     public $ShowGenericTask = false;
+    public $selectedStatuses = [];
 
     public $Tasklist;
     public $Factory = [];
@@ -57,6 +57,14 @@ class TaskLines extends Component
                                 $query->whereNotNull('order_lines_id');
                             })
                             ->get();
+
+        $this->selectedStatuses = Status::where('title', '!=', 'Finished')
+                                        ->pluck('id')
+                                        ->toArray();
+
+        if(empty($this->selectedStatuses)){
+            $this->selectedStatuses = Status::pluck('id')->toArray();
+        }
     }
 
     public function render()
@@ -78,32 +86,36 @@ class TaskLines extends Component
                                                         ->whereNull('sub_assembly_id');
                                         })
                                         ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
-                                        ->where('status_id', 'like', '%'.$this->searchIdStatus.'%')
                                         ->where('label','like', '%'.$this->search.'%')
                                         ->when($this->searchIdRessource, function($query){
                                             $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
+                                        })
+                                        ->when($this->selectedStatuses, function($query){
+                                            $query->whereIn('status_id', $this->selectedStatuses);
                                         })
                                         ->get();
         }
         else{
             $Tasklist = $this->Tasklist = Task::with('OrderLines.order')
-            ->where(function ($query) {
-                $query->where(function ($query) {
-                    $query->whereNotNull('sub_assembly_id')
-                            ->whereHas('SubAssembly', function ($query) {
-                                $query->whereNotNull('order_lines_id');
-                            });
-                })
-                ->orWhereNotNull('order_lines_id'); // Combine 'or' within the first 'where'
-            })
-            ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
-            ->where('status_id', 'like', '%'.$this->searchIdStatus.'%')
-            ->where('label', 'like', '%'.$this->search.'%')
-            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
-            ->when($this->searchIdRessource, function($query){
-                $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
-            })
-            ->get();
+                            ->where(function ($query) {
+                                $query->where(function ($query) {
+                                    $query->whereNotNull('sub_assembly_id')
+                                            ->whereHas('SubAssembly', function ($query) {
+                                                $query->whereNotNull('order_lines_id');
+                                            });
+                                })
+                                ->orWhereNotNull('order_lines_id'); // Combine 'or' within the first 'where'
+                            })
+                            ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
+                            ->where('label', 'like', '%'.$this->search.'%')
+                            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+                            ->when($this->searchIdRessource, function($query){
+                                $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
+                            })
+                            ->when($this->selectedStatuses, function($query){
+                                $query->whereIn('status_id', $this->selectedStatuses);
+                            })
+                            ->get();
 
         }
 

--- a/resources/views/livewire/task-lines.blade.php
+++ b/resources/views/livewire/task-lines.blade.php
@@ -39,15 +39,20 @@
                             <label for="searchIdService">{{ __('general_content.status_trans_key') }}</label>
                             <div class="input-group">
                                 <div class="input-group-prepend">
-                                    <span class="input-group-text"><i class="fas fa-list"></i></span>
+                                    <span class="input-group-text"><i class="fas fa-filter"></i></span>
                                 </div>
-                                <select class="form-control" name="searchIdStatus" id="searchIdStatus" wire:model.live="searchIdStatus">
-                                    <option value="" selected>{{ __('general_content.select_statu_trans_key') }}</option>
+                                <div class="form-control overflow-auto" style="max-height: 200px;">
                                     @forelse ($StatusSelect as $item)
-                                    <option value="{{ $item->id }}">{{ $item->title }}</option>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" value="{{ $item->id }}" id="status-{{ $item->id }}" wire:model.live="selectedStatuses">
+                                            <label class="form-check-label" for="status-{{ $item->id }}">
+                                                {{ $item->title }}
+                                            </label>
+                                        </div>
                                     @empty
+                                        <p class="text-muted mb-0">{{ __('general_content.no_data_trans_key') }}</p>
                                     @endforelse
-                                </select>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- initialize task status filters excluding finished tasks by default
- replace status dropdown with checkbox list for filtering task statuses
- apply selected statuses to both regular and generic task queries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae624ae50832da8a2273bce4e7e48)