### PR TITLE
Add required_qty to N2P task payloads

### DIFF
--- a/app/Services/N2P/N2PPayloadBuilder.php
+++ b/app/Services/N2P/N2PPayloadBuilder.php
@@ -115,6 +115,7 @@ class N2PPayloadBuilder
             return array_filter([
                 'operation_code' => $operationCode,
                 'workcenter_code' => $workcenterCode,
+                'required_qty' => $this->nullableNumber($task->qty ?? $task->qty_init),
                 'planned_start_at' => $this->nullableDateTime($task->start_date),
                 'planned_end_at' => $this->nullableDateTime($task->end_date),
                 'planned_time_min' => $plannedTimeMinutes,

--- a/docs/n2p-integration.md
+++ b/docs/n2p-integration.md
@@ -47,6 +47,7 @@
         {
           "operation_code": "CUT",
           "workcenter_code": "CNC01",
+          "required_qty": 10,
           "planned_start_at": "2026-02-21 08:00:00",
           "planned_end_at": "2026-02-21 10:00:00",
           "planned_time_min": 90


### PR DESCRIPTION
### Motivation
- Include per-task quantity in the N2P job payload so the external scheduler receives the required quantity for each task.
- Keep the integration documentation in sync with the actual payload sent to N2P.

### Description
- Add `required_qty` to each task payload in `app/Services/N2P/N2PPayloadBuilder.php` using `nullableNumber($task->qty ?? $task->qty_init)` inside `mapTasks`.
- Update the example payload in `docs/n2p-integration.md` to show `required_qty` on the example task.
- Preserve existing filtering behavior so `required_qty` is omitted when the value is null or empty.

### Testing
- No automated tests were executed for this change.
- Changes were committed and staged for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695edc42cb70832dba2ca478426635ce)