### PR TITLE
Add SSL verification toggle for Nest2Prod integration

### DIFF
--- a/app/Http/Controllers/Integrations/N2PSettingsController.php
+++ b/app/Http/Controllers/Integrations/N2PSettingsController.php
@@ -29,7 +29,7 @@ class N2PSettingsController extends Controller
         $validated = $request->validated();
         $defaults = $this->defaults();
 
-        foreach (['n2p_enabled', 'n2p_send_tasks'] as $booleanKey) {
+        foreach (['n2p_enabled', 'n2p_send_tasks', 'n2p_verify_ssl'] as $booleanKey) {
             $validated[$booleanKey] = (bool) ($validated[$booleanKey] ?? false);
         }
 
@@ -53,6 +53,7 @@ class N2PSettingsController extends Controller
             'n2p_job_status_on_send' => 'released',
             'n2p_priority_default' => 3,
             'n2p_send_tasks' => true,
+            'n2p_verify_ssl' => true,
         ];
     }
 }

--- a/app/Http/Requests/Integrations/N2PSettingsRequest.php
+++ b/app/Http/Requests/Integrations/N2PSettingsRequest.php
@@ -22,6 +22,7 @@ class N2PSettingsRequest extends FormRequest
             'n2p_job_status_on_send' => ['required', 'string', 'max:191'],
             'n2p_priority_default' => ['required', 'integer', 'between:1,5'],
             'n2p_send_tasks' => ['required', 'boolean'],
+            'n2p_verify_ssl' => ['required', 'boolean'],
         ];
     }
 
@@ -30,6 +31,7 @@ class N2PSettingsRequest extends FormRequest
         $this->merge([
             'n2p_enabled' => $this->toBoolean($this->input('n2p_enabled')),
             'n2p_send_tasks' => $this->toBoolean($this->input('n2p_send_tasks')),
+            'n2p_verify_ssl' => $this->toBoolean($this->input('n2p_verify_ssl')),
         ]);
     }
 

--- a/app/Jobs/PushOrderToN2P.php
+++ b/app/Jobs/PushOrderToN2P.php
@@ -37,9 +37,16 @@ class PushOrderToN2P implements ShouldQueue
             'n2p_job_status_on_send',
             'n2p_priority_default',
             'n2p_send_tasks',
+            'n2p_verify_ssl',
+        ], [
+            'n2p_verify_ssl' => true,
         ]);
 
-        $client = new N2PClient($config['n2p_base_url'], $config['n2p_api_token'] ?? null);
+        $client = new N2PClient(
+            $config['n2p_base_url'],
+            $config['n2p_api_token'] ?? null,
+            $config['n2p_verify_ssl'] ?? true
+        );
         $payload = $payloadBuilder->build($order, $config);
 
         $response = $client->pushJobs($payload);

--- a/app/Services/N2P/N2PClient.php
+++ b/app/Services/N2P/N2PClient.php
@@ -10,7 +10,11 @@ class N2PClient
 {
     private const TIMEOUT = 15;
 
-    public function __construct(private readonly string $baseUrl, private readonly ?string $token = null)
+    public function __construct(
+        private readonly string $baseUrl,
+        private readonly ?string $token = null,
+        private readonly bool $verifySsl = true
+    )
     {
     }
 
@@ -22,6 +26,7 @@ class N2PClient
             ->contentType('application/json')
             ->timeout(self::TIMEOUT)
             ->withHeaders($this->authorizationHeader())
+            ->withOptions(['verify' => $this->verifySsl])
             ->post($url, $payload);
 
         Log::channel('n2p')->info('N2P push request', [

--- a/docs/n2p-integration.md
+++ b/docs/n2p-integration.md
@@ -9,6 +9,7 @@
 - `n2p_job_status_on_send` : statut job envoyé (par défaut `released`).
 - `n2p_priority_default` : priorité par défaut 1..5 (par défaut `3`).
 - `n2p_send_tasks` : envoyer les tâches liées aux lignes (bool).
+- `n2p_verify_ssl` : vérifier le certificat SSL lors des appels API (bool, par défaut `true`).
 
 ## Happy path (envoi automatique)
 1. Activer `n2p_enabled`, renseigner `n2p_base_url` et `n2p_api_token`.

--- a/resources/views/integrations/n2p-settings.blade.php
+++ b/resources/views/integrations/n2p-settings.blade.php
@@ -49,6 +49,9 @@
                 <div class="col-md-4">
                     <x-adminlte-input-switch name="n2p_send_tasks" label="Inclure les tâches" data-on-text="Oui" data-off-text="Non" :checked="old('n2p_send_tasks', $settings['n2p_send_tasks'])"/>
                 </div>
+                <div class="col-md-4">
+                    <x-adminlte-input-switch name="n2p_verify_ssl" label="Vérifier le certificat SSL" data-on-text="Oui" data-off-text="Non" :checked="old('n2p_verify_ssl', $settings['n2p_verify_ssl'])"/>
+                </div>
             </div>
 
             <div class="mt-3">


### PR DESCRIPTION
### Motivation
- Users experienced cURL SSL errors when pushing to Nest2Prod endpoints with self-signed or untrusted certificates, preventing pushes to `https://.../api/plugin/jobs`.
- Provide a configurable way to disable SSL verification for such environments while keeping verification enabled by default.

### Description
- Add a new boolean setting `n2p_verify_ssl` with default `true`, include it in settings defaults, validation (`N2PSettingsRequest`), controller (`N2PSettingsController`) and settings UI view.
- Propagate the setting into the job by fetching `n2p_verify_ssl` in `PushOrderToN2P` and pass it to the client constructor.
- Extend `N2PClient` to accept a `verifySsl` constructor parameter and use `->withOptions(['verify' => $this->verifySsl])` on the HTTP request.
- Update `docs/n2p-integration.md` to document the new `n2p_verify_ssl` option.

### Testing
- No automated tests were executed for this change.
- Changes were verified by static inspection and local commits completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d911226dc832d9b08da2861b82ba8)