### PR TITLE
Add missing `save_trans_key` translations to locale files

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -153,6 +153,7 @@ return [
     'created_at_trans_key'                     => 'تاريخ الإنشاء',
     'assigned_trans_key'                       => 'مخصص',
     'action_trans_key'                         => 'الإجراءات',
+    'save_trans_key'                           => 'حفظ',
     'user_trans_key'                           => 'المستخدم',
     'status_client_trans_key'                  => 'حالة العميل',
     'status_supplier_trans_key'                => 'حالة المورد',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -179,6 +179,7 @@ return [
     'created_at_trans_key'                     => 'Created at',
     'assigned_trans_key'                       => 'Assigned',
     'action_trans_key'                         => 'Actions',
+    'save_trans_key'                           => 'Save',
     'user_trans_key'                           => 'User',
     'status_client_trans_key'                  => 'Status client',
     'status_supplier_trans_key'                => 'Status supplier',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -153,6 +153,7 @@ return [
     'created_at_trans_key'                     => 'Creado en',
     'assigned_trans_key'                       => 'Asignado',
     'action_trans_key'                         => 'Acciones',
+    'save_trans_key'                           => 'Guardar',
     'user_trans_key'                           => 'Usuario',
     'status_client_trans_key'                  => 'Estado del cliente',
     'status_supplier_trans_key'                => 'Estado del proveedor',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -179,6 +179,7 @@ return [
     'created_at_trans_key'                     => 'Créer le',
     'assigned_trans_key'                       => 'Assigné à',
     'action_trans_key'                         => 'Actions',
+    'save_trans_key'                           => 'Enregistrer',
     'user_trans_key'                           => 'Utilisateur',
     'status_client_trans_key'                  => 'Etat client',
     'status_supplier_trans_key'                => 'Etat fournisseur',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -19,6 +19,7 @@ return [
     'created_at_trans_key'                     => 'Tạo lúc',
     'assigned_trans_key'                       => 'Đã phân công',
     'action_trans_key'                         => 'Chức năng',
+    'save_trans_key'                           => 'Lưu',
 
     // BUTTON
     'view_all_trans_key'                       => 'Xem toàn bộ',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -179,6 +179,7 @@ return [
     'created_at_trans_key'                     => '创建于',
     'assigned_trans_key'                       => '指派给',
     'action_trans_key'                         => '操作',
+    'save_trans_key'                           => '保存',
     'user_trans_key'                           => '用户',
     'status_client_trans_key'                  => '客户状态',
     'status_supplier_trans_key'                => '供应商状态',


### PR DESCRIPTION
### Motivation
- The Save button in some views used `__('general_content.save_trans_key')` but the `save_trans_key` entry was missing in several locale files causing untranslated labels. 
- Ensure consistent UI text across supported locales by adding the missing translation key.

### Description
- Added `'save_trans_key'` to `resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`, `resources/lang/ar/general_content.php`, `resources/lang/es/general_content.php`, `resources/lang/vi/general_content.php`, and `resources/lang/zh-CN/general_content.php` with appropriate translations.
- No changes were made to view templates; only localization strings were inserted.
- Commit recorded as `Add missing save translation key` and six files were updated.

### Testing
- No automated tests were run for this change.
- Changes were verified by checking the modified files and a `git diff --stat` showing the six insertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d27777714832d8cb187175d3b910a)