### PR TITLE
Add `bend_count` to products and propagate to quote/order line details

### DIFF
--- a/app/Http/Requests/Products/UpdateProductsRequest.php
+++ b/app/Http/Requests/Products/UpdateProductsRequest.php
@@ -34,6 +34,7 @@ class UpdateProductsRequest extends FormRequest
             'material' => 'nullable|string|max:255',
             'thickness' => 'nullable|numeric',
             'weight' => 'nullable|numeric',
+            'bend_count' => 'nullable|integer|min:0',
             'x_size' => 'nullable|numeric',
             'y_size' => 'nullable|numeric',
             'z_size' => 'nullable|numeric',
@@ -48,6 +49,8 @@ class UpdateProductsRequest extends FormRequest
             'diameter_oversize' => 'nullable|numeric',
             'section_size' => 'nullable|numeric',
             'finishing' => 'nullable|string|max:255',
+            'cad_file_path' => 'nullable|string|max:255',
+            'cam_file_path' => 'nullable|string|max:255',
             'picture'=> 'image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];
     }

--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -291,7 +291,12 @@ class OrderLine extends Component
         ]);
 
         //add line detail
-        $orderLineDetails = OrderLineDetails::create(['order_lines_id'=>$NewOrderLine->id]);
+        $detailData = ['order_lines_id' => $NewOrderLine->id];
+        if ($this->product_id) {
+            $product = Products::find($this->product_id);
+            $detailData = array_merge($detailData, $this->buildLineDetailDataFromProduct($product));
+        }
+        $orderLineDetails = OrderLineDetails::create($detailData);
         $this->customRequirements[$orderLineDetails->id] = [];
 
         // Set Flash Message
@@ -762,6 +767,7 @@ class OrderLine extends Component
         $newProductDetail->thickness = $orderLineDetailData->thickness;
         $newProductDetail->finishing = $orderLineDetailData->finishing;
         $newProductDetail->weight = $orderLineDetailData->weight;
+        $newProductDetail->bend_count = $orderLineDetailData->bend_count;
         $newProductDetail->x_size = $orderLineDetailData->x_size;
         $newProductDetail->y_size = $orderLineDetailData->y_size;
         $newProductDetail->z_size = $orderLineDetailData->z_size;
@@ -770,7 +776,34 @@ class OrderLine extends Component
         $newProductDetail->z_oversize = $orderLineDetailData->z_oversize;
         $newProductDetail->diameter = $orderLineDetailData->diameter;
         $newProductDetail->diameter_oversize = $orderLineDetailData->diameter_oversize;
+        $newProductDetail->cad_file_path = $orderLineDetailData->cad_file_path;
+        $newProductDetail->cam_file_path = $orderLineDetailData->cam_file_path;
         $newProductDetail->save();
+    }
+
+    private function buildLineDetailDataFromProduct(?Products $product): array
+    {
+        if (!$product) {
+            return [];
+        }
+
+        return [
+            'x_size' => $product->x_size,
+            'y_size' => $product->y_size,
+            'z_size' => $product->z_size,
+            'x_oversize' => $product->x_oversize,
+            'y_oversize' => $product->y_oversize,
+            'z_oversize' => $product->z_oversize,
+            'diameter' => $product->diameter,
+            'diameter_oversize' => $product->diameter_oversize,
+            'material' => $product->material,
+            'thickness' => $product->thickness,
+            'finishing' => $product->finishing,
+            'weight' => $product->weight,
+            'bend_count' => $product->bend_count,
+            'cad_file_path' => $product->cad_file_path,
+            'cam_file_path' => $product->cam_file_path,
+        ];
     }
     
     private function duplicateProductTasks($orderLineId, $newProductId)

--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -259,7 +259,12 @@ class QuoteLine extends Component
         ]);
         
         //add line detail
-        $quoteLineDetails = QuoteLineDetails::create(['quote_lines_id'=>$NewQuoteLine->id]);
+        $detailData = ['quote_lines_id' => $NewQuoteLine->id];
+        if ($this->product_id) {
+            $product = Products::find($this->product_id);
+            $detailData = array_merge($detailData, $this->buildLineDetailDataFromProduct($product));
+        }
+        $quoteLineDetails = QuoteLineDetails::create($detailData);
         $this->customRequirements[$quoteLineDetails->id] = [];
         
         // Set Flash Message
@@ -482,6 +487,7 @@ class QuoteLine extends Component
         $newProductDetail->thickness = $quoteLineDetailData->thickness;
         $newProductDetail->finishing = $quoteLineDetailData->finishing;
         $newProductDetail->weight = $quoteLineDetailData->weight;
+        $newProductDetail->bend_count = $quoteLineDetailData->bend_count;
         $newProductDetail->x_size = $quoteLineDetailData->x_size;
         $newProductDetail->y_size = $quoteLineDetailData->y_size;
         $newProductDetail->z_size = $quoteLineDetailData->z_size;
@@ -490,6 +496,8 @@ class QuoteLine extends Component
         $newProductDetail->z_oversize = $quoteLineDetailData->z_oversize;
         $newProductDetail->diameter = $quoteLineDetailData->diameter;
         $newProductDetail->diameter_oversize = $quoteLineDetailData->diameter_oversize;
+        $newProductDetail->cad_file_path = $quoteLineDetailData->cad_file_path;
+        $newProductDetail->cam_file_path = $quoteLineDetailData->cam_file_path;
         $newProductDetail->save();
     }
     
@@ -534,6 +542,31 @@ class QuoteLine extends Component
         $this->customerPriceList = [];
         $this->appliedPriceListId = null;
         $this->priceSource = null;
+    }
+
+    private function buildLineDetailDataFromProduct(?Products $product): array
+    {
+        if (!$product) {
+            return [];
+        }
+
+        return [
+            'x_size' => $product->x_size,
+            'y_size' => $product->y_size,
+            'z_size' => $product->z_size,
+            'x_oversize' => $product->x_oversize,
+            'y_oversize' => $product->y_oversize,
+            'z_oversize' => $product->z_oversize,
+            'diameter' => $product->diameter,
+            'diameter_oversize' => $product->diameter_oversize,
+            'material' => $product->material,
+            'thickness' => $product->thickness,
+            'finishing' => $product->finishing,
+            'weight' => $product->weight,
+            'bend_count' => $product->bend_count,
+            'cad_file_path' => $product->cad_file_path,
+            'cam_file_path' => $product->cam_file_path,
+        ];
     }
 
     protected function loadCustomerPriceList(bool $resetSelection = true): void

--- a/app/Livewire/StockCurrent.php
+++ b/app/Livewire/StockCurrent.php
@@ -122,12 +122,12 @@ class StockCurrent extends Component
             'thickness'=>$ProductDetail->thickness,
             'finishing'=>$ProductDetail->finishing,
             'weight'=>$ProductDetail->weight,
-            'bend_count'=>0,
+            'bend_count'=>$ProductDetail->bend_count,
             'material_loss_rate'=>0,
             'cad_file'=>$ProductDetail->drawing_file,
             'cam_file'=>null,
-            'cad_file_path'=>null,
-            'cam_file_path'=>null,
+            'cad_file_path'=>$ProductDetail->cad_file_path,
+            'cam_file_path'=>$ProductDetail->cam_file_path,
         ]);
 
         $TaskLine = Task::where('products_id', $productId)->get();

--- a/app/Models/Products/Products.php
+++ b/app/Models/Products/Products.php
@@ -40,6 +40,7 @@ class Products extends Model
                             'material', 
                             'thickness', 
                             'weight', 
+                            'bend_count',
                             'x_size', 
                             'y_size', 
                             'z_size', 
@@ -58,6 +59,8 @@ class Products extends Model
                             'drawing_file',
                             'stl_file',
                             'svg_file',
+                            'cad_file_path',
+                            'cam_file_path',
                             'csv_file_name',];
 
     // Only log changes

--- a/database/migrations/2026_01_07_213912_add_cad_cam_file_paths_to_products_table.php
+++ b/database/migrations/2026_01_07_213912_add_cad_cam_file_paths_to_products_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->string('cad_file_path')->nullable()->after('svg_file');
+            $table->string('cam_file_path')->nullable()->after('cad_file_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['cad_file_path', 'cam_file_path']);
+        });
+    }
+};

--- a/database/migrations/2026_01_07_214242_add_bend_count_to_products_table.php
+++ b/database/migrations/2026_01_07_214242_add_bend_count_to_products_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->unsignedInteger('bend_count')->nullable()->after('weight');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('bend_count');
+        });
+    }
+};

--- a/resources/views/products/products-show.blade.php
+++ b/resources/views/products/products-show.blade.php
@@ -192,6 +192,16 @@
                     </div>
                 </div>
                 <div class="row">
+                    <div class="form-group col-md-4">
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-layer-group"></i></span>
+                            </div>
+                            <input type="number" class="form-control" value="{{ $Product->bend_count }}" name="bend_count" id="bend_count" placeholder="{{ __('general_content.bend_count_trans_key') }}" step="1" min="0">
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
                   <div class="form-group col-md-4">
                       <div class="input-group">
                           <div class="input-group-prepend">
@@ -201,8 +211,20 @@
                       </div>
                   </div>
                   <div class="form-group col-md-4">
+                    <div class="input-group">
+                      <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="far fa-folder-open"></i></span>
+                      </div>
+                      <input type="text" class="form-control" value="{{ $Product->cad_file_path }}" name="cad_file_path" id="cad_file_path" placeholder="{{ __('CAD file path') }}">
+                    </div>
                   </div>
                   <div class="form-group col-md-4">
+                    <div class="input-group">
+                      <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="far fa-folder-open"></i></span>
+                      </div>
+                      <input type="text" class="form-control" value="{{ $Product->cam_file_path }}" name="cam_file_path" id="cam_file_path" placeholder="{{ __('CAM file path') }}">
+                    </div>
                   </div>
                 </div>
                 <hr>


### PR DESCRIPTION
### Motivation
- Persist `bend_count` on `products` and expose it in the product edit UI.
- Ensure `bend_count` is copied between products and quote/order line details and preserved when creating products from line details.
- Retain and propagate CAD/CAM file path fields so product file paths are available on line details.

### Description
- Add migrations `2026_01_07_214242_add_bend_count_to_products_table.php` (adds `bend_count`) and `2026_01_07_213912_add_cad_cam_file_paths_to_products_table.php` (adds `cad_file_path`/`cam_file_path`).
- Add `bend_count`, `cad_file_path`, and `cam_file_path` to `Products::$fillable` and validation rules in `app/Http/Requests/Products/UpdateProductsRequest.php`.
- Update product edit view `resources/views/products/products-show.blade.php` to include inputs for `bend_count`, `cad_file_path`, and `cam_file_path`.
- Update Livewire components `app/Livewire/QuoteLine.php`, `app/Livewire/OrderLine.php`, and `app/Livewire/StockCurrent.php` to prefill line details from a selected product via `buildLineDetailDataFromProduct` and to copy `bend_count` and CAD/CAM paths when creating or converting products/lines.

### Testing
- No automated tests were executed against these changes.
- Runtime verification was not performed because the development server could not be started in this environment due to missing dependencies (e.g. `vendor/autoload.php`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed20def90832d8b1e7eb48868ace1)