### PR TITLE
Fix migration to extend order_site_implantations table

### DIFF
--- a/database/migrations/2025_08_25_154924_create_order_site_implantations_table.php
+++ b/database/migrations/2025_08_25_154924_create_order_site_implantations_table.php
@@ -11,16 +11,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('order_site_implantations', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('order_site_id')->constrained()->onDelete('cascade');
+        Schema::table('order_site_implantations', function (Blueprint $table) {
             $table->integer('workforce')->nullable();
             $table->string('equipment')->nullable();
             $table->string('step')->nullable();
             $table->date('start_date')->nullable();
             $table->date('end_date')->nullable();
             $table->text('notes')->nullable();
-            $table->timestamps();
         });
     }
 
@@ -29,6 +26,15 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('order_site_implantations');
+        Schema::table('order_site_implantations', function (Blueprint $table) {
+            $table->dropColumn([
+                'workforce',
+                'equipment',
+                'step',
+                'start_date',
+                'end_date',
+                'notes',
+            ]);
+        });
     }
 };


### PR DESCRIPTION
### Motivation
- A later migration attempted to create the `order_site_implantations` table while an earlier migration already creates it, causing a duplicate table SQL error.  
- The 2024 migration `2024_10_09_000001_create_order_site_implantations_table.php` already defines the table schema and timestamps.  
- The 2025 migration should only add additional columns to the existing table rather than recreate it.  
- The rollback must not drop the entire table for safety on downgrade.  

### Description
- Updated `database/migrations/2025_08_25_154924_create_order_site_implantations_table.php` to use `Schema::table` and add the columns `workforce`, `equipment`, `step`, `start_date`, `end_date`, and `notes`.  
- Removed creation of `id`, `order_site_id`, and `timestamps` from the 2025 migration so it no longer duplicates the original table definition.  
- Changed `down()` to drop only the newly added columns instead of calling `Schema::dropIfExists('order_site_implantations')`.  
- No other code paths or files were modified.  

### Testing
- No automated tests were executed against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696102f5f044832d82e6f3ebc0683522)