### PR TITLE
Add order line planned start/end dates to N2P job payloads

### DIFF
--- a/app/Services/N2P/N2PPayloadBuilder.php
+++ b/app/Services/N2P/N2PPayloadBuilder.php
@@ -31,6 +31,19 @@ class N2PPayloadBuilder
         $priority = $this->clampPriority($order->priority ?? $defaultPriority);
 
         $dueDate = $orderLine->delivery_date ?? $order->validity_date ?? null;
+        $tasks = $orderLine->Task ?? collect();
+        $plannedStartAt = optional(
+            $tasks
+                ->filter(fn (Task $task) => (bool) $task->start_date)
+                ->sortBy('start_date')
+                ->first()
+        )->start_date;
+        $plannedEndAt = optional(
+            $tasks
+                ->filter(fn (Task $task) => (bool) $task->end_date)
+                ->sortByDesc('end_date')
+                ->first()
+        )->end_date;
 
         $product = $orderLine->Product;
         $details = $orderLine->OrderLineDetails;
@@ -50,6 +63,8 @@ class N2PPayloadBuilder
             'material' => $details?->material ?? $product?->material,
             'thickness' => $this->nullableNumber($details?->thickness ?? $product?->thickness),
             'notes' => $orderLine->comment ?? $order->comment,
+            'planned_start_at' => $this->nullableDateTime($plannedStartAt),
+            'planned_end_at' => $this->nullableDateTime($plannedEndAt),
         ];
 
         if (!$job['due_date']) {


### PR DESCRIPTION
### Motivation
- Ensure job-level `planned_start_at` and `planned_end_at` reflect the span of tasks on each order line.
- Use the earliest task `start_date` and the latest task `end_date` so downstream systems receive line-level planned windows.

### Description
- In `buildJob` compute `$tasks = $orderLine->Task ?? collect()` and derive `plannedStartAt` from the first task with a `start_date` and `plannedEndAt` from the last task with an `end_date`.
- Add `planned_start_at` and `planned_end_at` to the job payload formatted via `nullableDateTime` so absent values are omitted.
- Preserve existing task mapping by keeping `mapTasks` unchanged and only adding the line-level planned timestamps to the top-level job object.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed69ae8b0832d95b5265d8b6d9b20)