### PR TITLE
Fix null currency handling in QuotesController

### DIFF
--- a/app/Http/Controllers/Workflow/QuotesController.php
+++ b/app/Http/Controllers/Workflow/QuotesController.php
@@ -49,7 +49,8 @@ class QuotesController extends Controller
         $data['quoteMonthlyRecapPreviousYear'] = $this->quoteKPIService->getQuoteMonthlyRecapPreviousYear($CurentYear);
         $topCustomers = $this->quoteKPIService->getTopCustomersByQuoteVolume(3);
         $quotesCountByUser = $this->quoteKPIService->getQuotesCountByUser();
-        $averageAmount =  Number::currency($this->quoteKPIService->getAverageQuoteAmount(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        $averageAmount =  Number::currency($this->quoteKPIService->getAverageQuoteAmount(), $currency, config('app.locale'));
         $conversionRate =  $this->quoteKPIService->getQuoteConversionRate();
         $responseRate =  $this->quoteKPIService->getQuoteResponseRate();
 
@@ -77,8 +78,9 @@ class QuotesController extends Controller
         $AccountingDeleveriesSelect =  $this->SelectDataService->getAccountingDelivery();
         $Reviewers = $this->SelectDataService->getUsers();
         $QuoteCalculatorService = new QuoteCalculatorService($id);
-        $totalPrice =  Number::currency($QuoteCalculatorService->getTotalPrice(), $factory->curency, config('app.locale'));
-        $subPrice = Number::currency($QuoteCalculatorService->getSubTotal(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        $totalPrice =  Number::currency($QuoteCalculatorService->getTotalPrice(), $currency, config('app.locale'));
+        $subPrice = Number::currency($QuoteCalculatorService->getSubTotal(), $currency, config('app.locale'));
         $vatPrice =  $QuoteCalculatorService->getVatTotal();
         $TotalServiceProductTime = $QuoteCalculatorService->getTotalProductTimeByService();
         $TotalServiceSettingTime = $QuoteCalculatorService->getTotalSettingTimeByService();


### PR DESCRIPTION
### Motivation
- Prevent a TypeError from being thrown when `Number::currency` is called with a null currency value. 
- Ensure quote KPI and quote totals render correctly when the factory currency is missing. 

### Description
- Add a fallback currency assignment ` $currency = $factory->curency ?? 'EUR';` in `index` and `show` methods of `app/Http/Controllers/Workflow/QuotesController.php`.
- Replace direct uses of ` $factory->curency` with the new ` $currency` variable for `Number::currency` calls for `averageAmount`, `totalPrice`, and `subPrice`.
- This change avoids passing `null` as the second argument to `Number::currency`.

### Testing
- No automated tests were executed as part of this change.
- The repository commit was created successfully after the file update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610dc4f89c832d95af9bc210be1edc)