### PR TITLE
Update order sites migration

### DIFF
--- a/database/migrations/2025_08_24_000000_create_order_sites_table.php
+++ b/database/migrations/2025_08_24_000000_create_order_sites_table.php
@@ -11,7 +11,21 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (!Schema::hasTable('order_sites')) {
+        if (Schema::hasTable('order_sites')) {
+            Schema::table('order_sites', function (Blueprint $table) {
+                if (!Schema::hasColumn('order_sites', 'location')) {
+                    $table->string('location')->nullable()->after('order_id');
+                }
+
+                if (!Schema::hasColumn('order_sites', 'characteristics')) {
+                    $table->text('characteristics')->nullable()->after('location');
+                }
+
+                if (!Schema::hasColumn('order_sites', 'contact_info')) {
+                    $table->text('contact_info')->nullable()->after('characteristics');
+                }
+            });
+        } else {
             Schema::create('order_sites', function (Blueprint $table) {
                 $table->id();
                 $table->foreignId('order_id')->constrained('orders')->onDelete('cascade');
@@ -28,6 +42,20 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('order_sites');
+        if (Schema::hasTable('order_sites')) {
+            Schema::table('order_sites', function (Blueprint $table) {
+                if (Schema::hasColumn('order_sites', 'contact_info')) {
+                    $table->dropColumn('contact_info');
+                }
+
+                if (Schema::hasColumn('order_sites', 'characteristics')) {
+                    $table->dropColumn('characteristics');
+                }
+
+                if (Schema::hasColumn('order_sites', 'location')) {
+                    $table->dropColumn('location');
+                }
+            });
+        }
     }
 };


### PR DESCRIPTION
## Summary
- change the 2025 order sites migration to alter the existing table instead of re-creating it
- add location, characteristics, and contact_info columns conditionally when the table exists, and clean them up on rollback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bed47125c832daedef3296979325b)