### PR TITLE
Add collapsible sections to order line detail modal

### DIFF
--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -169,163 +169,231 @@
                                             <form method="POST" action="{{ route('orders.update.detail.line', ['idOrder'=>  $OrderLine->orders_id, 'id' => $OrderLine->OrderLineDetails->id]) }}" enctype="multipart/form-data">
                                             @csrf
                                             <div class="card-body">
-                                                <div class="row">
-                                                    <div class="form-group col-md-4">
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fab fa-mdb"></i></span>
-                                                            </div>
-                                                            <input type="text" class="form-control" value="{{ $OrderLine->OrderLineDetails->material }}" name="material" id="material"  placeholder="{{ __('general_content.material_trans_key') }}">
+                                                <div class="accordion" id="orderLineDetailAccordion{{ $OrderLine->id }}">
+                                                    <div class="card card-outline card-success mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#orderLineMainFeatures{{ $OrderLine->id }}" aria-expanded="true" aria-controls="orderLineMainFeatures{{ $OrderLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-stream text-success mr-2"></i> {{ __('Caractéristiques principales') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-vertical"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->thickness }}" name="thickness" id="thickness"  placeholder="{{ __('general_content.thickness_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-weight-hanging"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->weight }}" name="weight" id="weight"  placeholder="{{ __('general_content.weight_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <hr>
-                                                <div class="row">
-                                                    <div class="form-group col-md-4">
-                                                        <label for="x_size">X</label>
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{  $OrderLine->OrderLineDetails->x_size }}" name="x_size" id="x_size"  placeholder="{{ __('general_content.x_size_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <label for="y_size">Y</label>
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{  $OrderLine->OrderLineDetails->y_size }}"  name="y_size" id="y_size"  placeholder="{{ __('general_content.y_size_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <label for="z_size">Z</label>
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{  $OrderLine->OrderLineDetails->z_size }}" name="z_size" id="z_size"  placeholder="{{ __('general_content.z_size_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="row">
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                        <div id="orderLineMainFeatures{{ $OrderLine->id }}" class="collapse show" aria-labelledby="orderLineMainFeatures{{ $OrderLine->id }}" data-parent="#orderLineDetailAccordion{{ $OrderLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fab fa-mdb"></i></span>
+                                                                            </div>
+                                                                            <input type="text" class="form-control" value="{{ $OrderLine->OrderLineDetails->material }}" name="material" id="material"  placeholder="{{ __('general_content.material_trans_key') }}">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-vertical"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->thickness }}" name="thickness" id="thickness"  placeholder="{{ __('general_content.thickness_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-weight-hanging"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->weight }}" name="weight" id="weight"  placeholder="{{ __('general_content.weight_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
                                                                 </div>
-                                                                <input type="number" class="form-control"  value="{{ $OrderLine->OrderLineDetails->x_oversize }}" name="x_oversize" id="x_oversize"  placeholder="{{ __('general_content.x_oversize_trans_key') }}" step=".001">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->y_oversize }}" name="y_oversize" id="y_oversize"  placeholder="{{ __('general_content.y_oversize_trans_key') }}" step=".001">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->z_oversize }}" name="z_oversize" id="z_oversize"  placeholder="{{ __('general_content.z_oversize_trans_key') }}" step=".001">
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <hr>
-                                                    <div class="row">
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->diameter }}" name="diameter" id="diameter"  placeholder="{{ __('general_content.diameter_trans_key') }}" step=".001">
-                                                            </div>
+
+                                                    <div class="card card-outline card-primary mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#orderLineDimensions{{ $OrderLine->id }}" aria-expanded="false" aria-controls="orderLineDimensions{{ $OrderLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-ruler-combined text-primary mr-2"></i> {{ __('Dimensions (X, Y, Z)') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                        <div id="orderLineDimensions{{ $OrderLine->id }}" class="collapse" aria-labelledby="orderLineDimensions{{ $OrderLine->id }}" data-parent="#orderLineDetailAccordion{{ $OrderLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-4">
+                                                                        <label for="x_size">X</label>
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{  $OrderLine->OrderLineDetails->x_size }}" name="x_size" id="x_size"  placeholder="{{ __('general_content.x_size_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <label for="y_size">Y</label>
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{  $OrderLine->OrderLineDetails->y_size }}"  name="y_size" id="y_size"  placeholder="{{ __('general_content.y_size_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <label for="z_size">Z</label>
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{  $OrderLine->OrderLineDetails->z_size }}" name="z_size" id="z_size"  placeholder="{{ __('general_content.z_size_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
                                                                 </div>
-                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->diameter_oversize }}" name="diameter_oversize" id="diameter_oversize"  placeholder="{{ __('general_content.diameter_oversize_trans_key') }}" step=".001">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-percentage"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->material_loss_rate }}" name="material_loss_rate" id="material_loss_rate"  placeholder="{{ __('general_content.material_loss_rate_trans_key') }}" step=".001">
+                                                                <div class="row">
+                                                                        <div class="form-group col-md-4">
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                                </div>
+                                                                                <input type="number" class="form-control"  value="{{ $OrderLine->OrderLineDetails->x_oversize }}" name="x_oversize" id="x_oversize"  placeholder="{{ __('general_content.x_oversize_trans_key') }}" step=".001">
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="form-group col-md-4">
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                                </div>
+                                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->y_oversize }}" name="y_oversize" id="y_oversize"  placeholder="{{ __('general_content.y_oversize_trans_key') }}" step=".001">
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="form-group col-md-4">
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                                </div>
+                                                                                <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->z_oversize }}" name="z_oversize" id="z_oversize"  placeholder="{{ __('general_content.z_oversize_trans_key') }}" step=".001">
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
                                                             </div>
                                                         </div>
                                                     </div>
+
+                                                    <div class="card card-outline card-warning mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#orderLineCircularSpecs{{ $OrderLine->id }}" aria-expanded="false" aria-controls="orderLineCircularSpecs{{ $OrderLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-circle-notch text-warning mr-2"></i> {{ __('Spécifications circulaires') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
+                                                        </div>
+                                                        <div id="orderLineCircularSpecs{{ $OrderLine->id }}" class="collapse" aria-labelledby="orderLineCircularSpecs{{ $OrderLine->id }}" data-parent="#orderLineDetailAccordion{{ $OrderLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->diameter }}" name="diameter" id="diameter"  placeholder="{{ __('general_content.diameter_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->diameter_oversize }}" name="diameter_oversize" id="diameter_oversize"  placeholder="{{ __('general_content.diameter_oversize_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-percentage"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $OrderLine->OrderLineDetails->material_loss_rate }}" name="material_loss_rate" id="material_loss_rate"  placeholder="{{ __('general_content.material_loss_rate_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
                                                     @php $orderDetailId = $OrderLine->OrderLineDetails->id; @endphp
-                                                    <div class="row">
-                                                        <div class="col-12">
-                                                            <label class="text-info">{{ __('Custom requirements') }}</label>
+                                                    <div class="card card-outline card-danger mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#orderLineCustomReq{{ $OrderLine->id }}" aria-expanded="false" aria-controls="orderLineCustomReq{{ $OrderLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-tasks text-danger mr-2"></i> {{ __('Exigences personnalisées') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        @forelse($customRequirements[$orderDetailId] ?? [] as $index => $requirement)
-                                                            <div class="form-row align-items-end w-100" wire:key="order-custom-{{ $orderDetailId }}-{{ $index }}">
-                                                                <div class="form-group col-md-5">
-                                                                    <label for="order_custom_requirement_label_{{ $orderDetailId }}_{{ $index }}">{{ __('Label') }}</label>
-                                                                    <input type="text" class="form-control" id="order_custom_requirement_label_{{ $orderDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][label]" wire:model="customRequirements.{{ $orderDetailId }}.{{ $index }}.label" placeholder="{{ __('Label') }}">
+                                                        <div id="orderLineCustomReq{{ $OrderLine->id }}" class="collapse" aria-labelledby="orderLineCustomReq{{ $OrderLine->id }}" data-parent="#orderLineDetailAccordion{{ $OrderLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="col-12">
+                                                                        <label class="text-info">{{ __('Custom requirements') }}</label>
+                                                                    </div>
+                                                                    @forelse($customRequirements[$orderDetailId] ?? [] as $index => $requirement)
+                                                                        <div class="form-row align-items-end w-100" wire:key="order-custom-{{ $orderDetailId }}-{{ $index }}">
+                                                                            <div class="form-group col-md-5">
+                                                                                <label for="order_custom_requirement_label_{{ $orderDetailId }}_{{ $index }}">{{ __('Label') }}</label>
+                                                                                <input type="text" class="form-control" id="order_custom_requirement_label_{{ $orderDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][label]" wire:model="customRequirements.{{ $orderDetailId }}.{{ $index }}.label" placeholder="{{ __('Label') }}">
+                                                                            </div>
+                                                                            <div class="form-group col-md-5">
+                                                                                <label for="order_custom_requirement_value_{{ $orderDetailId }}_{{ $index }}">{{ __('Value') }}</label>
+                                                                                <input type="text" class="form-control" id="order_custom_requirement_value_{{ $orderDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][value]" wire:model="customRequirements.{{ $orderDetailId }}.{{ $index }}.value" placeholder="{{ __('Value') }}">
+                                                                            </div>
+                                                                            <div class="form-group col-md-2">
+                                                                                <button type="button" class="btn btn-outline-danger mt-4" wire:click="removeCustomRequirement({{ $orderDetailId }}, {{ $index }})"><i class="fas fa-trash"></i></button>
+                                                                            </div>
+                                                                        </div>
+                                                                    @empty
+                                                                        <div class="col-12">
+                                                                            <p class="text-muted">{{ __('No custom requirement added yet.') }}</p>
+                                                                        </div>
+                                                                    @endforelse
+                                                                    <div class="col-12 mb-3">
+                                                                        <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $orderDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
+                                                                    </div>
                                                                 </div>
-                                                                <div class="form-group col-md-5">
-                                                                    <label for="order_custom_requirement_value_{{ $orderDetailId }}_{{ $index }}">{{ __('Value') }}</label>
-                                                                    <input type="text" class="form-control" id="order_custom_requirement_value_{{ $orderDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][value]" wire:model="customRequirements.{{ $orderDetailId }}.{{ $index }}.value" placeholder="{{ __('Value') }}">
-                                                                </div>
-                                                                <div class="form-group col-md-2">
-                                                                    <button type="button" class="btn btn-outline-danger mt-4" wire:click="removeCustomRequirement({{ $orderDetailId }}, {{ $index }})"><i class="fas fa-trash"></i></button>
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-6">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fab fa-mdb"></i></span>
+                                                                            </div>
+                                                                            <input type="text" class="form-control" value="{{ $OrderLine->OrderLineDetails->finishing }}" name="finishing" id="finishing"  placeholder="{{ __('general_content.finishing_trans_key') }}">
+                                                                        </div>
+                                                                    </div>
                                                                 </div>
                                                             </div>
-                                                        @empty
-                                                            <div class="col-12">
-                                                                <p class="text-muted">{{ __('No custom requirement added yet.') }}</p>
-                                                            </div>
-                                                        @endforelse
-                                                        <div class="col-12 mb-3">
-                                                            <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $orderDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
                                                         </div>
                                                     </div>
-                                                    <div class="row">
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fab fa-mdb"></i></span>
+
+                                                    <div class="card card-outline card-secondary mb-0">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#orderLineComments{{ $OrderLine->id }}" aria-expanded="false" aria-controls="orderLineComments{{ $OrderLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-comments text-secondary mr-2"></i> {{ __('Commentaires') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
+                                                        </div>
+                                                        <div id="orderLineComments{{ $OrderLine->id }}" class="collapse" aria-labelledby="orderLineComments{{ $OrderLine->id }}" data-parent="#orderLineDetailAccordion{{ $OrderLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <x-FormTextareaComment  label="Internal comment" name="internal_comment" comment="{{ $OrderLine->OrderLineDetails->internal_comment }}" />
                                                                 </div>
-                                                                <input type="text" class="form-control" value="{{ $OrderLine->OrderLineDetails->finishing }}" name="finishing" id="finishing"  placeholder="{{ __('general_content.finishing_trans_key') }}">
+                                                                <div class="row mt-3">
+                                                                    <x-FormTextareaComment  label="External comment" name="external_comment" comment="{{ $OrderLine->OrderLineDetails->external_comment }}" />
+                                                                </div>
                                                             </div>
                                                         </div>
-                                                        <div class="form-group col-md-4">
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                        </div>
-                                                    </div>
-                                                    <hr>
-                                                    <div class="row">
-                                                        <x-FormTextareaComment  label="Internal comment" name="internal_comment" comment="{{ $OrderLine->OrderLineDetails->internal_comment }}" />
-                                                    </div>
-                                                    <div class="row">
-                                                        <x-FormTextareaComment  label="External comment" name="external_comment" comment="{{ $OrderLine->OrderLineDetails->external_comment }}" />
                                                     </div>
                                                 </div>
                                                 <div class="card-footer">
@@ -333,23 +401,39 @@
                                                 </div>
                                             </form>
                                             <div class="card-body">
-                                                <form action="{{ route('orders.update.detail.picture', ['idOrder'=>  $OrderLine->orders_id, 'id' => $OrderLine->OrderLineDetails->id]) }}" method="POST" enctype="multipart/form-data">
-                                                    @csrf
-                                                    <label for="picture">{{ __('general_content.picture_file_trans_key') }}</label>(peg,png,jpg,gif,svg | max: 10 240 Ko)
-                                                    <div class="input-group">
-                                                        <div class="input-group-prepend">
-                                                            <span class="input-group-text"><i class="far fa-image"></i></span>
+                                                <div class="accordion" id="orderLineAttachmentAccordion{{ $OrderLine->id }}">
+                                                    <div class="card card-outline card-success mb-0">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#orderLineAttachments{{ $OrderLine->id }}" aria-expanded="true" aria-controls="orderLineAttachments{{ $OrderLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-paperclip text-success mr-2"></i> {{ __('Fichiers attachés') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        <div class="custom-file">
-                                                            <input type="hidden" name="id" value="{{ $OrderLine->id }}">
-                                                            <input type="file" class="custom-file-input" name="picture" id="picture">
-                                                            <label class="custom-file-label" for="picture">{{ __('general_content.choose_file_trans_key') }}</label>
-                                                        </div>
-                                                        <div class="input-group-append">
-                                                            <button type="submit" class="btn btn-success">{{ __('general_content.upload_trans_key') }}</button>
+                                                        <div id="orderLineAttachments{{ $OrderLine->id }}" class="collapse show" aria-labelledby="orderLineAttachments{{ $OrderLine->id }}" data-parent="#orderLineAttachmentAccordion{{ $OrderLine->id }}">
+                                                            <div class="card-body">
+                                                                <form action="{{ route('orders.update.detail.picture', ['idOrder'=>  $OrderLine->orders_id, 'id' => $OrderLine->OrderLineDetails->id]) }}" method="POST" enctype="multipart/form-data">
+                                                                    @csrf
+                                                                    <label for="picture">{{ __('general_content.picture_file_trans_key') }}</label>(peg,png,jpg,gif,svg | max: 10 240 Ko)
+                                                                    <div class="input-group">
+                                                                        <div class="input-group-prepend">
+                                                                            <span class="input-group-text"><i class="far fa-image"></i></span>
+                                                                        </div>
+                                                                        <div class="custom-file">
+                                                                            <input type="hidden" name="id" value="{{ $OrderLine->id }}">
+                                                                            <input type="file" class="custom-file-input" name="picture" id="picture">
+                                                                            <label class="custom-file-label" for="picture">{{ __('general_content.choose_file_trans_key') }}</label>
+                                                                        </div>
+                                                                        <div class="input-group-append">
+                                                                            <button type="submit" class="btn btn-success">{{ __('general_content.upload_trans_key') }}</button>
+                                                                        </div>
+                                                                    </div>
+                                                                </form>
+                                                            </div>
                                                         </div>
                                                     </div>
-                                                </form>
+                                                </div>
                                             </div>
                                         </x-adminlte-modal>
                                     </div>

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -89,143 +89,202 @@
                                             <form method="POST" action="{{ route('quotes.update.detail.line', ['idQuote'=>  $QuoteLine->quotes_id, 'id' => $QuoteLine->QuoteLineDetails->id]) }}" enctype="multipart/form-data">
                                             @csrf
                                             <div class="card-body">
-                                                <div class="row">
-                                                    <div class="form-group col-md-4">
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fab fa-mdb"></i></span>
-                                                            </div>
-                                                            <input type="text" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->material }}" name="material" id="material"  placeholder="{{ __('general_content.material_trans_key') }}">
+                                                <div class="accordion" id="quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                    <div class="card card-outline card-success mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineMainFeatures{{ $QuoteLine->id }}" aria-expanded="true" aria-controls="quoteLineMainFeatures{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-stream text-success mr-2"></i> {{ __('Caractéristiques principales') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-vertical"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->thickness }}" name="thickness" id="thickness"  placeholder="{{ __('general_content.thickness_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-weight-hanging"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->weight }}" name="weight" id="weight"  placeholder="{{ __('general_content.weight_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <hr>
-                                                <div class="row">
-                                                    <div class="form-group col-md-4">
-                                                        <label for="x_size">X</label>
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{  $QuoteLine->QuoteLineDetails->x_size }}" name="x_size" id="x_size"  placeholder="{{ __('general_content.x_size_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <label for="y_size">Y</label>
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{  $QuoteLine->QuoteLineDetails->y_size }}"  name="y_size" id="y_size"  placeholder="{{ __('general_content.y_size_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <label for="z_size">Z</label>
-                                                        <div class="input-group">
-                                                            <div class="input-group-prepend">
-                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                            </div>
-                                                            <input type="number" class="form-control" value="{{  $QuoteLine->QuoteLineDetails->z_size }}" name="z_size" id="z_size"  placeholder="{{ __('general_content.z_size_trans_key') }}" step=".001">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="row">
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                        <div id="quoteLineMainFeatures{{ $QuoteLine->id }}" class="collapse show" aria-labelledby="quoteLineMainFeatures{{ $QuoteLine->id }}" data-parent="#quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fab fa-mdb"></i></span>
+                                                                            </div>
+                                                                            <input type="text" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->material }}" name="material" id="material"  placeholder="{{ __('general_content.material_trans_key') }}">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-vertical"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->thickness }}" name="thickness" id="thickness"  placeholder="{{ __('general_content.thickness_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-weight-hanging"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->weight }}" name="weight" id="weight"  placeholder="{{ __('general_content.weight_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
                                                                 </div>
-                                                                <input type="number" class="form-control"  value="{{ $QuoteLine->QuoteLineDetails->x_oversize }}" name="x_oversize" id="x_oversize"  placeholder="{{ __('general_content.x_oversize_trans_key') }}" step=".001">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->y_oversize }}" name="y_oversize" id="y_oversize"  placeholder="{{ __('general_content.y_oversize_trans_key') }}" step=".001">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->z_oversize }}" name="z_oversize" id="z_oversize"  placeholder="{{ __('general_content.z_oversize_trans_key') }}" step=".001">
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <hr>
-                                                    <div class="row">
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->diameter }}" name="diameter" id="diameter"  placeholder="{{ __('general_content.diameter_trans_key') }}" step=".001">
-                                                            </div>
+
+                                                    <div class="card card-outline card-primary mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineDimensions{{ $QuoteLine->id }}" aria-expanded="false" aria-controls="quoteLineDimensions{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-ruler-combined text-primary mr-2"></i> {{ __('Dimensions (X, Y, Z)') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                        <div id="quoteLineDimensions{{ $QuoteLine->id }}" class="collapse" aria-labelledby="quoteLineDimensions{{ $QuoteLine->id }}" data-parent="#quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-4">
+                                                                        <label for="x_size">X</label>
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{  $QuoteLine->QuoteLineDetails->x_size }}" name="x_size" id="x_size"  placeholder="{{ __('general_content.x_size_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <label for="y_size">Y</label>
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{  $QuoteLine->QuoteLineDetails->y_size }}"  name="y_size" id="y_size"  placeholder="{{ __('general_content.y_size_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <label for="z_size">Z</label>
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{  $QuoteLine->QuoteLineDetails->z_size }}" name="z_size" id="z_size"  placeholder="{{ __('general_content.z_size_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
                                                                 </div>
-                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->diameter_oversize }}" name="diameter_oversize" id="diameter_oversize"  placeholder="{{ __('general_content.diameter_oversize_trans_key') }}" step=".001">
-                                                            </div>
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fas fa-percentage"></i></span>
-                                                                </div>
-                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->material_loss_rate }}" name="material_loss_rate" id="material_loss_rate"  placeholder="{{ __('general_content.material_loss_rate_trans_key') }}" step=".001">
+                                                                <div class="row">
+                                                                        <div class="form-group col-md-4">
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                                </div>
+                                                                                <input type="number" class="form-control"  value="{{ $QuoteLine->QuoteLineDetails->x_oversize }}" name="x_oversize" id="x_oversize"  placeholder="{{ __('general_content.x_oversize_trans_key') }}" step=".001">
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="form-group col-md-4">
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                                </div>
+                                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->y_oversize }}" name="y_oversize" id="y_oversize"  placeholder="{{ __('general_content.y_oversize_trans_key') }}" step=".001">
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="form-group col-md-4">
+                                                                            <div class="input-group">
+                                                                                <div class="input-group-prepend">
+                                                                                    <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                                </div>
+                                                                                <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->z_oversize }}" name="z_oversize" id="z_oversize"  placeholder="{{ __('general_content.z_oversize_trans_key') }}" step=".001">
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
                                                             </div>
                                                         </div>
                                                     </div>
+
+                                                    <div class="card card-outline card-warning mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineCircularSpecs{{ $QuoteLine->id }}" aria-expanded="false" aria-controls="quoteLineCircularSpecs{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-circle-notch text-warning mr-2"></i> {{ __('Spécifications circulaires') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
+                                                        </div>
+                                                        <div id="quoteLineCircularSpecs{{ $QuoteLine->id }}" class="collapse" aria-labelledby="quoteLineCircularSpecs{{ $QuoteLine->id }}" data-parent="#quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->diameter }}" name="diameter" id="diameter"  placeholder="{{ __('general_content.diameter_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->diameter_oversize }}" name="diameter_oversize" id="diameter_oversize"  placeholder="{{ __('general_content.diameter_oversize_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-group col-md-4">
+                                                                        <div class="input-group">
+                                                                            <div class="input-group-prepend">
+                                                                                <span class="input-group-text"><i class="fas fa-percentage"></i></span>
+                                                                            </div>
+                                                                            <input type="number" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->material_loss_rate }}" name="material_loss_rate" id="material_loss_rate"  placeholder="{{ __('general_content.material_loss_rate_trans_key') }}" step=".001">
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
                                                     @php $quoteDetailId = $QuoteLine->QuoteLineDetails->id; @endphp
-                                                    <div class="row">
-                                                        <div class="col-12">
-                                                            <label class="text-info">{{ __('Custom requirements') }}</label>
+                                                    <div class="card card-outline card-danger mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineCustomReq{{ $QuoteLine->id }}" aria-expanded="false" aria-controls="quoteLineCustomReq{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-tasks text-danger mr-2"></i> {{ __('Exigences personnalisées') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        @forelse($customRequirements[$quoteDetailId] ?? [] as $index => $requirement)
-                                                            <div class="form-row align-items-end w-100" wire:key="quote-custom-{{ $quoteDetailId }}-{{ $index }}">
-                                                                <div class="form-group col-md-5">
-                                                                    <label for="custom_requirement_label_{{ $quoteDetailId }}_{{ $index }}">{{ __('Label') }}</label>
-                                                                    <input type="text" class="form-control" id="custom_requirement_label_{{ $quoteDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][label]" wire:model="customRequirements.{{ $quoteDetailId }}.{{ $index }}.label" placeholder="{{ __('Label') }}">
-                                                                </div>
-                                                                <div class="form-group col-md-5">
-                                                                    <label for="custom_requirement_value_{{ $quoteDetailId }}_{{ $index }}">{{ __('Value') }}</label>
-                                                                    <input type="text" class="form-control" id="custom_requirement_value_{{ $quoteDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][value]" wire:model="customRequirements.{{ $quoteDetailId }}.{{ $index }}.value" placeholder="{{ __('Value') }}">
-                                                                </div>
-                                                                <div class="form-group col-md-2">
-                                                                    <button type="button" class="btn btn-outline-danger mt-4" wire:click="removeCustomRequirement({{ $quoteDetailId }}, {{ $index }})"><i class="fas fa-trash"></i></button>
+                                                        <div id="quoteLineCustomReq{{ $QuoteLine->id }}" class="collapse" aria-labelledby="quoteLineCustomReq{{ $QuoteLine->id }}" data-parent="#quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <div class="col-12">
+                                                                        <label class="text-info">{{ __('Custom requirements') }}</label>
+                                                                    </div>
+                                                                    @forelse($customRequirements[$quoteDetailId] ?? [] as $index => $requirement)
+                                                                        <div class="form-row align-items-end w-100" wire:key="quote-custom-{{ $quoteDetailId }}-{{ $index }}">
+                                                                            <div class="form-group col-md-5">
+                                                                                <label for="custom_requirement_label_{{ $quoteDetailId }}_{{ $index }}">{{ __('Label') }}</label>
+                                                                                <input type="text" class="form-control" id="custom_requirement_label_{{ $quoteDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][label]" wire:model="customRequirements.{{ $quoteDetailId }}.{{ $index }}.label" placeholder="{{ __('Label') }}">
+                                                                            </div>
+                                                                            <div class="form-group col-md-5">
+                                                                                <label for="custom_requirement_value_{{ $quoteDetailId }}_{{ $index }}">{{ __('Value') }}</label>
+                                                                                <input type="text" class="form-control" id="custom_requirement_value_{{ $quoteDetailId }}_{{ $index }}" name="custom_requirements[{{ $index }}][value]" wire:model="customRequirements.{{ $quoteDetailId }}.{{ $index }}.value" placeholder="{{ __('Value') }}">
+                                                                            </div>
+                                                                            <div class="form-group col-md-2">
+                                                                                <button type="button" class="btn btn-outline-danger mt-4" wire:click="removeCustomRequirement({{ $quoteDetailId }}, {{ $index }})"><i class="fas fa-trash"></i></button>
+                                                                            </div>
+                                                                        </div>
+                                                                    @empty
+                                                                        <div class="col-12">
+                                                                            <p class="text-muted">{{ __('No custom requirement added yet.') }}</p>
+                                                                        </div>
+                                                                    @endforelse
+                                                                    <div class="col-12 mb-3">
+                                                                        <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $quoteDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
+                                                                    </div>
                                                                 </div>
                                                             </div>
-                                                        @empty
-                                                            <div class="col-12">
-                                                                <p class="text-muted">{{ __('No custom requirement added yet.') }}</p>
-                                                            </div>
-                                                        @endforelse
-                                                        <div class="col-12 mb-3">
-                                                            <button type="button" class="btn btn-outline-primary" wire:click="addCustomRequirement({{ $quoteDetailId }})"><i class="fas fa-plus"></i> {{ __('Add requirement') }}</button>
                                                         </div>
                                                     </div>
+
                                                     @php
                                                         $lineProductCustomFields = $productCustomFields[$QuoteLine->id] ?? collect();
                                                         $defaultCategoryLabel = __('general_content.custom_fields_default_category_trans_key');
@@ -234,72 +293,80 @@
                                                         });
                                                     @endphp
                                                     @if($lineProductCustomFields->isNotEmpty())
-                                                        <hr>
-                                                        <div class="row">
-                                                            <div class="col-12">
-                                                                <label class="text-info">{{ __('general_content.custom_fields_trans_key') }} - {{ __('general_content.product_trans_key') }}</label>
-                                                            </div>
+                                                    <div class="card card-outline card-info mb-2">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineProductFields{{ $QuoteLine->id }}" aria-expanded="false" aria-controls="quoteLineProductFields{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-sliders-h text-info mr-2"></i> {{ __('general_content.custom_fields_trans_key') }} - {{ __('general_content.product_trans_key') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        @foreach($groupedProductFields as $categoryLabel => $fields)
-                                                            <div class="row">
-                                                                <div class="col-12 mb-2">
-                                                                    <strong>{{ $categoryLabel }}</strong>
-                                                                </div>
-                                                                @foreach($fields as $customField)
-                                                                    @php
-                                                                        $fieldInputId = 'quote-line-'.$QuoteLine->id.'-custom-field-'.$customField->id;
-                                                                        $fieldValue = old("product_custom_fields.{$customField->id}", $customField->line_value ?? $customField->product_value);
-                                                                        $fieldOptions = is_array($customField->options) ? $customField->options : [];
-                                                                    @endphp
-                                                                    <div class="form-group col-md-6">
-                                                                        @if ($customField->type === 'checkbox')
-                                                                            <input type="hidden" name="product_custom_fields[{{ $customField->id }}]" value="0">
-                                                                            <div class="form-check">
-                                                                                <input class="form-check-input" type="checkbox" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]" value="1" {{ $fieldValue ? 'checked' : '' }}>
-                                                                                <label class="form-check-label" for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                        <div id="quoteLineProductFields{{ $QuoteLine->id }}" class="collapse" aria-labelledby="quoteLineProductFields{{ $QuoteLine->id }}" data-parent="#quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                @foreach($groupedProductFields as $categoryLabel => $fields)
+                                                                    <div class="row">
+                                                                        <div class="col-12 mb-2">
+                                                                            <strong>{{ $categoryLabel }}</strong>
+                                                                        </div>
+                                                                        @foreach($fields as $customField)
+                                                                            @php
+                                                                                $fieldInputId = 'quote-line-'.$QuoteLine->id.'-custom-field-'.$customField->id;
+                                                                                $fieldValue = old("product_custom_fields.{$customField->id}", $customField->line_value ?? $customField->product_value);
+                                                                                $fieldOptions = is_array($customField->options) ? $customField->options : [];
+                                                                            @endphp
+                                                                            <div class="form-group col-md-6">
+                                                                                @if ($customField->type === 'checkbox')
+                                                                                    <input type="hidden" name="product_custom_fields[{{ $customField->id }}]" value="0">
+                                                                                    <div class="form-check">
+                                                                                        <input class="form-check-input" type="checkbox" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]" value="1" {{ $fieldValue ? 'checked' : '' }}>
+                                                                                        <label class="form-check-label" for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                                                    </div>
+                                                                                @elseif ($customField->type === 'select')
+                                                                                    <label for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                                                    <select class="form-control" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]">
+                                                                                        <option value="">{{ __('general_content.custom_fields_select_placeholder_trans_key') }}</option>
+                                                                                        @foreach ($fieldOptions as $option)
+                                                                                            <option value="{{ $option }}" {{ $fieldValue === $option ? 'selected' : '' }}>{{ $option }}</option>
+                                                                                        @endforeach
+                                                                                    </select>
+                                                                                @else
+                                                                                    <label for="{{ $fieldInputId }}">{{ $customField->name }}</label>
+                                                                                    <div class="input-group">
+                                                                                        <div class="input-group-prepend">
+                                                                                            <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
+                                                                                        </div>
+                                                                                        <input class="form-control" type="{{ $customField->type }}" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]" value="{{ $fieldValue }}" placeholder="{{ __('general_content.custom_fields_placeholder_trans_key') }}">
+                                                                                    </div>
+                                                                                @endif
                                                                             </div>
-                                                                        @elseif ($customField->type === 'select')
-                                                                            <label for="{{ $fieldInputId }}">{{ $customField->name }}</label>
-                                                                            <select class="form-control" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]">
-                                                                                <option value="">{{ __('general_content.custom_fields_select_placeholder_trans_key') }}</option>
-                                                                                @foreach ($fieldOptions as $option)
-                                                                                    <option value="{{ $option }}" {{ $fieldValue === $option ? 'selected' : '' }}>{{ $option }}</option>
-                                                                                @endforeach
-                                                                            </select>
-                                                                        @else
-                                                                            <label for="{{ $fieldInputId }}">{{ $customField->name }}</label>
-                                                                            <div class="input-group">
-                                                                                <div class="input-group-prepend">
-                                                                                    <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
-                                                                                </div>
-                                                                                <input class="form-control" type="{{ $customField->type }}" id="{{ $fieldInputId }}" name="product_custom_fields[{{ $customField->id }}]" value="{{ $fieldValue }}" placeholder="{{ __('general_content.custom_fields_placeholder_trans_key') }}">
-                                                                            </div>
-                                                                        @endif
+                                                                        @endforeach
                                                                     </div>
                                                                 @endforeach
                                                             </div>
-                                                        @endforeach
+                                                        </div>
+                                                    </div>
                                                     @endif
-                                                    <div class="row">
-                                                        <div class="form-group col-md-4">
-                                                            <div class="input-group">
-                                                                <div class="input-group-prepend">
-                                                                    <span class="input-group-text"><i class="fab fa-mdb"></i></span>
+
+                                                    <div class="card card-outline card-secondary mb-0">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineComments{{ $QuoteLine->id }}" aria-expanded="false" aria-controls="quoteLineComments{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-comments text-secondary mr-2"></i> {{ __('Commentaires') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
+                                                        </div>
+                                                        <div id="quoteLineComments{{ $QuoteLine->id }}" class="collapse" aria-labelledby="quoteLineComments{{ $QuoteLine->id }}" data-parent="#quoteLineDetailAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                <div class="row">
+                                                                    <x-FormTextareaComment  label="Internal comment" name="internal_comment" comment="{{ $QuoteLine->QuoteLineDetails->internal_comment }}" />
                                                                 </div>
-                                                                <input type="text" class="form-control" value="{{ $QuoteLine->QuoteLineDetails->finishing }}" name="finishing" id="finishing"  placeholder="{{ __('general_content.finishing_trans_key') }}">
+                                                                <div class="row mt-3">
+                                                                    <x-FormTextareaComment  label="External comment" name="external_comment" comment="{{ $QuoteLine->QuoteLineDetails->external_comment }}" />
+                                                                </div>
                                                             </div>
                                                         </div>
-                                                        <div class="form-group col-md-4">
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                        </div>
-                                                    </div>
-                                                    <hr>
-                                                    <div class="row">
-                                                        <x-FormTextareaComment  label="Internal comment" name="internal_comment" comment="{{ $QuoteLine->QuoteLineDetails->internal_comment }}" />
-                                                    </div>
-                                                    <div class="row">
-                                                        <x-FormTextareaComment  label="External comment" name="external_comment" comment="{{ $QuoteLine->QuoteLineDetails->external_comment }}" />
                                                     </div>
                                                 </div>
                                                 <div class="card-footer">
@@ -307,23 +374,39 @@
                                                 </div>
                                             </form>
                                             <div class="card-body">
-                                                <form action="{{ route('quotes.update.detail.picture', ['idQuote'=>  $QuoteLine->quotes_id, 'id' => $QuoteLine->QuoteLineDetails->id]) }}" method="POST" enctype="multipart/form-data">
-                                                    @csrf
-                                                    <label for="picture">{{ __('general_content.picture_file_trans_key') }}</label>(peg,png,jpg,gif,svg | max: 10 240 Ko)
-                                                    <div class="input-group">
-                                                        <div class="input-group-prepend">
-                                                            <span class="input-group-text"><i class="far fa-image"></i></span>
+                                                <div class="accordion" id="quoteLineAttachmentAccordion{{ $QuoteLine->id }}">
+                                                    <div class="card card-outline card-success mb-0">
+                                                        <div class="card-header">
+                                                            <button class="btn btn-link text-left w-100 d-flex align-items-center justify-content-between" type="button" data-toggle="collapse" data-target="#quoteLineAttachments{{ $QuoteLine->id }}" aria-expanded="true" aria-controls="quoteLineAttachments{{ $QuoteLine->id }}">
+                                                                <span class="d-flex align-items-center">
+                                                                    <i class="fas fa-paperclip text-success mr-2"></i> {{ __('Fichiers attachés') }}
+                                                                </span>
+                                                                <i class="fas fa-chevron-down"></i>
+                                                            </button>
                                                         </div>
-                                                        <div class="custom-file">
-                                                            <input type="hidden" name="id" value="{{ $QuoteLine->id }}">
-                                                            <input type="file" class="custom-file-input" name="picture" id="picture">
-                                                            <label class="custom-file-label" for="picture">{{ __('general_content.choose_file_trans_key') }}</label>
-                                                        </div>
-                                                        <div class="input-group-append">
-                                                            <button type="submit" class="btn btn-success">{{ __('general_content.upload_trans_key') }}</button>
+                                                        <div id="quoteLineAttachments{{ $QuoteLine->id }}" class="collapse show" aria-labelledby="quoteLineAttachments{{ $QuoteLine->id }}" data-parent="#quoteLineAttachmentAccordion{{ $QuoteLine->id }}">
+                                                            <div class="card-body">
+                                                                <form action="{{ route('quotes.update.detail.picture', ['idQuote'=>  $QuoteLine->quotes_id, 'id' => $QuoteLine->QuoteLineDetails->id]) }}" method="POST" enctype="multipart/form-data">
+                                                                    @csrf
+                                                                    <label for="picture">{{ __('general_content.picture_file_trans_key') }}</label>(peg,png,jpg,gif,svg | max: 10 240 Ko)
+                                                                    <div class="input-group">
+                                                                        <div class="input-group-prepend">
+                                                                            <span class="input-group-text"><i class="far fa-image"></i></span>
+                                                                        </div>
+                                                                        <div class="custom-file">
+                                                                            <input type="hidden" name="id" value="{{ $QuoteLine->id }}">
+                                                                            <input type="file" class="custom-file-input" name="picture" id="picture">
+                                                                            <label class="custom-file-label" for="picture">{{ __('general_content.choose_file_trans_key') }}</label>
+                                                                        </div>
+                                                                        <div class="input-group-append">
+                                                                            <button type="submit" class="btn btn-success">{{ __('general_content.upload_trans_key') }}</button>
+                                                                        </div>
+                                                                    </div>
+                                                                </form>
+                                                            </div>
                                                         </div>
                                                     </div>
-                                                </form>
+                                                </div>
                                             </div>
                                         </x-adminlte-modal>
                                     </div>


### PR DESCRIPTION
## Summary
- restructure the order and quote line detail modals into collapsible sections for primary characteristics, dimensions, circular specifications, custom requirements, comments, and attachments
- preserve existing fields, custom product field handling, and upload actions within the new accordion layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be4ff83b4832d9cd232146213f7ab)