### PR TITLE
Normalize boolean switch inputs in N2P settings request

### DIFF
--- a/app/Http/Requests/Integrations/N2PSettingsRequest.php
+++ b/app/Http/Requests/Integrations/N2PSettingsRequest.php
@@ -24,4 +24,17 @@ class N2PSettingsRequest extends FormRequest
             'n2p_send_tasks' => ['required', 'boolean'],
         ];
     }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'n2p_enabled' => $this->toBoolean($this->input('n2p_enabled')),
+            'n2p_send_tasks' => $this->toBoolean($this->input('n2p_send_tasks')),
+        ]);
+    }
+
+    private function toBoolean(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+    }
 }


### PR DESCRIPTION
### Motivation
- Form switch components submit stringy/empty values that fail the `boolean` validation rules for N2P settings.
- Unchecked switches must be treated as `false` so required boolean fields do not reject valid submissions.
- Keep server-side validation robust against HTML form input variants for switches.

### Description
- Added `prepareForValidation()` to `app/Http/Requests/Integrations/N2PSettingsRequest.php` to normalize switch inputs before validation.
- Coerces `n2p_enabled` and `n2p_send_tasks` to booleans via a new `toBoolean()` helper. 
- `toBoolean()` uses `filter_var(..., FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false` so absent or non-boolean values become `false`.
- Validation rules themselves were left unchanged and continue to declare both fields as `required` and `boolean`.

### Testing
- No automated tests were executed for this change.
- Existing validation rules remain in place so the change is limited to normalizing input prior to validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d28ab01f0832da684d44bbb9a3ed6)