### PR TITLE
Support product custom fields on quote lines

### DIFF
--- a/app/Http/Controllers/Workflow/QuoteLinesController.php
+++ b/app/Http/Controllers/Workflow/QuoteLinesController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Workflow;
 use Illuminate\Http\Request;
 use App\Services\ImportCsvService;
 use App\Http\Controllers\Controller;
+use App\Models\Admin\CustomField;
+use App\Models\Admin\CustomFieldValue;
 use App\Models\Workflow\QuoteLineDetails;
 use App\Http\Requests\Workflow\UpdateQuoteLineDetailsRequest;
 
@@ -28,8 +30,13 @@ class QuoteLinesController extends Controller
         $QuoteLineDetails = QuoteLineDetails::findOrFail($request->id);
         $validated = $request->validated();
         $validated['custom_requirements'] = $this->sanitizeCustomRequirements($request->input('custom_requirements', []));
+        unset($validated['product_custom_fields']);
 
         $QuoteLineDetails->update($validated);
+        $this->syncProductCustomFields(
+            $QuoteLineDetails->quote_lines_id,
+            $request->input('product_custom_fields', [])
+        );
 
         return redirect()->route('quotes.show', ['id' => $idQuote])->with('success', 'Successfully updated quote detail line');
     }
@@ -48,6 +55,44 @@ class QuoteLinesController extends Controller
             })
             ->values()
             ->all();
+    }
+
+    private function syncProductCustomFields(int $quoteLineId, array $fields): void
+    {
+        if (empty($fields)) {
+            return;
+        }
+
+        $validIds = CustomField::where('related_type', 'product')->pluck('id')->all();
+
+        foreach ($fields as $fieldId => $fieldValue) {
+            if (!in_array((int) $fieldId, $validIds, true)) {
+                continue;
+            }
+
+            $existingValue = CustomFieldValue::where('custom_field_id', $fieldId)
+                ->where('entity_id', $quoteLineId)
+                ->where('entity_type', 'quote_line')
+                ->first();
+
+            if ($fieldValue === null || $fieldValue === '') {
+                if ($existingValue) {
+                    $existingValue->delete();
+                }
+                continue;
+            }
+
+            if ($existingValue) {
+                $existingValue->update(['value' => $fieldValue]);
+            } else {
+                CustomFieldValue::create([
+                    'custom_field_id' => $fieldId,
+                    'entity_id' => $quoteLineId,
+                    'entity_type' => 'quote_line',
+                    'value' => $fieldValue,
+                ]);
+            }
+        }
     }
     
     /**

--- a/app/Http/Requests/Workflow/UpdateQuoteLineDetailsRequest.php
+++ b/app/Http/Requests/Workflow/UpdateQuoteLineDetailsRequest.php
@@ -42,6 +42,8 @@ class UpdateQuoteLineDetailsRequest extends FormRequest
             'custom_requirements' => 'nullable|array',
             'custom_requirements.*.label' => 'nullable|string|max:255',
             'custom_requirements.*.value' => 'nullable|string|max:255',
+            'product_custom_fields' => 'nullable|array',
+            'product_custom_fields.*' => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -16,6 +16,7 @@ use App\Models\Products\CustomerPriceList;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\QuoteLines;
 use Illuminate\Support\Facades\App;
+use App\Services\CustomFieldService;
 use App\Models\Methods\MethodsUnits;
 use App\Models\Planning\SubAssembly;
 use Illuminate\Support\Facades\Auth;
@@ -34,6 +35,7 @@ class QuoteLine extends Component
     public $search = '';
     public $sortField = 'ordre'; // default sorting field
     public $sortAsc = true; // default sort direction
+    protected $customFieldService;
     
     public $QuoteId;
     public $QuoteStatu;
@@ -61,6 +63,7 @@ class QuoteLine extends Component
     public $appliedPriceListId = null;
     public $priceSource = null;
     public $priceListToggleKey;
+    public $productCustomFields = [];
 
     protected $updatingPriceFromList = false;
 
@@ -73,6 +76,7 @@ class QuoteLine extends Component
     {
         // Resolve the service via the Laravel container
         $this->orderService = App::make(OrderService::class);
+        $this->customFieldService = App::make(CustomFieldService::class);
     }
 
     // Validation Rules
@@ -148,6 +152,8 @@ class QuoteLine extends Component
                                                             ->where('quotes_id', '=', $this->quotes_id)
                                                             ->where('label','like', '%'.$this->search.'%')->get();
 
+        $this->loadProductCustomFields($QuoteLineslist);
+
         foreach ($QuoteLineslist as $line) {
             $detail = $line->QuoteLineDetails;
             if ($detail && !array_key_exists($detail->id, $this->customRequirements)) {
@@ -197,6 +203,14 @@ class QuoteLine extends Component
         }
 
         $this->customRequirements[$detailId][] = ['label' => '', 'value' => ''];
+    }
+
+    private function loadProductCustomFields($quoteLines): void
+    {
+        foreach ($quoteLines as $line) {
+            $this->productCustomFields[$line->id] = $this->customFieldService
+                ->getProductCustomFieldsForQuoteLine($line->product_id, $line->id);
+        }
     }
 
     public function removeCustomRequirement($detailId, $index): void

--- a/app/Services/CustomFieldService.php
+++ b/app/Services/CustomFieldService.php
@@ -26,4 +26,38 @@ class CustomFieldService
             ->orderBy('custom_fields.name')
             ->get();
     }
+
+    /**
+     * Get product custom fields with values scoped to a quote line.
+     *
+     * This returns all custom fields defined for products, including any value
+     * previously saved for the provided quote line (entity_type = quote_line)
+     * and the product's own value as a fallback.
+     */
+    public function getProductCustomFieldsForQuoteLine(?int $productId, int $quoteLineId)
+    {
+        if (!$productId) {
+            return collect();
+        }
+
+        return CustomField::where('custom_fields.related_type', '=', 'product')
+            ->leftJoin('custom_field_values as line_values', function ($join) use ($quoteLineId) {
+                $join->on('custom_fields.id', '=', 'line_values.custom_field_id')
+                    ->where('line_values.entity_type', '=', 'quote_line')
+                    ->where('line_values.entity_id', '=', $quoteLineId);
+            })
+            ->leftJoin('custom_field_values as product_values', function ($join) use ($productId) {
+                $join->on('custom_fields.id', '=', 'product_values.custom_field_id')
+                    ->where('product_values.entity_type', '=', 'product')
+                    ->where('product_values.entity_id', '=', $productId);
+            })
+            ->select(
+                'custom_fields.*',
+                'line_values.value as line_value',
+                'product_values.value as product_value'
+            )
+            ->orderBy('custom_fields.category')
+            ->orderBy('custom_fields.name')
+            ->get();
+    }
 }

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -226,6 +226,60 @@
                                                             <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $quoteDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
                                                         </div>
                                                     </div>
+                                                    @php
+                                                        $lineProductCustomFields = $productCustomFields[$QuoteLine->id] ?? collect();
+                                                        $defaultCategoryLabel = __('general_content.custom_fields_default_category_trans_key');
+                                                        $groupedProductFields = $lineProductCustomFields->groupBy(function ($field) use ($defaultCategoryLabel) {
+                                                            return $field->category ?? $defaultCategoryLabel;
+                                                        });
+                                                    @endphp
+                                                    @if($lineProductCustomFields->isNotEmpty())
+                                                        <hr>
+                                                        <div class="row">
+                                                            <div class="col-12">
+                                                                <label class="text-info">{{ __('general_content.custom_fields_trans_key') }} - {{ __('general_content.product_trans_key') }}</label>
+                                                            </div>
+                                                        </div>
+                                                        @foreach($groupedProductFields as $categoryLabel => $fields)
+                                                            <div class="row">
+                                                                <div class="col-12 mb-2">
+                                                                    <strong>{{ $categoryLabel }}</strong>
+                                                                </div>
+                                                                @foreach($fields as $customField)
+                                                                    @php
+                                                                        $fieldInputId = 'quote-line-'.$QuoteLine->id.'-custom-field-'.$customField->id;
+                                                                        $fieldValue = old("product_custom_fields.{$customField->id}", $customField->line_value ?? $customField->product_value);
+                                                                        $fieldOptions = is_array($customField->options) ? $customField->options : [];
+                                                                    @endphp
+                                                                    <div class="form-group col-md-6">
+                                                                        @if ($customField->type === 'checkbox')
+                                                                            <input type="hidden" name="product_custom_fields[{{ $customField->id }}]" value="0">
+                                                                            <div class="form-check">
+                                                                                <input class="form-check-input" type="checkbox" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]" value="1" {{ $fieldValue ? 'checked' : '' }}>
+                                                                                <label class="form-check-label" for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                                            </div>
+                                                                        @elseif ($customField->type === 'select')
+                                                                            <label for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                                            <select class="form-control" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]">
+                                                                                <option value="">{{ __('general_content.custom_fields_select_placeholder_trans_key') }}</option>
+                                                                                @foreach ($fieldOptions as $option)
+                                                                                    <option value="{{ $option }}" {{ $fieldValue === $option ? 'selected' : '' }}>{{ $option }}</option>
+                                                                                @endforeach
+                                                                            </select>
+                                                                        @else
+                                                                            <label for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
+                                                                                </div>
+                                                                                <input class="form-control" type="{{ $customField->type }}" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]" value="{{ $fieldValue }}" placeholder="{{ __('general_content.custom_fields_placeholder_trans_key') }}">
+                                                                            </div>
+                                                                        @endif
+                                                                    </div>
+                                                                @endforeach
+                                                            </div>
+                                                        @endforeach
+                                                    @endif
                                                     <div class="row">
                                                         <div class="form-group col-md-4">
                                                             <div class="input-group">


### PR DESCRIPTION
## Summary
- load product-level custom fields with quote-line values and product defaults when viewing line details
- render product custom field inputs alongside quote line details for per-line overrides
- validate and persist quote-line scoped product custom field values when updating details

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aea941ddc832dbdf059a2958e8b2e)