### PR TITLE
Add required_qty to N2P task payloads

### DIFF
--- a/app/Services/N2P/N2PPayloadBuilder.php
+++ b/app/Services/N2P/N2PPayloadBuilder.php
@@ -89,7 +89,7 @@ class N2PPayloadBuilder
 
 
         if ($sendTasks) {
-            $tasksPayload = $this->mapTasks($orderLine->Task);
+            $tasksPayload = $this->mapTasks($orderLine, $orderLine->Task);
         
             $job['tasks'] = $tasksPayload;
         }
@@ -97,9 +97,9 @@ class N2PPayloadBuilder
         return array_filter($job, fn ($value) => !is_null($value) && $value !== '');
     }
 
-    private function mapTasks($tasks): array
+    private function mapTasks(OrderLines $orderLine, $tasks): array
     {
-        return $tasks->map(function (Task $task) {
+        return $tasks->map(function (Task $task) use ($orderLine) {
             $operationCode = $task->label ?: ($task->service->code ?? null);
             if (!$operationCode) {
                 $operationCode = Str::slug($task->label ?? 'task-' . $task->getKey());
@@ -118,6 +118,7 @@ class N2PPayloadBuilder
                 'planned_start_at' => $this->nullableDateTime($task->start_date),
                 'planned_end_at' => $this->nullableDateTime($task->end_date),
                 'planned_time_min' => $plannedTimeMinutes,
+                'required_qty' => (float) $orderLine->qty,
                 'notes' => $task->comment ?? null,
             ], fn ($value) => !is_null($value) && $value !== '');
         })->values()->all();


### PR DESCRIPTION
### Motivation
- Ensure each task sent to N2P includes the order line quantity so consumers can know required quantities per operation.
- Provide the task mapping function with the order line context to allow per-task fields derived from the line.
- Keep task-level `required_qty` consistent with the job-level `required_qty` already present on the job payload.

### Description
- Pass the order line into the task mapper by changing the call to `mapTasks($orderLine, $orderLine->Task)`.
- Update the mapper signature to `mapTasks(OrderLines $orderLine, $tasks)` and capture the `$orderLine` in the closure.
- Add a `required_qty` field to each task payload set to `(float) $orderLine->qty`.
- Preserve existing payload filtering logic so null/empty values are omitted.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695edc1b1c08832d85f9944717ca96cb)