### PR TITLE
Fix currency fallback in dashboard totals

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -148,16 +148,18 @@ class HomeController extends Controller
                                         }])
                                         ->orderBy('ordre')->get();
 
+        $currency = $factory->curency ?? 'EUR';
+
         //total price
         $deliveredMonthInProgress = $this->deliveryKPIService->getDeliveryMonthlyProgress($CurentMonth, $CurentYear);
-        $deliveredMonthInProgress = Number::currency($deliveredMonthInProgress->orderSum ?? 0,$factory->curency, config('app.locale'));
+        $deliveredMonthInProgress = Number::currency($deliveredMonthInProgress->orderSum ?? 0, $currency, config('app.locale'));
                                                 
         $remainingDeliveryOrder =   $this->orderKPIService->getOrderMonthlyRemainingToDelivery($CurentMonth, $CurentYear);
 
-        $orderTotalFormattedDelivered =   Number::currency($orderTotalDelivered ?? 0,$factory->curency, config('app.locale'));
-        $orderTotalFormattedInvoiced =   Number::currency($orderTotaInvoiced ?? 0,$factory->curency, config('app.locale'));
-        $FormattedEstimatedBudgets =   Number::currency($EstimatedBudgets ?? 0,$factory->curency, config('app.locale'));
-        $remainingDeliveryOrder =   Number::currency($remainingDeliveryOrder->orderSum ?? 0,$factory->curency, config('app.locale'));
+        $orderTotalFormattedDelivered =   Number::currency($orderTotalDelivered ?? 0, $currency, config('app.locale'));
+        $orderTotalFormattedInvoiced =   Number::currency($orderTotaInvoiced ?? 0, $currency, config('app.locale'));
+        $FormattedEstimatedBudgets =   Number::currency($EstimatedBudgets ?? 0, $currency, config('app.locale'));
+        $remainingDeliveryOrder =   Number::currency($remainingDeliveryOrder->orderSum ?? 0, $currency, config('app.locale'));
 
         return view('dashboard', [
             'userRoleCount' => $userRoleCount,


### PR DESCRIPTION
### Motivation
- Prevent `Number::currency()` receiving a null currency when `$factory->curency` is not set, which caused a type error. 
- Ensure dashboard total formatting always has a valid currency code to avoid runtime exceptions. 

### Description
- Add a local fallback variable ` $currency = $factory->curency ?? 'EUR'` in `HomeController::index`. 
- Replace direct uses of `$factory->curency` in `Number::currency(...)` calls with the new `$currency` variable. 
- Changes are limited to `app/Http/Controllers/HomeController.php` around the dashboard totals formatting. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610a332a6c832db13489604f685d19)