### PR TITLE
Add status filters to companies list view

### DIFF
--- a/app/Livewire/CompaniesLines.php
+++ b/app/Livewire/CompaniesLines.php
@@ -22,6 +22,7 @@ class CompaniesLines extends Component
     public $search = '';
     public $sortField = 'label'; // default sorting field
     public $sortAsc = true; // default sort direction
+    public $statusFilter = 'all';
 
     public $Companies;
 
@@ -36,6 +37,13 @@ class CompaniesLines extends Component
 
     protected $notificationService;
     protected $documentCodeGenerator;
+
+    protected $queryString = [
+        'search' => ['except' => ''],
+        'sortField' => ['except' => 'label'],
+        'sortAsc' => ['except' => true],
+        'statusFilter' => ['as' => 'type', 'except' => 'all'],
+    ];
 
     public function __construct()
     {
@@ -65,6 +73,11 @@ class CompaniesLines extends Component
         $this->resetPage();
     }
 
+    public function updatingStatusFilter()
+    {
+        $this->resetPage();
+    }
+
     public function mount()
     {
         $this->user_id = Auth::id();
@@ -72,13 +85,36 @@ class CompaniesLines extends Component
         $this->LastCompanie = Companies::orderBy('id', 'desc')->first();
         $companieId = $this->LastCompanie ? $this->LastCompanie->id : 0;
         $this->code = $this->documentCodeGenerator->generateDocumentCode('company', $companieId);
+
+        $availableFilters = ['all', 'client', 'prospect', 'supplier', 'client_supplier'];
+        $requestedFilter = request()->query('type');
+
+        if (in_array($requestedFilter, $availableFilters, true)) {
+            $this->statusFilter = $requestedFilter;
+        }
     }
 
     public function render()
     {
-        
+        $companiesQuery = Companies::where('label', 'like', '%' . $this->search . '%');
+
+        switch ($this->statusFilter) {
+            case 'client':
+                $companiesQuery->where('statu_customer', 2)->where('statu_supplier', '!=', 2);
+                break;
+            case 'prospect':
+                $companiesQuery->where('statu_customer', 3);
+                break;
+            case 'supplier':
+                $companiesQuery->where('statu_supplier', 2)->where('statu_customer', '!=', 2);
+                break;
+            case 'client_supplier':
+                $companiesQuery->where('statu_customer', 2)->where('statu_supplier', 2);
+                break;
+        }
+
         return view('livewire.companies-lines', [
-            'Companieslist' => Companies::where('label','like', '%'.$this->search.'%')->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->paginate(10),
+            'Companieslist' => $companiesQuery->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->paginate(10),
         ]);
     }
 

--- a/resources/views/livewire/companies-lines.blade.php
+++ b/resources/views/livewire/companies-lines.blade.php
@@ -123,7 +123,25 @@
                     <div class="card-body">
                         <div class="row">
                             <div class="col-md-10">
-                                @include('include.search-card')
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        @include('include.search-card')
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="input-group mb-3">
+                                            <div class="input-group-prepend">
+                                                <span class="input-group-text"><i class="fas fa-filter fa-fw"></i></span>
+                                            </div>
+                                            <select class="form-control" wire:model.live="statusFilter">
+                                                <option value="all">{{ __('general_content.view_all_trans_key') }}</option>
+                                                <option value="client">{{ __('general_content.client_trans_key') }}</option>
+                                                <option value="prospect">{{ __('general_content.prospect_trans_key') }}</option>
+                                                <option value="supplier">{{ __('general_content.suppliers_trans_key') }}</option>
+                                                <option value="client_supplier">{{ __('general_content.suppliers_client_trans_key') }}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="col-md-2">
                                 <button type="button" class="btn btn-success float-sm-right" data-toggle="modal" data-target="#ModalCompanie">


### PR DESCRIPTION
## Summary
- add type-based filtering to the companies Livewire list with support for query params
- reset pagination and persist filter selection via query string
- update companies index UI with a dropdown to filter clients, prospects, suppliers, or both

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aeeaed618832dbdeb3a432eb97945)