### PR TITLE
Guard opportunity log factories when no records exist

### DIFF
--- a/database/factories/Workflow/OpportunitiesActivitiesLogsFactory.php
+++ b/database/factories/Workflow/OpportunitiesActivitiesLogsFactory.php
@@ -25,8 +25,11 @@ class OpportunitiesActivitiesLogsFactory extends Factory
      */
     public function definition()
     {
+        $opportunity = Opportunities::query()->inRandomOrder()->first()
+            ?? Opportunities::factory()->create();
+
         return [
-            'opportunities_id' =>  Opportunities::all()->random()->id, 
+            'opportunities_id' => $opportunity->id,
             'label' => $this->faker->sentence(3),
             'type' => $this->faker->numberBetween(1, 5), // Random type between 1 and 5
             'statu' => $this->faker->numberBetween(1, 4), // Random status between 1 and 4

--- a/database/factories/Workflow/OpportunitiesEventsLogsFactory.php
+++ b/database/factories/Workflow/OpportunitiesEventsLogsFactory.php
@@ -25,8 +25,11 @@ class OpportunitiesEventsLogsFactory extends Factory
      */
     public function definition()
     {
+        $opportunity = Opportunities::query()->inRandomOrder()->first()
+            ?? Opportunities::factory()->create();
+
         return [
-            'opportunities_id' =>  Opportunities::all()->random()->id, 
+            'opportunities_id' => $opportunity->id,
             'label' => $this->faker->sentence,
             'type' => $this->faker->numberBetween(1, 4), // Random type between 1 and 4
             'start_date' => $this->faker->dateTimeBetween('-1 year', 'now'),


### PR DESCRIPTION
### Motivation

- Seeding failed with `InvalidArgumentException` because factories used `Opportunities::all()->random()` when the `opportunities` table was empty. 
- Prevent factory code from calling `Arr::random` on an empty collection and crashing seeds. 
- Make activity and event log factories resilient when no `Opportunities` records exist. 

### Description

- Replace `Opportunities::all()->random()->id` with a guarded lookup that does `Opportunities::query()->inRandomOrder()->first() ?? Opportunities::factory()->create()` and set `'opportunities_id' => $opportunity->id` in `database/factories/Workflow/OpportunitiesActivitiesLogsFactory.php`.
- Apply the same change to `database/factories/Workflow/OpportunitiesEventsLogsFactory.php` to keep behavior consistent across log factories.
- Preserve all existing fake data fields and defaults while ensuring a fallback `Opportunities` record is created when necessary.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610717f170832d81d67c61d5e1485d)