### PR TITLE
Add Attendance model, migration and store endpoint

### DIFF
--- a/app/Http/Controllers/HumanResources/AttendanceController.php
+++ b/app/Http/Controllers/HumanResources/AttendanceController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\HumanResources;
+
+use App\Http\Controllers\Controller;
+use App\Models\HumanResources\Attendance;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class AttendanceController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'user_id' => ['required', 'integer', 'exists:users,id'],
+            'direction' => ['required', 'string', 'in:in,out'],
+            'source' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $lastAttendance = Attendance::where('user_id', $validated['user_id'])
+            ->latest('punched_at')
+            ->first();
+
+        if ($lastAttendance && $lastAttendance->direction === $validated['direction']) {
+            throw ValidationException::withMessages([
+                'direction' => ['Cannot punch ' . $validated['direction'] . ' twice in a row.'],
+            ]);
+        }
+
+        $attendance = Attendance::create([
+            'user_id' => $validated['user_id'],
+            'punched_at' => now(),
+            'direction' => $validated['direction'],
+            'source' => $validated['source'] ?? null,
+        ]);
+
+        return response()->json($attendance, 201);
+    }
+}

--- a/app/Models/HumanResources/Attendance.php
+++ b/app/Models/HumanResources/Attendance.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\HumanResources;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Attendance extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'punched_at',
+        'direction',
+        'source',
+    ];
+
+    protected $casts = [
+        'punched_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@ use App\Models\Admin\Announcements;
 use App\Models\Companies\Companies;
 use App\Models\Quality\QualityAction;
 use App\Models\Methods\MethodsSection;
+use App\Models\HumanResources\Attendance;
 use App\Models\Products\StockLocation;
 use Spatie\Permission\Traits\HasRoles;
 use App\Models\Planning\TaskActivities;
@@ -191,6 +192,16 @@ class User extends Authenticatable
     public function section()
     {
         return $this->hasMany(MethodsSection::class);
+    }
+
+    /**
+     * Define a one-to-many relationship with Attendance records.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function attendances()
+    {
+        return $this->hasMany(Attendance::class);
     }
 
     /**

--- a/database/migrations/2026_03_01_000000_create_attendances_table.php
+++ b/database/migrations/2026_03_01_000000_create_attendances_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('attendances', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('punched_at');
+            $table->string('direction');
+            $table->string('source')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('attendances');
+    }
+};


### PR DESCRIPTION
### Motivation
- Introduce attendance tracking for users with punch timestamps, direction and source metadata.
- Ensure punches are validated and prevent invalid consecutive punches (e.g. two `in` in a row).

### Description
- Add `App\Models\HumanResources\Attendance` model with fillable fields `user_id`, `punched_at`, `direction`, and `source`, and cast `punched_at` to `datetime`.
- Create migration to add the `attendances` table with `id`, foreign `user_id`, `punched_at` timestamp, `direction` string, nullable `source`, and timestamps.
- Add a `attendances()` relationship to `App\Models\User` as a `hasMany` to `Attendance`.
- Implement `App\Http\Controllers\HumanResources\AttendanceController@store` which validates `user_id` exists and `direction` is one of `in,out`, sets `punched_at` to `now()`, and rejects consecutive punches with the same `direction`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602916ed08832d92516b9716fb0e77)