### PR TITLE
Add latest customer age to dashboard card

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -71,6 +71,13 @@ class HomeController extends Controller
             $data[$count->type] = $count->count;
             return $data;
         }, []);
+        $latestCustomerCreatedAt = DB::table('companies')
+            ->where('statu_customer', '=', '2')
+            ->orderByDesc('created_at')
+            ->value('created_at');
+        $data['latest_customer_since'] = $latestCustomerCreatedAt
+            ? Carbon::parse($latestCustomerCreatedAt)->diffForHumans()
+            : __('general_content.not_available_trans_key');
 
         $Announcement = Announcements::latest()->first();
 

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -668,6 +668,7 @@ return [
     'dashboard_trans_key'                      => 'Dashboard',
     'client_trans_key'                         => 'Clients',
     'new_client_trans_key'                     => 'New names',
+    'since_time_trans_key'                     => 'Since :time',
     'suppliers_trans_key'                      => 'Suppliers',
     'supplier_evaluations_trans_key'           => 'Supplier evaluations',
     'suppliers_client_trans_key'               => 'Clients / Suppliers',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -668,6 +668,7 @@ return [
     'dashboard_trans_key'                      => 'Tableau de bord',
     'client_trans_key'                         => 'Clients',
     'new_client_trans_key'                     => 'Nouveaux client',
+    'since_time_trans_key'                     => 'Depuis :time',
     'suppliers_trans_key'                      => 'Fournisseurs',
     'supplier_evaluations_trans_key'           => 'Évaluations fournisseurs',
     'suppliers_client_trans_key'               => 'Client / Fournisseurs',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -667,6 +667,7 @@ return [
     'dashboard_trans_key'                      => '仪表盘',
     'client_trans_key'                         => '客户',
     'new_client_trans_key'                     => '新增客户',
+    'since_time_trans_key'                     => '自 :time',
     'suppliers_trans_key'                      => '供应商',
     'supplier_evaluations_trans_key'           => '供应商评估',
     'suppliers_client_trans_key'               => '客户/供应商',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -41,7 +41,7 @@
   <div class="row" id="dashboard-row">
     <div class="col-lg-2">
       <x-adminlte-small-box title="{{$data['customers_count']}}"
-                            text="{{ __('general_content.new_client_trans_key') }}" 
+                            text="{{ __('general_content.new_client_trans_key') }} - {{ __('general_content.since_time_trans_key', ['time' => $data['latest_customer_since']]) }}" 
                             icon="far fa-building"
                             theme="info" 
                             url="{{ route('companies', ['type' => 'client']) }}" 


### PR DESCRIPTION
### Motivation
- Display how long since the most recent customer was added on the dashboard small-box to provide quick insight into new client activity.
- Use the existing dashboard data payload so the UI can remain lightweight and localized.

### Description
- Query the `companies` table for the most recent `created_at` where `statu_customer = 2` and expose `latest_customer_since` in the dashboard data using `Carbon::diffForHumans()` with a fallback to `not_available_trans_key`.
- Update the dashboard small-box text to append the localized "since" string using `__('general_content.since_time_trans_key', ['time' => $data['latest_customer_since']])`.
- Add the new translation key `since_time_trans_key` to `resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`, and `resources/lang/zh-CN/general_content.php`.
- Changes applied in `app/Http/Controllers/HomeController.php`, `resources/views/dashboard.blade.php`, and the three language files.

### Testing
- No automated test suite was executed for this change.
- An attempt to run the development server with `php artisan serve` failed due to missing Composer dependencies (`vendor/autoload.php`), so runtime verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696026781090832db93d761b1017c023)