### PR TITLE
Add human resources attendance report (route, controller, view, menu & i18n)

### DIFF
--- a/app/Http/Controllers/Admin/HumanResourcesController.php
+++ b/app/Http/Controllers/Admin/HumanResourcesController.php
@@ -13,7 +13,9 @@ use App\Models\UserExpenseCategory;
 use App\Services\SelectDataService;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Carbon;
 use App\Models\Admin\UserEmploymentContracts;
+use App\Models\Planning\TaskActivities;
 use App\Http\Requests\Admin\StoreUserExpenseRequest;
 use App\Http\Requests\Admin\UpdateUserExpenseRequest;
 use App\Http\Requests\Admin\StoreUserExpenseReportRequest;
@@ -353,5 +355,105 @@ class HumanResourcesController extends Controller
         $UserExpenseReport->save();
 
         return redirect()->route('human.resources')->with('success', 'Successfully valide  expense report');
+    }
+
+    /**
+     * Display the attendance report.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function attendanceReport(Request $request)
+    {
+        $filterUserId = $request->input('user_id');
+        $startDate = $request->input('start_date');
+        $endDate = $request->input('end_date');
+        $userSelect = $this->SelectDataService->getUsers();
+
+        $activities = TaskActivities::with('user')
+            ->when($filterUserId, function ($query, $filterUserId) {
+                return $query->where('user_id', $filterUserId);
+            })
+            ->when($startDate, function ($query, $startDate) {
+                return $query->whereDate('timestamp', '>=', $startDate);
+            })
+            ->when($endDate, function ($query, $endDate) {
+                return $query->whereDate('timestamp', '<=', $endDate);
+            })
+            ->orderBy('user_id')
+            ->orderBy('timestamp')
+            ->get();
+
+        $report = [];
+        $dayBuckets = [];
+        $openSessions = [];
+
+        foreach ($activities as $activity) {
+            $userId = $activity->user_id;
+            if (!isset($report[$userId])) {
+                $report[$userId] = [
+                    'user' => $activity->user,
+                    'total_seconds' => 0,
+                    'anomalies' => 0,
+                ];
+            }
+
+            $timestamp = Carbon::parse($activity->timestamp);
+            $dayBuckets[$userId][$timestamp->toDateString()] = true;
+
+            $taskId = $activity->task_id;
+            if ($activity->type === TaskActivities::TYPE_START) {
+                if (isset($openSessions[$userId][$taskId])) {
+                    $report[$userId]['anomalies']++;
+                }
+                $openSessions[$userId][$taskId] = $timestamp;
+                continue;
+            }
+
+            if (in_array($activity->type, [TaskActivities::TYPE_END, TaskActivities::TYPE_FINISH], true)) {
+                if (isset($openSessions[$userId][$taskId])) {
+                    $startTime = $openSessions[$userId][$taskId];
+                    if ($timestamp->greaterThan($startTime)) {
+                        $report[$userId]['total_seconds'] += $timestamp->diffInSeconds($startTime);
+                    } else {
+                        $report[$userId]['anomalies']++;
+                    }
+                    unset($openSessions[$userId][$taskId]);
+                } else {
+                    $report[$userId]['anomalies']++;
+                }
+            }
+        }
+
+        foreach ($openSessions as $userId => $tasks) {
+            foreach ($tasks as $taskId => $startTime) {
+                if (isset($report[$userId])) {
+                    $report[$userId]['anomalies']++;
+                }
+            }
+        }
+
+        foreach ($report as $userId => $data) {
+            $report[$userId]['days'] = isset($dayBuckets[$userId]) ? count($dayBuckets[$userId]) : 0;
+        }
+
+        if ($filterUserId && !isset($report[$filterUserId])) {
+            $report[$filterUserId] = [
+                'user' => User::find($filterUserId),
+                'total_seconds' => 0,
+                'anomalies' => 0,
+                'days' => 0,
+            ];
+        }
+
+        return view('admin/human-resources-attendance', [
+            'AttendanceReport' => $report,
+            'userSelect' => $userSelect,
+            'filters' => [
+                'user_id' => $filterUserId,
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+            ],
+        ]);
     }
 }

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -627,6 +627,11 @@ return [
                     'url'  => 'human-resources/users',
                     'icon_color' => 'info',
                 ],
+                [
+                    'text' => 'attendance_report_trans_key',
+                    'url'  => 'human-resources/attendance',
+                    'icon_color' => 'primary',
+                ],
             ],
         ],
         [

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -983,6 +983,11 @@ return [
     'expense_report_trans_key'              => 'تقرير المصاريف',
     'new_expense_report_trans_key'          => 'تقرير مصاريف جديد',
     'expense_validation_trans_key'          => 'تحقق من المصاريف',
+    'attendance_report_trans_key'           => 'تقرير الحضور',
+    'total_duration_trans_key'              => 'المدة الإجمالية',
+    'anomalies_trans_key'                   => 'الشذوذات',
+    'filter_trans_key'                      => 'تصفية',
+    'all_trans_key'                         => 'الكل',
 
     'licence_trans_key'                     => 'ترخيص',
     'release_note_trans_key'                => 'ملاحظات الإصدار',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1158,6 +1158,11 @@ return [
     'expense_report_trans_key'                 => 'Expense report',
     'new_expense_report_trans_key'             => 'New expense report',
     'expense_validation_trans_key'             => 'Expense validation',
+    'attendance_report_trans_key'              => 'Attendance report',
+    'total_duration_trans_key'                 => 'Total duration',
+    'anomalies_trans_key'                      => 'Anomalies',
+    'filter_trans_key'                         => 'Filter',
+    'all_trans_key'                            => 'All',
 
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Release notes',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -984,6 +984,11 @@ return [
     'expense_report_trans_key'             => 'Informe de gastos',
     'new_expense_report_trans_key'         => 'Nuevo informe de gastos',
     'expense_validation_trans_key'         => 'Validación de gastos',
+    'attendance_report_trans_key'          => 'Informe de asistencia',
+    'total_duration_trans_key'             => 'Duración total',
+    'anomalies_trans_key'                  => 'Anomalías',
+    'filter_trans_key'                     => 'Filtrar',
+    'all_trans_key'                        => 'Todos',
 
     'licence_trans_key'                    => 'Licencia',
     'release_note_trans_key'               => 'Notas de la versión',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1158,6 +1158,11 @@ return [
     'expense_report_trans_key'                 => 'Note de frais',
     'new_expense_report_trans_key'             => 'Nouvelle note de frais',
     'expense_validation_trans_key'             => 'Validation des note de frais',
+    'attendance_report_trans_key'              => 'Rapport de présence',
+    'total_duration_trans_key'                 => 'Durée totale',
+    'anomalies_trans_key'                      => 'Anomalies',
+    'filter_trans_key'                         => 'Filtrer',
+    'all_trans_key'                            => 'Tous',
 
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Notes de version',

--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -69,6 +69,7 @@ return [
     'human_resources_trans_key'                => 'Human resources',
     'expenses_trans_key'                       => 'Expenses',
     'users_list_trans_key'                     => 'Users list',
+    'attendance_report_trans_key'              => 'Attendance report',
     'documents_trans_key'                      => 'Documents',
     'osh_trans_key'                            => 'OSH',
     'incidents_trans_key'                      => 'Incidents',

--- a/resources/lang/vendor/adminlte/fr/menu.php
+++ b/resources/lang/vendor/adminlte/fr/menu.php
@@ -69,6 +69,7 @@ return [
     'human_resources_trans_key'                => 'Ressources humaine',
     'expenses_trans_key'                       => 'Note de frais',
     'users_list_trans_key'                     => 'Utilisateurs liste',
+    'attendance_report_trans_key'              => 'Rapport de présence',
     'documents_trans_key'                      => 'Documents',
     'osh_trans_key'                            => 'Risque et santé',
     'incidents_trans_key'                      => 'Incidents',

--- a/resources/lang/vendor/adminlte/vi/menu.php
+++ b/resources/lang/vendor/adminlte/vi/menu.php
@@ -49,6 +49,7 @@ return [
     'methods_trans_key'                        => 'Phương thức',
     'accounting_trans_key'                      => 'Kế toán',
     'human_resources_trans_key'                => 'Nguồn nhân lực',
+    'attendance_report_trans_key'              => 'Báo cáo chấm công',
     'users_trans_key'                          => 'Người dùng',
     'your_company_trans_key'                   => 'Công ty của bạn',
     'energy_consumption_trans_key'             => 'Mức tiêu thụ năng lượng',

--- a/resources/lang/vendor/adminlte/zh-CN/menu.php
+++ b/resources/lang/vendor/adminlte/zh-CN/menu.php
@@ -69,6 +69,7 @@ return [
     'human_resources_trans_key'                => '人力资源',
     'expenses_trans_key'                       => '费用报销',
     'users_list_trans_key'                     => '用户列表',
+    'attendance_report_trans_key'              => '考勤报表',
     'documents_trans_key'                      => '文档',
     'osh_trans_key'                            => '职业健康与安全',
     'incidents_trans_key'                      => '事件',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -1157,6 +1157,11 @@ return [
     'expense_report_trans_key'                 => '费用报表',
     'new_expense_report_trans_key'             => '新建费用报表',
     'expense_validation_trans_key'             => '报销审核',
+    'attendance_report_trans_key'              => '考勤报表',
+    'total_duration_trans_key'                 => '总时长',
+    'anomalies_trans_key'                      => '异常',
+    'filter_trans_key'                         => '筛选',
+    'all_trans_key'                            => '全部',
 
     'licence_trans_key'                        => '许可证',
     'release_note_trans_key'                   => '版本说明',

--- a/resources/views/admin/human-resources-attendance.blade.php
+++ b/resources/views/admin/human-resources-attendance.blade.php
@@ -1,0 +1,87 @@
+@extends('adminlte::page')
+
+@section('title', __('general_content.attendance_report_trans_key'))
+
+@section('content_header')
+    <h1>{{ __('general_content.attendance_report_trans_key') }}</h1>
+@stop
+
+@section('content')
+@include('include.alert-result')
+<div class="card">
+    <div class="card-header">
+        <form method="GET" action="{{ route('human.resources.attendance') }}">
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="form-group">
+                        <label for="user_id">{{ __('general_content.user_trans_key') }}</label>
+                        <select class="form-control" name="user_id" id="user_id">
+                            <option value="">{{ __('general_content.all_trans_key') }}</option>
+                            @foreach ($userSelect as $item)
+                                <option value="{{ $item->id }}" @if($filters['user_id'] == $item->id) selected @endif>
+                                    {{ $item->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label for="start_date">{{ __('general_content.start_date_trans_key') }}</label>
+                        <input type="date" class="form-control" name="start_date" id="start_date" value="{{ $filters['start_date'] }}">
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label for="end_date">{{ __('general_content.end_date_trans_key') }}</label>
+                        <input type="date" class="form-control" name="end_date" id="end_date" value="{{ $filters['end_date'] }}">
+                    </div>
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
+                    <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.filter_trans_key') }}" theme="info" icon="fas fa-filter"/>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive p-0">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>{{ __('general_content.user_trans_key') }}</th>
+                        <th>{{ __('general_content.days_trans_key') }}</th>
+                        <th>{{ __('general_content.total_duration_trans_key') }}</th>
+                        <th>{{ __('general_content.anomalies_trans_key') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($AttendanceReport as $row)
+                        @php
+                            $totalSeconds = $row['total_seconds'] ?? 0;
+                            $hours = floor($totalSeconds / 3600);
+                            $minutes = floor(($totalSeconds % 3600) / 60);
+                            $duration = sprintf('%02d:%02d', $hours, $minutes);
+                        @endphp
+                        <tr>
+                            <td>{{ optional($row['user'])->name }}</td>
+                            <td>{{ $row['days'] ?? 0 }}</td>
+                            <td>{{ $duration }}</td>
+                            <td>{{ $row['anomalies'] ?? 0 }}</td>
+                        </tr>
+                    @empty
+                        <x-EmptyDataLine col="4" text="{{ __('general_content.no_data_trans_key') }}" />
+                    @endforelse
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th>{{ __('general_content.user_trans_key') }}</th>
+                        <th>{{ __('general_content.days_trans_key') }}</th>
+                        <th>{{ __('general_content.total_duration_trans_key') }}</th>
+                        <th>{{ __('general_content.anomalies_trans_key') }}</th>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+</div>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -453,6 +453,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     Route::group(['prefix' => 'human-resources', 'middleware' => ['auth', 'check.factory']], function () {
         // Index route
         Route::get('/', 'App\Http\Controllers\Admin\HumanResourcesController@index')->name('human.resources');
+        Route::get('/attendance', 'App\Http\Controllers\Admin\HumanResourcesController@attendanceReport')->name('human.resources.attendance');
 
         // Index User route
         Route::get('/users', 'App\Http\Controllers\Admin\HumanResourcesController@indexUsers')->name('human.resources.index.users');


### PR DESCRIPTION
### Motivation
- Add an attendance reporting feature under Human Resources to show per-user presence summaries, total duration and anomalies based on task activity logs.
- Provide filtering by user and date range and expose the report in the AdminLTE HR menu for easy access.
- Reuse existing `TaskActivities` logs to compute aggregated metrics (days, total duration, anomalies) without changing the schema.

### Description
- Added a new route `human-resources/attendance` in `routes/web.php` mapped to `HumanResourcesController::attendanceReport` and protected by `auth` + `check.factory` middleware.
- Implemented `attendanceReport(Request $request)` in `app/Http/Controllers/Admin/HumanResourcesController.php` that queries `App\Models\Planning\TaskActivities`, applies `user_id`/`start_date`/`end_date` filters, and aggregates per-user `days`, `total_seconds` and `anomalies` (uses `Carbon` for timestamps).
- Created the Blade view `resources/views/admin/human-resources-attendance.blade.php` which provides filter inputs and renders a summary table (user, days, total duration, anomalies).
- Added a menu entry in `config/adminlte.php` and updated i18n strings in `resources/lang/*` and `resources/lang/vendor/adminlte/*` (English, French, Spanish, Arabic, Chinese, Vietnamese where applicable) to surface labels for the new report and UI texts.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696029177e1c832db01686afed10fad3)