### PR TITLE
Guard order currency formatting against null factory currency

### DIFF
--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -257,7 +257,8 @@ class Orders extends Model
     public function getFormattedTotalPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getTotalPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getTotalPriceAttribute(), $currency, config('app.locale'));
 
     }
 


### PR DESCRIPTION
### Motivation
- The application threw `Illuminate\Support\Number::currency(): Argument #2 ($in) must be of type string, null given` when formatting order totals because `Factory->curency` could be null.
- Provide a safe fallback currency to avoid passing `null` into `Number::currency()` and prevent the runtime exception.
- Limit the change to the order total formatting logic to fix the immediate error.

### Description
- Updated `app/Models/Workflow/Orders.php` in `getFormattedTotalPriceAttribute()` to compute `$currency = $factory->curency ?? 'EUR'` before formatting.
- Replaced the direct use of `$factory->curency` with the guarded `$currency` when calling `Number::currency()`.
- This prevents `null` from being passed as the second argument to `Number::currency()` and resolves the type error.

### Testing
- No automated tests were executed as part of this change.
- Manual runtime reproduction of the original error is not included in automated test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610bbdb45c832daf15b6ecf9fc4813)