### PR TITLE
Add missing generic `select` translation key for multiple locales

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -378,6 +378,7 @@ return [
     'new_invoice_document_trans_key'    => 'مستند فاتورة جديد',
     'new_purchase_document_trans_key'   => 'مستند شراء جديد',
     
+    'select_trans_key'                      => 'اختر',
     'select_vat_trans_key'                  => 'اختر الضريبة المضافة',
     'select_product_trans_key'              => 'اختر المنتج',
     'user_management_trans_key'             => 'إدارة المستخدمين',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -427,6 +427,7 @@ return [
     'new_purchase_document_trans_key'          => 'New purchase document',
     
     //SELECT
+    'select_trans_key'                         => 'Select',
     'select_vat_trans_key'                     => 'Select VAT',
     'select_product_trans_key'                 => 'Select Product',
     'user_management_trans_key'                => 'User management',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -376,6 +376,7 @@ return [
     'new_purchase_document_trans_key'          => 'Nuevo documento de compra',
 
     // SELECT
+    'select_trans_key'                         => 'Seleccionar',
     'select_vat_trans_key'                     => 'Seleccionar IVA',
     'select_product_trans_key'                 => 'Seleccionar Producto',
     'user_management_trans_key'                => 'Gestión de usuarios',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -427,6 +427,7 @@ return [
     'new_purchase_document_trans_key'          => 'Nouvelle commande d\'achat',
 
     //SELECT
+    'select_trans_key'                         => 'Selectionner',
     'select_vat_trans_key'                     => 'Selectionner TVA',
     'select_product_trans_key'                 => 'Selectionner produit',
     'user_management_trans_key'                => 'Utilisateur responsable',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -165,6 +165,7 @@ return [
     'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',
     'order_site_trans_key'                     => 'Công trường',
     'characteristics_trans_key'                => 'Đặc điểm',
+    'select_trans_key'                         => 'Chọn',
     'select_ressource_trans_key'               => 'Chọn nguồn lực',
     'contact_info_trans_key'                   => 'Thông tin liên hệ',
     'custom_fields_trans_key'                  => 'Trường tùy chỉnh',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -426,6 +426,7 @@ return [
     'new_purchase_document_trans_key'          => '新建采购单',
 
     //SELECT
+    'select_trans_key'                         => '选择',
     'select_vat_trans_key'                     => '选择增值税',
     'select_product_trans_key'                 => '选择产品',
     'user_management_trans_key'                => '负责人',


### PR DESCRIPTION
### Motivation
- The task tools dropdown was rendering an untranslated placeholder due to a missing `select_trans_key` entry in the localization files. 
- Provide a generic, reusable `Select` label to avoid showing raw translation keys in the UI.

### Description
- Added the `select_trans_key` entry to `resources/lang/*/general_content.php` for the following locales: `en`, `fr`, `es`, `ar`, `vi`, and `zh-CN`.
- Each file contains a localized string for the `select_trans_key` key (e.g. `"Select"`, `"Selectionner"`, `"Seleccionar"`, etc.).
- This translation is referenced by the task management view via `__('general_content.select_trans_key')` in `resources/views/livewire/task-manage.blade.php` so the placeholder now displays correctly.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd0db8eec832d9eadbdfa88d60f10)