### PR TITLE
Add configurable 'nest2prod' color palette and theme CSS

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -783,6 +783,16 @@ return [
     */
 
     'plugins' => [
+        'ThemeNest2Prod' => [
+            'active' => env('WEBERP_COLOR_THEME', 'nest2prod') === 'nest2prod',
+            'files' => [
+                [
+                    'type' => 'css',
+                    'asset' => true,
+                    'location' => 'css/theme-nest2prod.css',
+                ],
+            ],
+        ],
         'Datatables' => [
             'active' => false,
             'files' => [

--- a/config/theme.php
+++ b/config/theme.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'palette' => env('WEBERP_COLOR_THEME', 'nest2prod'),
+    'nest2prod_css' => 'css/theme-nest2prod.css',
+];

--- a/public/css/theme-nest2prod.css
+++ b/public/css/theme-nest2prod.css
@@ -1,0 +1,58 @@
+:root {
+    --sidebar-width: 300px;
+    --badge-unplanned-bg: #fef3e7;
+    --badge-unplanned-text: #ff7cc8;
+    --badge-planned-bg: #e7f0fe;
+    --badge-planned-text: #0366d6;
+    --badge-inprogress-bg: #fff5cc;
+    --badge-inprogress-text: #c58a00;
+    --badge-completed-bg: #d5f5e3;
+    --badge-completed-text: #218c74;
+    --badge-stopped-bg: #fdecea;
+    --badge-stopped-text: #c0392b;
+    --badge-deleted-bg: #f4f6f7;
+    --badge-deleted-text: #7f8c8d;
+    --badge-deleted-decoration: line-through;
+    --form-disabled-bg: #f0f0f0;
+    --form-disabled-text: #888888;
+    --form-disabled-border: #cccccc;
+    --surface-primary-rgb: 255 255 255;
+    --surface-muted-rgb: 248 250 252;
+    --border-strong-rgb: 226 232 240;
+    --border-muted-rgb: 203 213 225;
+    --text-primary-rgb: 15 23 42;
+    --text-secondary-rgb: 51 65 85;
+    --text-tertiary-rgb: 71 85 105;
+}
+
+@media (max-width: 768px) {
+    :root {
+        --sidebar-width: 0px;
+    }
+}
+
+.dark {
+    --badge-unplanned-bg: #4b2b15;
+    --badge-unplanned-text: #ffddb0;
+    --badge-planned-bg: #1e3458;
+    --badge-planned-text: #93c5fd;
+    --badge-inprogress-bg: #4a3a16;
+    --badge-inprogress-text: #fcd34d;
+    --badge-completed-bg: #1f3d32;
+    --badge-completed-text: #6ee7b7;
+    --badge-stopped-bg: #4a1f1d;
+    --badge-stopped-text: #fca5a5;
+    --badge-deleted-bg: #2f3437;
+    --badge-deleted-text: #d1d5db;
+    --badge-deleted-decoration: none;
+    --form-disabled-bg: #1f2937;
+    --form-disabled-text: #9ca3af;
+    --form-disabled-border: #374151;
+    --surface-primary-rgb: 15 23 42;
+    --surface-muted-rgb: 30 41 59;
+    --border-strong-rgb: 71 85 105;
+    --border-muted-rgb: 51 65 85;
+    --text-primary-rgb: 226 232 240;
+    --text-secondary-rgb: 203 213 225;
+    --text-tertiary-rgb: 148 163 184;
+}

--- a/resources/views/customer/layouts/app.blade.php
+++ b/resources/views/customer/layouts/app.blade.php
@@ -27,6 +27,9 @@
     @else
         <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
     @endif
+    @if (config('theme.palette') === 'nest2prod')
+        <link rel="stylesheet" href="{{ asset(config('theme.nest2prod_css')) }}">
+    @endif
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -12,6 +12,9 @@
 
         <!-- Styles -->
         <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+        @if (config('theme.palette') === 'nest2prod')
+            <link rel="stylesheet" href="{{ asset(config('theme.nest2prod_css')) }}">
+        @endif
 
         <!-- Scripts -->
         <script src="{{ asset('js/app.js') }}" defer></script>


### PR DESCRIPTION
### Motivation
- Provide a softer color palette and make it configurable so the app can switch between the default/bootstrap look and a `nest2prod` theme.
- Allow loading a theme stylesheet at runtime without modifying many view files.

### Description
- Add a configuration file `config/theme.php` with a `palette` setting controlled by the `WEBERP_COLOR_THEME` environment variable and a pointer to the CSS (`nest2prod_css`).
- Add the `nest2prod` stylesheet at `public/css/theme-nest2prod.css` containing CSS custom properties for badges, surfaces, borders and text colors.
- Register the theme as an AdminLTE plugin entry in `config/adminlte.php` so it can be included as an asset when enabled via `WEBERP_COLOR_THEME`.
- Conditionally include the `nest2prod` CSS in `resources/views/layouts/guest.blade.php` and `resources/views/customer/layouts/app.blade.php` when `config('theme.palette') === 'nest2prod'`.

### Testing
- Attempted to run the application with `php artisan serve`, but it failed due to missing `vendor/autoload.php` so runtime verification could not be completed (failed).
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600c18b800832d9a2bd6c935537ceb)