### PR TITLE
Show only open quotes and orders on dashboard cards

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -63,8 +63,8 @@ class HomeController extends Controller
         $all_count = DB::table('users')->selectRaw("'user_count' as type, count(*) as count")
             ->unionAll(DB::table('companies')->selectRaw("'customers_count' as type, count(*) as count")->where('statu_customer', '=', '2')->whereYear('created_at', '=', $CurentYear))
             ->unionAll(DB::table('companies')->selectRaw("'suppliers_count' as type, count(*) as count")->where('statu_supplier', '=', '2'))
-            ->unionAll(DB::table('quotes')->selectRaw("'quotes_count' as type, count(*) as count"))
-            ->unionAll(DB::table('orders')->selectRaw("'orders_count' as type, count(*) as count"))
+            ->unionAll(DB::table('quotes')->selectRaw("'quotes_count' as type, count(*) as count")->where('statu', 1))
+            ->unionAll(DB::table('orders')->selectRaw("'orders_count' as type, count(*) as count")->where('statu', 1))
             ->unionAll(DB::table('quality_non_conformities')->selectRaw("'quality_non_conformities_count' as type, count(*) as count"))
             ->get();
         $data = $all_count->reduce(function($data, $count) {

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -59,7 +59,7 @@
     <!-- ./col -->
     <div class="col-lg-2 col-md-2">
       <x-adminlte-small-box title="{{ $data['quotes_count'] }}" 
-                            text="{{ __('general_content.quote_trans_key') }}" 
+                            text="{{ __('general_content.quote_trans_key') }} {{ __('general_content.open_trans_key') }}" 
                             icon="fas fa-calculator"
                             theme="primary" 
                             url="{{ route('quotes') }}" 
@@ -68,7 +68,7 @@
     <!-- ./col -->
     <div class="col-lg-2 col-md-2">
       <x-adminlte-small-box title="{{ $data['orders_count'] }}" 
-                            text="{{ __('general_content.orders_trans_key') }}" 
+                            text="{{ __('general_content.orders_trans_key') }} {{ __('general_content.open_trans_key') }}" 
                             icon="fas fa-shopping-cart"
                             theme="yellow" 
                             url="{{ route('orders') }}" 


### PR DESCRIPTION
### Motivation
- Afficher sur les cartes du tableau de bord le nombre de devis et commandes qui sont réellement « ouverts » plutôt que le total global.
- Rendre les libellés explicites pour éviter toute confusion sur le statut compté.

### Description
- Restreint les requêtes de comptage dans `HomeController::index` pour ne récupérer que les enregistrements `quotes` et `orders` avec `statu = 1`.
- Met à jour la vue `resources/views/dashboard.blade.php` pour afficher `{{ __('general_content.open_trans_key') }}` à côté des libellés des cartes devis et commandes.
- Modifications apportées aux fichiers `app/Http/Controllers/HomeController.php` et `resources/views/dashboard.blade.php`.

### Testing
- Aucune suite de tests automatisés n'a été exécutée pour cette modification.
- Les changements ont été appliqués et commités localement, mais pas couverts par des tests automatisés dans ce rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602692b750832d965d0473f537abad)