### PR TITLE
Add tool availability and booking-conflict checks to task management

### DIFF
--- a/app/Livewire/TaskManage.php
+++ b/app/Livewire/TaskManage.php
@@ -12,6 +12,7 @@ use App\Models\Products\Products;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\QuoteLines;
 use App\Models\Methods\MethodsUnits;
+use App\Models\Methods\MethodsTools;
 use App\Models\Planning\SubAssembly;
 use App\Models\Methods\MethodsServices;
 use Illuminate\Support\Facades\Validator;
@@ -52,6 +53,9 @@ class TaskManage extends Component
     public $unit_price = 0.00;
     public $subAssemblyUnit_price = 0;
     public $methods_units_id = 0;
+    public $methods_tools_id;
+    public $start_date;
+    public $end_date;
 
     Private $quote_lines_id;
     Private $order_lines_id;
@@ -66,6 +70,7 @@ class TaskManage extends Component
     public $UnitsSelect = [];
     public $ProductSelect  = [];
     public $ComponentSelect  = [];
+    public $ToolsSelect = [];
     public $todayDate = '';
 
     public $csvFile;
@@ -77,6 +82,9 @@ class TaskManage extends Component
         'methods_services_id' =>'required',
         'unit_cost'=>'required|numeric|gt:0',
         'unit_price'=>'required|numeric|gt:0',
+        'methods_tools_id' =>'nullable|exists:methods_tools,id',
+        'start_date' => 'nullable|date',
+        'end_date' => 'nullable|date|after_or_equal:start_date',
     ];
 
     public function ChangeTaskType() 
@@ -144,6 +152,29 @@ class TaskManage extends Component
         $this->unit_price = round((float)$this->unit_cost * (1+((float)$this->methods_services_margin/100)),2);
     }
 
+    protected function toolIsAlreadyBooked($existingTask = null): bool
+    {
+        if (!$this->methods_tools_id || !$this->start_date || !$this->end_date) {
+            return false;
+        }
+
+        $query = Task::where('methods_tools_id', $this->methods_tools_id)
+                        ->where(function ($query) {
+                            $query->whereBetween('start_date', [$this->start_date, $this->end_date])
+                                    ->orWhereBetween('end_date', [$this->start_date, $this->end_date])
+                                    ->orWhere(function ($query) {
+                                        $query->where('start_date', '<=', $this->start_date)
+                                                ->where('end_date', '>=', $this->end_date);
+                                    });
+                        });
+
+        if ($existingTask) {
+            $query->where('id', '!=', $existingTask->id);
+        }
+
+        return $query->exists();
+    }
+
     public function mount($idType, $idPage, $idLine) 
     {
         $this->idLine = $idLine;
@@ -165,8 +196,11 @@ class TaskManage extends Component
 
         $this->todayDate = Carbon::today();
         $this->UnitsSelect = MethodsUnits::select('id', 'label', 'code')->orderBy('label')->get();
+        $this->ToolsSelect = MethodsTools::available()->orderBy('code')->get();
         $status =  Status::select('id')->orderBy('order')->first();
         $this->status_id = $status->id;
+        $this->start_date = null;
+        $this->end_date = null;
         $this->ProductSelect = Products::select('id', 'code','label', 'methods_services_id')->with('service')->whereRelation('service', 'type', 2)
                                                                                                             ->OrwhereRelation('service', 'type', 3)
                                                                                                             ->OrwhereRelation('service', 'type', 4)
@@ -232,6 +266,9 @@ class TaskManage extends Component
         $this->unit_cost  = '';
         $this->unit_price  = '';    
         $this->methods_units_id  = '';
+        $this->methods_tools_id = null;
+        $this->start_date = null;
+        $this->end_date = null;
     }
 
     public function storeTask($idLine  = null){
@@ -244,6 +281,9 @@ class TaskManage extends Component
         elseif($this->methods_services_id == __('general_content.select_service_trans_key') || is_null($this->methods_services_id)){
             // Set Flash Message
             session()->flash('error', 'Please select service.');
+        }
+        elseif($this->toolIsAlreadyBooked()){
+            session()->flash('error', __('general_content.tool_already_booked_trans_key'));
         }
         else{
 
@@ -294,6 +334,8 @@ class TaskManage extends Component
                         'unit_cost' => $this->unit_cost,  
                         'unit_price' => $this->unit_price,  
                         'methods_units_id' => $this->methods_units_id,  
+                        'start_date' => $this->start_date,
+                        'end_date' => $this->end_date,
                         'x_size', 
                         'y_size', 
                         'z_size', 
@@ -306,7 +348,7 @@ class TaskManage extends Component
                         'material', 
                         'thickness', 
                         'weight', 
-                        'methods_tools_id',
+                        'methods_tools_id' => $this->methods_tools_id,
                         'origin' => "0"];
 
             if ($this->idType == 'nomenclature_lines_id') {
@@ -418,6 +460,9 @@ class TaskManage extends Component
         $this->unit_cost = $Line->unit_cost;
         $this->unit_price = $Line->unit_price;     
         $this->methods_units_id = $Line->methods_units_id;
+        $this->start_date = $Line->start_date;
+        $this->end_date = $Line->end_date;
+        $this->methods_tools_id = $Line->methods_tools_id;
 
                 
         $this->TaskType = in_array($Line->type, [1, 2]) ? 'TechCut' : 'BOM';
@@ -432,8 +477,14 @@ class TaskManage extends Component
         $this->methods_services_id =  $splitMethod[0]; 
         $this->type =  $splitMethod[1]; 
 
+        $task = Task::find($this->taskId);
+        if ($this->toolIsAlreadyBooked($task)) {
+            session()->flash('error', __('general_content.tool_already_booked_trans_key'));
+            return;
+        }
+
         // Update line
-        Task::find($this->taskId)->fill([
+        $task->fill([
             'ordre' => $this->ordre, 
             'label' => $this->label,
             'methods_services_id' => $this->methods_services_id,  
@@ -446,6 +497,9 @@ class TaskManage extends Component
             'unit_cost' => $this->unit_cost,  
             'unit_price' => $this->unit_price,  
             'methods_units_id' => $this->methods_units_id, 
+            'methods_tools_id' => $this->methods_tools_id,
+            'start_date' => $this->start_date,
+            'end_date' => $this->end_date,
         ])->save();
 
         $this->updateLines = false;

--- a/app/Models/Methods/MethodsTools.php
+++ b/app/Models/Methods/MethodsTools.php
@@ -11,10 +11,20 @@ class MethodsTools extends Model
     use HasFactory;
 
     // Fillable attributes for mass assignment
-    protected $fillable= ['code',  'label',  'ETAT', 'cost' , 'picture',  'end_date',  'comment',  'qty'];
+    protected $fillable= ['code',  'label',  'ETAT', 'cost' , 'picture',  'end_date',  'comment',  'qty', 'availability'];
+
+    protected $casts = [
+        'availability' => 'boolean',
+    ];
 
     public function Task()
     {
         return $this->hasMany(Task::class);
+    }
+
+    public function scopeAvailable($query)
+    {
+        return $query->where('availability', true)
+                    ->where('ETAT', 1);
     }
 }

--- a/app/Models/Planning/Task.php
+++ b/app/Models/Planning/Task.php
@@ -244,6 +244,31 @@ class Task extends Model
         return $this->belongsTo(MethodsTools::class, 'methods_tools_id');
     }
 
+    public function overlapsWithExistingToolBooking(): bool
+    {
+        if (!$this->methods_tools_id || !$this->start_date || !$this->end_date) {
+            return false;
+        }
+
+        return self::where('methods_tools_id', $this->methods_tools_id)
+                    ->where('id', '!=', $this->id ?? 0)
+                    ->where(function (Builder $query) {
+                        $query->where(function (Builder $query) {
+                                    $query->where('start_date', '<=', $this->start_date)
+                                            ->where('end_date', '>=', $this->start_date);
+                                })
+                                ->orWhere(function (Builder $query) {
+                                    $query->where('start_date', '<=', $this->end_date)
+                                            ->where('end_date', '>=', $this->end_date);
+                                })
+                                ->orWhere(function (Builder $query) {
+                                    $query->where('start_date', '>=', $this->start_date)
+                                            ->where('end_date', '<=', $this->end_date);
+                                });
+                    })
+                    ->exists();
+    }
+
     /**
      * Define a belongs-to relationship with the User model.
      * This indicates that each task belongs to a single user.

--- a/database/migrations/2025_02_20_000001_add_availability_to_methods_tools_table.php
+++ b/database/migrations/2025_02_20_000001_add_availability_to_methods_tools_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('methods_tools', function (Blueprint $table) {
+            $table->boolean('availability')->default(true)->after('qty');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('methods_tools', function (Blueprint $table) {
+            $table->dropColumn('availability');
+        });
+    }
+};

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -345,6 +345,7 @@ return [
     'units_trans_key'                          => 'Units',
     'families_trans_key'                       => 'Families',
     'tools_trans_key'                          => 'Tools',
+    'tool_already_booked_trans_key'            => 'The selected tool is already booked for this time slot.',
     'batches_trans_key'                        => 'Batches',
 
     'absence_trans_key'                        => 'Absence',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -345,6 +345,7 @@ return [
     'units_trans_key'                          => 'Unités',
     'families_trans_key'                       => 'Famille',
     'tools_trans_key'                          => 'Outils',
+    'tool_already_booked_trans_key'            => "L'outil sélectionné est déjà réservé sur ce créneau.",
     'batches_trans_key'                        => 'Lots',
 
     'absence_trans_key'                        => 'Absence',

--- a/resources/views/livewire/task-manage.blade.php
+++ b/resources/views/livewire/task-manage.blade.php
@@ -84,6 +84,21 @@
                         @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
                     <div class="form-group col-md-2">
+                        <label for="methods_tools_id">{{ __('general_content.tools_trans_key') }}</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-tools"></i></span>
+                            </div>
+                            <select class="form-control @error('methods_tools_id') is-invalid @enderror" name="methods_tools_id" id="methods_tools_id" wire:model.live="methods_tools_id">
+                                <option value="">{{ __('general_content.select_trans_key') }}</option>
+                                @foreach ($ToolsSelect as $tool)
+                                <option value="{{ $tool->id }}">{{ $tool->code }} - {{ $tool->label }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        @error('methods_tools_id') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                    </div>
+                    <div class="form-group col-md-2">
                         @if($TaskType == 'BOM') 
                         <label for="component_id">{{__('general_content.component_trans_key') }}</label>
                         <div class="input-group">
@@ -136,6 +151,26 @@
                         </div>
                         @error('unit_time') <span class="text-danger">{{ $message }}<br/></span>@enderror
                         @endif
+                    </div>
+                    <div class="form-group col-md-2">
+                        <label for="start_date">{{ __('general_content.start_date_trans_key') }}</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-calendar"></i></span>
+                            </div>
+                            <input type="datetime-local" class="form-control @error('start_date') is-invalid @enderror" name="start_date" id="start_date" wire:model.live="start_date">
+                        </div>
+                        @error('start_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                    </div>
+                    <div class="form-group col-md-2">
+                        <label for="end_date">{{ __('general_content.end_date_trans_key') }}</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-calendar-check"></i></span>
+                            </div>
+                            <input type="datetime-local" class="form-control @error('end_date') is-invalid @enderror" name="end_date" id="end_date" wire:model.live="end_date">
+                        </div>
+                        @error('end_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
                     <div class="form-group col-md-2">
                         <label for="unit_cost">{{ __('general_content.cost_trans_key') }}</label>
@@ -205,8 +240,11 @@
                             <th>{{ __('general_content.sort_trans_key') }}</th>
                             <th>{{__('general_content.label_trans_key') }}</th>
                             <th>{{ __('general_content.service_trans_key') }}</th>
+                            <th>{{ __('general_content.tools_trans_key') }}</th>
                             <th>{{ __('general_content.setting_time_trans_key') }}</th>
                             <th>{{ __('general_content.unit_time_trans_key') }}</th>
+                            <th>{{ __('general_content.start_date_trans_key') }}</th>
+                            <th>{{ __('general_content.end_date_trans_key') }}</th>
                             <th>{{ __('general_content.total_time_trans_key') }}</th>
                             <th>{{ __('general_content.progress_trans_key') }}</th>
                             <th>{{ __('general_content.cost_trans_key') }}</th>
@@ -240,8 +278,17 @@
                                     @endif
                                 @endif
                             </td>
+                            <td>
+                                @if($TechLine->MethodsTools)
+                                    {{ $TechLine->MethodsTools->code }} - {{ $TechLine->MethodsTools->label }}
+                                @else
+                                    {{ __('general_content.not_available_trans_key') }}
+                                @endif
+                            </td>
                             <td>{{ $TechLine->seting_time }} h</td>
                             <td>{{ $TechLine->unit_time }} h</td>
+                            <td>{{ $TechLine->start_date }}</td>
+                            <td>{{ $TechLine->end_date }}</td>
                             <td>{{ $TechLine->TotalTime() }} h</td>
                             <td><x-adminlte-progress theme="teal" value="{{ $TechLine->progress() }}" with-label animated/></td>
                             <td>{{ $TechLine->formatted_unit_cost }}</td>
@@ -275,7 +322,7 @@
                             @endif 
                         </tr>
                         @empty
-                        <x-EmptyDataLine col="14" text="{{ __('general_content.no_data_trans_key') }}"  />
+                        <x-EmptyDataLine col="16" text="{{ __('general_content.no_data_trans_key') }}"  />
                         @endforelse
                     </tbody>
                     <tfoot>
@@ -284,8 +331,11 @@
                             <th>{{ __('general_content.total_trans_key') }} :</th>
                             <th></th>
                             <th></th>
+                            <th></th>
                             <th>{{ $Line->getTechnicalCutTotalSettingTimeAttribute() }} h</th>
                             <th>{{ $Line->getTechnicalCutTotalUnitTimeAttribute() }} h</th>
+                            <th></th>
+                            <th></th>
                             <th></th>
                             <th></th>
                             <th>{{ number_format( $Line->getTechnicalCutTotalUnitCostAttribute(), 2, '.', ',') }} {{ $Factory->curency }}</th>
@@ -309,6 +359,7 @@
                             <th>{{ __('general_content.sort_trans_key') }}</th>
                             <th>{{ __('general_content.label_trans_key') }}</th>
                             <th>{{ __('general_content.service_trans_key') }}</th>
+                            <th>{{ __('general_content.tools_trans_key') }}</th>
                             <th>{{ __('general_content.component_trans_key') }}</th>
                             <th></th>
                             <th>{{ __('general_content.qty_trans_key') }}</th>
@@ -350,6 +401,13 @@
                                 <td><span>N/A</span></td>
                                 <td></td>
                             @endif
+                            <td>
+                                @if($BOMline->MethodsTools)
+                                    {{ $BOMline->MethodsTools->code }} - {{ $BOMline->MethodsTools->label }}
+                                @else
+                                    {{ __('general_content.not_available_trans_key') }}
+                                @endif
+                            </td>
                             <td>{{ $BOMline->qty }}</td>
                             <td>{{ $BOMline->formatted_unit_cost }}</td>
                             <td>{{ $BOMline->Margin() }} %</td>
@@ -373,13 +431,14 @@
                             </td>
                         </tr>
                         @empty
-                        <x-EmptyDataLine col="12" text="{{ __('general_content.no_data_trans_key') }}"  />
+                        <x-EmptyDataLine col="13" text="{{ __('general_content.no_data_trans_key') }}"  />
                         @endforelse
                     </tbody>
                     <tfoot>
                         <tr>
                             <th></th>
                             <th>{{ __('general_content.total_trans_key') }} :</th>
+                            <th></th>
                             <th></th>
                             <th></th>
                             <th></th>


### PR DESCRIPTION
### Motivation

- Track tool availability and expose tools in task planning to avoid assigning unavailable equipment.
- Prevent double-booking the same tool for overlapping task time windows by enforcing a business rule at creation/update.
- Make tool selection and scheduling visible in the task UI so planners can choose and review assigned tools.

### Description

- Add a migration `2025_02_20_000001_add_availability_to_methods_tools_table.php` that adds an `availability` boolean to the `methods_tools` table.
- Update the `MethodsTools` model to include `availability` in `$fillable`, cast it to `boolean`, and add a `scopeAvailable` for selecting available/active tools.
- Extend the `Task` model with a `MethodsTools` relation and an `overlapsWithExistingToolBooking` helper to detect overlapping bookings based on `start_date`/`end_date`.
- Update the `TaskManage` Livewire component and its Blade view to add `methods_tools_id`, `start_date`, `end_date` fields, validation rules, a `toolIsAlreadyBooked` check used on create/update, and display the selected tool in task lists, plus language keys for booking errors.

### Testing

- No automated tests were run for this change.
- The change was committed and files updated: migration, models, Livewire component, Blade view, and language files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc6f5c1ac832db55efb00754d517a)