### PR TITLE
Add Nest2Prod (N2P) integration: settings, payload builder, client, job & observer

### DIFF
--- a/app/Console/Commands/PushOrderToN2PCommand.php
+++ b/app/Console/Commands/PushOrderToN2PCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\PushOrderToN2P;
+use App\Models\Workflow\Orders;
+use App\Services\N2P\N2PPayloadBuilder;
+use App\Services\Settings\SettingsService;
+use Illuminate\Console\Command;
+
+class PushOrderToN2PCommand extends Command
+{
+    protected $signature = 'wem:n2p:push-order {orderId} {--sync : Execute immediately without queue}';
+
+    protected $description = 'Push a specific order to Nest2Prod';
+
+    public function handle(): int
+    {
+        $orderId = (int) $this->argument('orderId');
+
+        if (!Orders::whereKey($orderId)->exists()) {
+            $this->error("Order {$orderId} not found.");
+            return self::FAILURE;
+        }
+
+        if ($this->option('sync')) {
+            $this->info("Pushing order {$orderId} to Nest2Prod synchronously...");
+            (new PushOrderToN2P($orderId))->handle(
+                app(SettingsService::class),
+                app(N2PPayloadBuilder::class)
+            );
+        } else {
+            PushOrderToN2P::dispatch($orderId);
+            $this->info("Order {$orderId} queued for push.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Integrations/N2PSettingsController.php
+++ b/app/Http/Controllers/Integrations/N2PSettingsController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Integrations;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Integrations\N2PSettingsRequest;
+use App\Services\Settings\SettingsService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class N2PSettingsController extends Controller
+{
+    public function __construct(private SettingsService $settings)
+    {
+    }
+
+    public function edit(): View
+    {
+        $defaults = $this->defaults();
+        $settings = $this->settings->getMany(array_keys($defaults), $defaults);
+
+        return view('integrations.n2p-settings', [
+            'settings' => $settings,
+        ]);
+    }
+
+    public function update(N2PSettingsRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $defaults = $this->defaults();
+
+        foreach (['n2p_enabled', 'n2p_send_tasks'] as $booleanKey) {
+            $validated[$booleanKey] = (bool) ($validated[$booleanKey] ?? false);
+        }
+
+        $payload = array_merge($defaults, $validated);
+
+        $this->settings->setMany($payload);
+
+        return redirect()
+            ->route('admin.integrations.n2p')
+            ->with('success', __('general_content.success_trans_key'));
+    }
+
+    private function defaults(): array
+    {
+        return [
+            'n2p_enabled' => false,
+            'n2p_base_url' => '',
+            'n2p_api_token' => '',
+            'n2p_send_on_order_status_from' => 'OPEN',
+            'n2p_send_on_order_status_to' => 'IN_PROGRESS',
+            'n2p_job_status_on_send' => 'released',
+            'n2p_priority_default' => 3,
+            'n2p_send_tasks' => true,
+        ];
+    }
+}

--- a/app/Http/Requests/Integrations/N2PSettingsRequest.php
+++ b/app/Http/Requests/Integrations/N2PSettingsRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Integrations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class N2PSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('admin') ?? true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'n2p_enabled' => ['required', 'boolean'],
+            'n2p_base_url' => ['nullable', 'url'],
+            'n2p_api_token' => ['nullable', 'string'],
+            'n2p_send_on_order_status_from' => ['required', 'string', 'max:191'],
+            'n2p_send_on_order_status_to' => ['required', 'string', 'max:191'],
+            'n2p_job_status_on_send' => ['required', 'string', 'max:191'],
+            'n2p_priority_default' => ['required', 'integer', 'between:1,5'],
+            'n2p_send_tasks' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Jobs/PushOrderToN2P.php
+++ b/app/Jobs/PushOrderToN2P.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Workflow\Orders;
+use App\Services\N2P\N2PClient;
+use App\Services\N2P\N2PPayloadBuilder;
+use App\Services\Settings\SettingsService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class PushOrderToN2P implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 5;
+
+    public $backoff = [60, 300, 900, 1800, 3600];
+
+    public function __construct(public readonly int $orderId)
+    {
+    }
+
+    public function handle(SettingsService $settings, N2PPayloadBuilder $payloadBuilder): void
+    {
+        $order = Orders::with(['OrderLines.OrderLineDetails', 'OrderLines.Task.MethodsTools', 'companie'])
+            ->findOrFail($this->orderId);
+
+        $config = $settings->getMany([
+            'n2p_base_url',
+            'n2p_api_token',
+            'n2p_job_status_on_send',
+            'n2p_priority_default',
+            'n2p_send_tasks',
+        ]);
+
+        $client = new N2PClient($config['n2p_base_url'], $config['n2p_api_token'] ?? null);
+        $payload = $payloadBuilder->build($order, $config);
+
+        $response = $client->pushJobs($payload);
+
+        $order->update([
+            'n2p_last_push_at' => now(),
+            'n2p_last_push_status' => 'OK',
+            'n2p_last_push_error' => null,
+        ]);
+
+        Log::channel('n2p')->info('N2P push success', [
+            'order_id' => $order->getKey(),
+            'response' => $response,
+        ]);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Orders::query()
+            ->whereKey($this->orderId)
+            ->update([
+                'n2p_last_push_at' => now(),
+                'n2p_last_push_status' => 'ERROR',
+                'n2p_last_push_error' => $exception->getMessage(),
+            ]);
+
+        Log::channel('n2p')->error('N2P push failed', [
+            'order_id' => $this->orderId,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+}

--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -52,11 +52,15 @@ class Orders extends Model
                             'change_requested_by',
                             'change_reason',
                             'change_approved_at',
+                            'n2p_last_push_at',
+                            'n2p_last_push_status',
+                            'n2p_last_push_error',
                         ];
 
     protected $casts = [
         'reviewed_at' => 'datetime',
         'change_approved_at' => 'datetime',
+        'n2p_last_push_at' => 'datetime',
     ];
 
     // Only log changes

--- a/app/Observers/OrdersObserver.php
+++ b/app/Observers/OrdersObserver.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\PushOrderToN2P;
+use App\Models\Workflow\Orders;
+use App\Services\Settings\SettingsService;
+
+class OrdersObserver
+{
+    public function __construct(private SettingsService $settings)
+    {
+    }
+
+    public function updated(Orders $order): void
+    {
+        if (!$order->isDirty('statu')) {
+            return;
+        }
+
+        $config = $this->settings->getMany([
+            'n2p_enabled',
+            'n2p_send_on_order_status_from',
+            'n2p_send_on_order_status_to',
+        ]);
+
+        if (empty($config['n2p_enabled'])) {
+            return;
+        }
+
+        $fromSetting = $this->normalizeStatus($config['n2p_send_on_order_status_from'] ?? 'OPEN');
+        $toSetting = $this->normalizeStatus($config['n2p_send_on_order_status_to'] ?? 'IN_PROGRESS');
+
+        $oldStatus = $this->normalizeStatus($order->getOriginal('statu'));
+        $newStatus = $this->normalizeStatus($order->statu);
+
+        if ($oldStatus === $fromSetting && $newStatus === $toSetting) {
+            PushOrderToN2P::dispatch($order->getKey());
+        }
+    }
+
+    private function normalizeStatus($status): ?int
+    {
+        if (is_numeric($status)) {
+            return (int) $status;
+        }
+
+        $map = [
+            'OPEN' => 1,
+            'IN_PROGRESS' => 2,
+            'DELIVERED' => 3,
+            'PARTLY_DELIVERED' => 4,
+            'STOPPED' => 5,
+            'CANCELED' => 6,
+        ];
+
+        $upper = strtoupper((string) $status);
+
+        return $map[$upper] ?? null;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Models\Workflow\OrderLines;
 use Illuminate\Console\Command;
 use App\Services\SelectDataService;
 use Illuminate\Pagination\Paginator;
+use App\Observers\OrdersObserver;
 use App\Models\Workflow\DeliveryLines;
 use App\Models\Purchases\PurchaseLines;
 use Illuminate\Support\ServiceProvider;
@@ -43,6 +44,8 @@ class AppServiceProvider extends ServiceProvider
     public function  boot(Dispatcher $events)
     {
         Paginator::useBootstrap();
+
+        Orders::observe(OrdersObserver::class);
 
         $events->listen(BuildingMenu::class, function (BuildingMenu $event) {
 

--- a/app/Services/N2P/N2PClient.php
+++ b/app/Services/N2P/N2PClient.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services\N2P;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class N2PClient
+{
+    private const TIMEOUT = 15;
+
+    public function __construct(private readonly string $baseUrl, private readonly ?string $token = null)
+    {
+    }
+
+    public function pushJobs(array $payload): array
+    {
+        $url = rtrim($this->baseUrl, '/') . '/api/plugin/jobs';
+
+        $response = Http::acceptJson()
+            ->contentType('application/json')
+            ->timeout(self::TIMEOUT)
+            ->withHeaders($this->authorizationHeader())
+            ->post($url, $payload);
+
+        Log::channel('n2p')->info('N2P push request', [
+            'url' => $url,
+            'payload' => $payload,
+            'status' => $response->status(),
+        ]);
+
+        if ($response->failed()) {
+            $body = $response->body();
+            Log::channel('n2p')->error('N2P push failed', [
+                'url' => $url,
+                'status' => $response->status(),
+                'body' => $body,
+            ]);
+
+            throw new RequestException($response);
+        }
+
+        return $response->json();
+    }
+
+    private function authorizationHeader(): array
+    {
+        if (empty($this->token)) {
+            return [];
+        }
+
+        return ['Authorization' => 'Bearer ' . $this->token];
+    }
+}

--- a/app/Services/N2P/N2PPayloadBuilder.php
+++ b/app/Services/N2P/N2PPayloadBuilder.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Services\N2P;
+
+use App\Models\Planning\Task;
+use App\Models\Workflow\OrderLines;
+use App\Models\Workflow\Orders;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class N2PPayloadBuilder
+{
+    public function build(Orders $order, array $settings): array
+    {
+        $jobs = [];
+        $jobStatus = Arr::get($settings, 'n2p_job_status_on_send', 'released');
+        $defaultPriority = (int) Arr::get($settings, 'n2p_priority_default', 3);
+        $sendTasks = (bool) Arr::get($settings, 'n2p_send_tasks', true);
+
+        foreach ($order->OrderLines as $orderLine) {
+            $jobs[] = $this->buildJob($order, $orderLine, $jobStatus, $defaultPriority, $sendTasks);
+        }
+
+        return [
+            'jobs' => array_values(array_filter($jobs)),
+        ];
+    }
+
+    private function buildJob(Orders $order, OrderLines $orderLine, string $jobStatus, int $defaultPriority, bool $sendTasks): array
+    {
+        $priority = $this->clampPriority($order->priority ?? $defaultPriority);
+
+        $dueDate = $orderLine->delivery_date ?? $order->validity_date ?? null;
+
+        $product = $orderLine->Product;
+        $details = $orderLine->OrderLineDetails;
+        $company = $order->companie;
+
+        $job = [
+            'of_code' => $order->code ?? $order->uuid,
+            'line_ref' => (string) $orderLine->getKey(),
+            'required_qty' => (float) $orderLine->qty,
+            'status' => $jobStatus,
+            'priority' => $priority,
+            'due_date' => $this->nullableDate($dueDate),
+            'order_ref' => $order->code ?? null,
+            'customer_code' => $company?->code,
+            'customer_name' => $company?->label,
+            'product_ref' => $product?->code ?? $orderLine->code,
+            'material' => $details?->material ?? $product?->material,
+            'thickness' => $this->nullableNumber($details?->thickness ?? $product?->thickness),
+            'notes' => $orderLine->comment ?? $order->comment,
+        ];
+
+        if (!$job['due_date']) {
+            unset($job['due_date']);
+        }
+
+        if ($job['thickness'] === null) {
+            unset($job['thickness']);
+        }
+
+        if (!$job['notes']) {
+            unset($job['notes']);
+        }
+
+        if ($sendTasks) {
+            $job['tasks'] = $this->mapTasks($orderLine->Task);
+        }
+
+        return array_filter($job, fn ($value) => !is_null($value) && $value !== '');
+    }
+
+    private function mapTasks($tasks): array
+    {
+        return $tasks->map(function (Task $task) {
+            $operationCode = $task->code ?: ($task->operation_code ?? null);
+            if (!$operationCode) {
+                $operationCode = Str::slug($task->label ?? 'task-' . $task->getKey());
+            }
+
+            $plannedTimeMinutes = null;
+            if ($task->seting_time !== null || $task->unit_time !== null) {
+                $plannedTimeMinutes = (int) max(0, round($task->TotalTime() * 60));
+            }
+
+            $workcenterCode = $task->MethodsTools->code ?? null;
+
+            return array_filter([
+                'operation_code' => $operationCode,
+                'workcenter_code' => $workcenterCode,
+                'planned_start_at' => $this->nullableDateTime($task->start_date),
+                'planned_end_at' => $this->nullableDateTime($task->end_date),
+                'planned_time_min' => $plannedTimeMinutes,
+                'notes' => $task->comment ?? null,
+            ], fn ($value) => !is_null($value) && $value !== '');
+        })->values()->all();
+    }
+
+    private function clampPriority(?int $priority): int
+    {
+        $priority = $priority ?? 3;
+        return max(1, min(5, $priority));
+    }
+
+    private function nullableDate($date): ?string
+    {
+        if (!$date) {
+            return null;
+        }
+
+        return optional($date)->toDateString();
+    }
+
+    private function nullableDateTime($date): ?string
+    {
+        if (!$date) {
+            return null;
+        }
+
+        return optional($date)->toDateTimeString();
+    }
+
+    private function nullableNumber($number): ?float
+    {
+        if ($number === null || $number === '') {
+            return null;
+        }
+
+        return (float) $number;
+    }
+}

--- a/app/Services/Settings/SettingsService.php
+++ b/app/Services/Settings/SettingsService.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services\Settings;
+
+use App\Models\Setting;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+
+class SettingsService
+{
+    private const CACHE_PREFIX = 'settings.';
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return Cache::rememberForever($this->cacheKey($key), function () use ($key, $default) {
+            $setting = Setting::query()->where('key', $key)->first();
+
+            if (!$setting) {
+                return $default;
+            }
+
+            return $this->decodeValue($setting->value, $default);
+        });
+    }
+
+    public function getMany(array $keys, array $defaults = []): array
+    {
+        $values = [];
+        foreach ($keys as $key) {
+            $values[$key] = $this->get($key, Arr::get($defaults, $key));
+        }
+
+        return $values;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        Setting::query()->updateOrCreate(['key' => $key], ['value' => $this->encodeValue($value)]);
+        Cache::forget($this->cacheKey($key));
+    }
+
+    public function setMany(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    private function cacheKey(string $key): string
+    {
+        return self::CACHE_PREFIX . $key;
+    }
+
+    private function encodeValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_array($value) || is_object($value)) {
+            return json_encode($value);
+        }
+
+        return (string) $value;
+    }
+
+    private function decodeValue(string $value, mixed $default): mixed
+    {
+        $trimmed = trim($value);
+
+        if ($trimmed === 'null') {
+            return null;
+        }
+
+        if (is_numeric($trimmed)) {
+            return $trimmed + 0;
+        }
+
+        $lower = strtolower($trimmed);
+        if (in_array($lower, ['true', 'false'], true)) {
+            return $lower === 'true';
+        }
+
+        $json = json_decode($value, true);
+        if (json_last_error() === JSON_ERROR_NONE && is_array($json)) {
+            return $json;
+        }
+
+        if ($value === '') {
+            return $default;
+        }
+
+        return $value;
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -109,6 +109,12 @@ return [
             'handler' => NullHandler::class,
         ],
 
+        'n2p' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/n2p.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+        ],
+
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],

--- a/database/migrations/2026_02_19_000000_create_settings_table.php
+++ b/database/migrations/2026_02_19_000000_create_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2026_02_19_000100_add_n2p_fields_to_orders_table.php
+++ b/database/migrations/2026_02_19_000100_add_n2p_fields_to_orders_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dateTime('n2p_last_push_at')->nullable()->after('type');
+            $table->string('n2p_last_push_status')->nullable()->after('n2p_last_push_at');
+            $table->text('n2p_last_push_error')->nullable()->after('n2p_last_push_status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn(['n2p_last_push_at', 'n2p_last_push_status', 'n2p_last_push_error']);
+        });
+    }
+};

--- a/docs/n2p-integration.md
+++ b/docs/n2p-integration.md
@@ -1,0 +1,57 @@
+# Nest2Prod (N2P) - Intégration WEM
+
+## Paramètres Settings
+- `n2p_enabled` : activer/désactiver l’envoi (bool).
+- `n2p_base_url` : URL de base N2P (ex: `https://n2p.example.com`).
+- `n2p_api_token` : token API (Bearer).
+- `n2p_send_on_order_status_from` : statut source (ex: `OPEN`).
+- `n2p_send_on_order_status_to` : statut cible (ex: `IN_PROGRESS`).
+- `n2p_job_status_on_send` : statut job envoyé (par défaut `released`).
+- `n2p_priority_default` : priorité par défaut 1..5 (par défaut `3`).
+- `n2p_send_tasks` : envoyer les tâches liées aux lignes (bool).
+
+## Happy path (envoi automatique)
+1. Activer `n2p_enabled`, renseigner `n2p_base_url` et `n2p_api_token`.
+2. Saisir les statuts source/cible (ex: OPEN -> IN_PROGRESS).
+3. Passer une commande de `statu` 1 à `statu` 2 (OPEN -> IN_PROGRESS).
+4. Vérifier le log `storage/logs/n2p.log` et les colonnes `n2p_last_push_*` sur la commande.
+
+## Cas « N2P down »
+- Forcer un échec (ex: arrêter N2P ou URL invalide), relancer le changement de statut.
+- Vérifier que le job est ré-essayé (backoff progressif) et que `n2p_last_push_status = ERROR` contient le message.
+
+## Queue worker
+- Lancement standard : `php artisan queue:work`.
+- Le job `PushOrderToN2P` est réessayé 5 fois avec backoff `[60, 300, 900, 1800, 3600]`.
+
+## Commandes utiles
+- Pousser une commande : `php artisan wem:n2p:push-order {orderId}`.
+- En synchrone (sans queue) : `php artisan wem:n2p:push-order {orderId} --sync`.
+
+## Exemple de payload envoyé
+```json
+{
+  "jobs": [
+    {
+      "of_code": "ORD-1001",
+      "line_ref": "55",
+      "required_qty": 10,
+      "status": "released",
+      "priority": 2,
+      "due_date": "2026-03-01",
+      "customer_code": "CLI1",
+      "customer_name": "Client One",
+      "product_ref": "PART-001",
+      "tasks": [
+        {
+          "operation_code": "CUT",
+          "workcenter_code": "CNC01",
+          "planned_start_at": "2026-02-21 08:00:00",
+          "planned_end_at": "2026-02-21 10:00:00",
+          "planned_time_min": 90
+        }
+      ]
+    }
+  ]
+}
+```

--- a/resources/views/integrations/n2p-settings.blade.php
+++ b/resources/views/integrations/n2p-settings.blade.php
@@ -1,0 +1,65 @@
+@extends('adminlte::page')
+
+@section('title', 'Nest2Prod')
+
+@section('content_header')
+    <h1>Nest2Prod</h1>
+@stop
+
+@section('content')
+    @if(session('success'))
+        <x-adminlte-alert theme="success" title="{{ __('general_content.success_trans_key') }}">
+            {{ session('success') }}
+        </x-adminlte-alert>
+    @endif
+
+    <x-adminlte-card title="Configuration" theme="primary" theme-mode="outline">
+        <form method="POST" action="{{ route('admin.integrations.n2p.update') }}">
+            @csrf
+            @method('PUT')
+
+            <div class="row">
+                <div class="col-md-4">
+                    <x-adminlte-input-switch name="n2p_enabled" label="Activer l'intégration" data-on-text="Oui" data-off-text="Non" :checked="old('n2p_enabled', $settings['n2p_enabled'])"/>
+                </div>
+                <div class="col-md-4">
+                    <x-adminlte-input name="n2p_base_url" label="Base URL" placeholder="https://n2p.example.com" :value="old('n2p_base_url', $settings['n2p_base_url'])"/>
+                </div>
+                <div class="col-md-4">
+                    <x-adminlte-input name="n2p_api_token" label="API Token" type="password" :value="old('n2p_api_token', $settings['n2p_api_token'])"/>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-md-4">
+                    <x-adminlte-input name="n2p_send_on_order_status_from" label="Status source" placeholder="OPEN" :value="old('n2p_send_on_order_status_from', $settings['n2p_send_on_order_status_from'])"/>
+                </div>
+                <div class="col-md-4">
+                    <x-adminlte-input name="n2p_send_on_order_status_to" label="Status cible" placeholder="IN_PROGRESS" :value="old('n2p_send_on_order_status_to', $settings['n2p_send_on_order_status_to'])"/>
+                </div>
+                <div class="col-md-4">
+                    <x-adminlte-input name="n2p_job_status_on_send" label="Status job N2P" placeholder="released" :value="old('n2p_job_status_on_send', $settings['n2p_job_status_on_send'])"/>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-md-4">
+                    <x-adminlte-input name="n2p_priority_default" label="Priorité par défaut (1..5)" type="number" min="1" max="5" :value="old('n2p_priority_default', $settings['n2p_priority_default'])"/>
+                </div>
+                <div class="col-md-4">
+                    <x-adminlte-input-switch name="n2p_send_tasks" label="Inclure les tâches" data-on-text="Oui" data-off-text="Non" :checked="old('n2p_send_tasks', $settings['n2p_send_tasks'])"/>
+                </div>
+            </div>
+
+            <div class="mt-3">
+                <x-adminlte-button type="submit" label="{{ __('general_content.save_trans_key') }}" theme="primary" icon="fas fa-save"/>
+            </div>
+        </form>
+    </x-adminlte-card>
+@stop
+
+@section('css')
+@stop
+
+@section('js')
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -426,7 +426,9 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/factory/permissions/store', 'App\Http\Controllers\Admin\PermissionController@store')->middleware(['auth'])->name('admin.factory.permissions.store');
         Route::get('/factory/permissions/delete/{permission}', 'App\Http\Controllers\Admin\PermissionController@destroy')->middleware(['auth'])->name('admin.factory.permissions.destroy');
         Route::post('/factory/role/permissions/store', 'App\Http\Controllers\Admin\RoleController@RolePemissionStore')->middleware(['auth'])->name('admin.factory.rolepermissions.store');
-    
+        Route::get('/integrations/n2p', [\App\Http\Controllers\Integrations\N2PSettingsController::class, 'edit'])->middleware(['auth'])->name('admin.integrations.n2p');
+        Route::put('/integrations/n2p', [\App\Http\Controllers\Integrations\N2PSettingsController::class, 'update'])->middleware(['auth'])->name('admin.integrations.n2p.update');
+
         Route::post('/factory/custom-field/store', 'App\Http\Controllers\Admin\FactoryController@storeCustomField')->middleware(['auth'])->name('admin.factory.custom.field.store');
         Route::post('/factory/custom-field-value/storeOrUpdate/{id}/{type}', 'App\Http\Controllers\Admin\FactoryController@storeOrUpdateCustomField')->middleware(['auth'])->name('admin.factory.custom.field.value.store.update');
         

--- a/tests/Feature/N2PClientTest.php
+++ b/tests/Feature/N2PClientTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\N2P\N2PClient;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class N2PClientTest extends TestCase
+{
+    public function test_push_jobs_success(): void
+    {
+        Http::fake([
+            'https://n2p.test/api/plugin/jobs' => Http::response(['ok' => true], 200),
+        ]);
+
+        $client = new N2PClient('https://n2p.test', 'token');
+
+        $response = $client->pushJobs(['jobs' => []]);
+
+        $this->assertSame(['ok' => true], $response);
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://n2p.test/api/plugin/jobs'
+                && $request->hasHeader('Authorization', 'Bearer token');
+        });
+    }
+
+    public function test_push_jobs_throws_on_failure(): void
+    {
+        $this->expectException(RequestException::class);
+
+        Http::fake([
+            'https://n2p.test/api/plugin/jobs' => Http::response(['error' => 'fail'], 500),
+        ]);
+
+        $client = new N2PClient('https://n2p.test', null);
+        $client->pushJobs(['jobs' => []]);
+    }
+}

--- a/tests/Feature/N2PStatusChangeTest.php
+++ b/tests/Feature/N2PStatusChangeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\PushOrderToN2P;
+use App\Models\Setting;
+use App\Models\Workflow\Orders;
+use App\Observers\OrdersObserver;
+use App\Services\Settings\SettingsService;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class N2PStatusChangeTest extends TestCase
+{
+    public function test_dispatches_job_on_configured_status_change(): void
+    {
+        Queue::fake();
+
+        Setting::create(['key' => 'n2p_enabled', 'value' => 'true']);
+        Setting::create(['key' => 'n2p_send_on_order_status_from', 'value' => 'OPEN']);
+        Setting::create(['key' => 'n2p_send_on_order_status_to', 'value' => 'IN_PROGRESS']);
+
+        $order = new Orders([
+            'id' => 99,
+            'statu' => 2,
+        ]);
+        $order->setOriginal('statu', 1);
+
+        $observer = new OrdersObserver(new SettingsService());
+        $observer->updated($order);
+
+        Queue::assertPushed(PushOrderToN2P::class, function (PushOrderToN2P $job) {
+            return $job->orderId === 99;
+        });
+    }
+}

--- a/tests/Unit/N2PPayloadBuilderTest.php
+++ b/tests/Unit/N2PPayloadBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Methods\MethodsTools;
+use App\Models\Workflow\OrderLineDetails;
+use App\Models\Workflow\OrderLines;
+use App\Models\Workflow\Orders;
+use App\Services\N2P\N2PPayloadBuilder;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Mockery;
+use Tests\TestCase;
+
+class N2PPayloadBuilderTest extends TestCase
+{
+    public function test_builds_jobs_with_tasks(): void
+    {
+        $order = new Orders([
+            'id' => 10,
+            'code' => 'ORD-1001',
+            'uuid' => 'uuid-123',
+            'priority' => 2,
+            'validity_date' => Carbon::parse('2026-02-20'),
+        ]);
+
+        $company = new class {
+            public string $code = 'CLI1';
+            public string $label = 'Client One';
+        };
+
+        $line = new OrderLines([
+            'id' => 55,
+            'orders_id' => $order->getKey(),
+            'code' => 'LINE-1',
+            'qty' => 10,
+            'delivery_date' => Carbon::parse('2026-03-01'),
+            'comment' => 'Line note',
+        ]);
+
+        $details = new OrderLineDetails([
+            'material' => 'Steel',
+            'thickness' => 1.5,
+        ]);
+
+        $tool = new MethodsTools(['code' => 'CNC01']);
+
+        $task = Mockery::mock('App\Models\Planning\Task')->makePartial();
+        $task->shouldReceive('TotalTime')->andReturn(1.5);
+        $task->code = 'CUT';
+        $task->label = 'Laser cut';
+        $task->start_date = Carbon::parse('2026-02-21 08:00:00');
+        $task->end_date = Carbon::parse('2026-02-21 10:00:00');
+        $task->seting_time = 1.0;
+        $task->unit_time = 0.5;
+        $task->setRelation('MethodsTools', $tool);
+
+        $line->setRelation('OrderLineDetails', $details);
+        $line->setRelation('Task', new Collection([$task]));
+
+        $order->setRelation('OrderLines', new Collection([$line]));
+        $order->setRelation('companie', $company);
+
+        $builder = new N2PPayloadBuilder();
+
+        $payload = $builder->build($order, [
+            'n2p_job_status_on_send' => 'released',
+            'n2p_priority_default' => 3,
+            'n2p_send_tasks' => true,
+        ]);
+
+        $this->assertArrayHasKey('jobs', $payload);
+        $job = $payload['jobs'][0];
+        $this->assertSame('ORD-1001', $job['of_code']);
+        $this->assertSame('55', $job['line_ref']);
+        $this->assertSame('released', $job['status']);
+        $this->assertSame(2, $job['priority']);
+        $this->assertSame('2026-03-01', $job['due_date']);
+        $this->assertSame('CLI1', $job['customer_code']);
+        $this->assertSame('Client One', $job['customer_name']);
+        $this->assertSame('Steel', $job['material']);
+        $this->assertSame(1.5, $job['thickness']);
+        $this->assertCount(1, $job['tasks']);
+        $this->assertSame('CUT', $job['tasks'][0]['operation_code']);
+        $this->assertSame('CNC01', $job['tasks'][0]['workcenter_code']);
+        $this->assertSame('2026-02-21 08:00:00', $job['tasks'][0]['planned_start_at']);
+        $this->assertSame(90, $job['tasks'][0]['planned_time_min']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a configurable Nest2Prod (N2P) integration to push WEM OrderLines and Tasks as N2P jobs when an order transitions status (default OPEN -> IN_PROGRESS).
- Allow operators to enable/disable the integration and configure `base_url`/`token` and behavioral options from an admin UI.
- Ensure pushes are robust: serialized payload, HTTP client with timeout and logging, async job with retries/backoff and order-level push status tracking.

### Description
- Add persistent settings storage and service: `settings` migration + `App\Models\Setting` and `App\Services\Settings\SettingsService`, admin controller `Integrations\N2PSettingsController`, request validation `N2PSettingsRequest`, blade UI `resources/views/integrations/n2p-settings.blade.php`, and admin routes `admin/integrations/n2p`.
- Implement N2P payload builder and client: `app/Services/N2P/N2PPayloadBuilder.php` builds `{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d141f1bdc832db90c60354227711b)