### PR TITLE
Add attendance punches report tab

### DIFF
--- a/app/Http/Controllers/Admin/HumanResourcesController.php
+++ b/app/Http/Controllers/Admin/HumanResourcesController.php
@@ -14,6 +14,7 @@ use App\Services\SelectDataService;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Carbon;
+use App\Models\Attendance;
 use App\Models\Admin\UserEmploymentContracts;
 use App\Models\Planning\TaskActivities;
 use App\Http\Requests\Admin\StoreUserExpenseRequest;
@@ -446,8 +447,82 @@ class HumanResourcesController extends Controller
             ];
         }
 
+        $attendances = Attendance::with('user')
+            ->when($filterUserId, function ($query, $filterUserId) {
+                return $query->where('user_id', $filterUserId);
+            })
+            ->when($startDate, function ($query, $startDate) {
+                return $query->whereDate('punched_at', '>=', $startDate);
+            })
+            ->when($endDate, function ($query, $endDate) {
+                return $query->whereDate('punched_at', '<=', $endDate);
+            })
+            ->orderBy('user_id')
+            ->orderBy('punched_at')
+            ->get();
+
+        $attendanceReport = [];
+        $attendanceDayBuckets = [];
+        $openPunches = [];
+
+        foreach ($attendances as $attendance) {
+            $userId = $attendance->user_id;
+            if (!isset($attendanceReport[$userId])) {
+                $attendanceReport[$userId] = [
+                    'user' => $attendance->user,
+                    'total_seconds' => 0,
+                    'anomalies' => 0,
+                ];
+            }
+
+            $timestamp = Carbon::parse($attendance->punched_at);
+            $attendanceDayBuckets[$userId][$timestamp->toDateString()] = true;
+
+            if ($attendance->direction === 'in') {
+                if (isset($openPunches[$userId])) {
+                    $attendanceReport[$userId]['anomalies']++;
+                }
+                $openPunches[$userId] = $timestamp;
+                continue;
+            }
+
+            if ($attendance->direction === 'out') {
+                if (isset($openPunches[$userId])) {
+                    $startTime = $openPunches[$userId];
+                    if ($timestamp->greaterThan($startTime)) {
+                        $attendanceReport[$userId]['total_seconds'] += $timestamp->diffInSeconds($startTime);
+                    } else {
+                        $attendanceReport[$userId]['anomalies']++;
+                    }
+                    unset($openPunches[$userId]);
+                } else {
+                    $attendanceReport[$userId]['anomalies']++;
+                }
+            }
+        }
+
+        foreach ($openPunches as $userId => $startTime) {
+            if (isset($attendanceReport[$userId])) {
+                $attendanceReport[$userId]['anomalies']++;
+            }
+        }
+
+        foreach ($attendanceReport as $userId => $data) {
+            $attendanceReport[$userId]['days'] = isset($attendanceDayBuckets[$userId]) ? count($attendanceDayBuckets[$userId]) : 0;
+        }
+
+        if ($filterUserId && !isset($attendanceReport[$filterUserId])) {
+            $attendanceReport[$filterUserId] = [
+                'user' => User::find($filterUserId),
+                'total_seconds' => 0,
+                'anomalies' => 0,
+                'days' => 0,
+            ];
+        }
+
         return view('admin/human-resources-attendance', [
             'AttendanceReport' => $report,
+            'AttendancePunchReport' => $attendanceReport,
             'userSelect' => $userSelect,
             'filters' => [
                 'user_id' => $filterUserId,

--- a/resources/views/admin/human-resources-attendance.blade.php
+++ b/resources/views/admin/human-resources-attendance.blade.php
@@ -44,43 +44,101 @@
         </form>
     </div>
     <div class="card-body">
-        <div class="table-responsive p-0">
-            <table class="table table-hover">
-                <thead>
-                    <tr>
-                        <th>{{ __('general_content.user_trans_key') }}</th>
-                        <th>{{ __('general_content.days_trans_key') }}</th>
-                        <th>{{ __('general_content.total_duration_trans_key') }}</th>
-                        <th>{{ __('general_content.anomalies_trans_key') }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @forelse ($AttendanceReport as $row)
-                        @php
-                            $totalSeconds = $row['total_seconds'] ?? 0;
-                            $hours = floor($totalSeconds / 3600);
-                            $minutes = floor(($totalSeconds % 3600) / 60);
-                            $duration = sprintf('%02d:%02d', $hours, $minutes);
-                        @endphp
-                        <tr>
-                            <td>{{ optional($row['user'])->name }}</td>
-                            <td>{{ $row['days'] ?? 0 }}</td>
-                            <td>{{ $duration }}</td>
-                            <td>{{ $row['anomalies'] ?? 0 }}</td>
-                        </tr>
-                    @empty
-                        <x-EmptyDataLine col="4" text="{{ __('general_content.no_data_trans_key') }}" />
-                    @endforelse
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <th>{{ __('general_content.user_trans_key') }}</th>
-                        <th>{{ __('general_content.days_trans_key') }}</th>
-                        <th>{{ __('general_content.total_duration_trans_key') }}</th>
-                        <th>{{ __('general_content.anomalies_trans_key') }}</th>
-                    </tr>
-                </tfoot>
-            </table>
+        <ul class="nav nav-tabs" id="attendance-tabs" role="tablist">
+            <li class="nav-item">
+                <a class="nav-link active" id="attendance-activities-tab" data-toggle="tab" href="#attendance-activities" role="tab" aria-controls="attendance-activities" aria-selected="true">
+                    {{ __('general_content.activities_trans_key') }}
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" id="attendance-punches-tab" data-toggle="tab" href="#attendance-punches" role="tab" aria-controls="attendance-punches" aria-selected="false">
+                    {{ __('general_content.attendance_trans_key') }}
+                </a>
+            </li>
+        </ul>
+
+        <div class="tab-content pt-3">
+            <div class="tab-pane fade show active" id="attendance-activities" role="tabpanel" aria-labelledby="attendance-activities-tab">
+                <div class="table-responsive p-0">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>{{ __('general_content.user_trans_key') }}</th>
+                                <th>{{ __('general_content.days_trans_key') }}</th>
+                                <th>{{ __('general_content.total_duration_trans_key') }}</th>
+                                <th>{{ __('general_content.anomalies_trans_key') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($AttendanceReport as $row)
+                                @php
+                                    $totalSeconds = $row['total_seconds'] ?? 0;
+                                    $hours = floor($totalSeconds / 3600);
+                                    $minutes = floor(($totalSeconds % 3600) / 60);
+                                    $duration = sprintf('%02d:%02d', $hours, $minutes);
+                                @endphp
+                                <tr>
+                                    <td>{{ optional($row['user'])->name }}</td>
+                                    <td>{{ $row['days'] ?? 0 }}</td>
+                                    <td>{{ $duration }}</td>
+                                    <td>{{ $row['anomalies'] ?? 0 }}</td>
+                                </tr>
+                            @empty
+                                <x-EmptyDataLine col="4" text="{{ __('general_content.no_data_trans_key') }}" />
+                            @endforelse
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <th>{{ __('general_content.user_trans_key') }}</th>
+                                <th>{{ __('general_content.days_trans_key') }}</th>
+                                <th>{{ __('general_content.total_duration_trans_key') }}</th>
+                                <th>{{ __('general_content.anomalies_trans_key') }}</th>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="attendance-punches" role="tabpanel" aria-labelledby="attendance-punches-tab">
+                <div class="table-responsive p-0">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>{{ __('general_content.user_trans_key') }}</th>
+                                <th>{{ __('general_content.days_trans_key') }}</th>
+                                <th>{{ __('general_content.total_duration_trans_key') }}</th>
+                                <th>{{ __('general_content.anomalies_trans_key') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($AttendancePunchReport as $row)
+                                @php
+                                    $totalSeconds = $row['total_seconds'] ?? 0;
+                                    $hours = floor($totalSeconds / 3600);
+                                    $minutes = floor(($totalSeconds % 3600) / 60);
+                                    $duration = sprintf('%02d:%02d', $hours, $minutes);
+                                @endphp
+                                <tr>
+                                    <td>{{ optional($row['user'])->name }}</td>
+                                    <td>{{ $row['days'] ?? 0 }}</td>
+                                    <td>{{ $duration }}</td>
+                                    <td>{{ $row['anomalies'] ?? 0 }}</td>
+                                </tr>
+                            @empty
+                                <x-EmptyDataLine col="4" text="{{ __('general_content.no_data_trans_key') }}" />
+                            @endforelse
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <th>{{ __('general_content.user_trans_key') }}</th>
+                                <th>{{ __('general_content.days_trans_key') }}</th>
+                                <th>{{ __('general_content.total_duration_trans_key') }}</th>
+                                <th>{{ __('general_content.anomalies_trans_key') }}</th>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Motivation

- The admin attendance report previously only aggregated `TaskActivities` and did not read the `attendances` table, so punch-based attendance data was missing.
- Keep the existing task-activity logic while providing a separate view for raw punch data to reconcile attendance with task activity.

### Description

- Import the `Attendance` model and add a query that filters `Attendance` by `user_id`, `start_date`, and `end_date` and orders by `user_id` and `punched_at`.
- Aggregate punch records by pairing `in`/`out` directions into `total_seconds`, counting `anomalies` for unmatched or out-of-order punches, and counting distinct `days` per user into `AttendancePunchReport`.
- Pass `AttendancePunchReport` to the `admin/human-resources-attendance` view and add a tabbed UI that keeps the existing `TaskActivities` report and renders the new punches report in a second tab.
- Update the Blade template to render two tables (activities and punches) and reuse the existing duration formatting logic for the new dataset.

### Testing

- No automated tests were run for this change.
- Changes were committed and the modified files are `app/Http/Controllers/Admin/HumanResourcesController.php` and `resources/views/admin/human-resources-attendance.blade.php`.
- Manual verification is recommended to ensure the new tab renders and punch aggregation matches expectations.
- Additional integration or unit tests should be added to validate pairing logic and edge cases for `in`/`out` anomalies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960c0feae54832d8c2ac2946f881469)