### PR TITLE
Fix controller currency fallbacks

### DIFF
--- a/app/Http/Controllers/Companies/CompaniesController.php
+++ b/app/Http/Controllers/Companies/CompaniesController.php
@@ -81,6 +81,7 @@ class CompaniesController extends Controller
     public function show(Companies $id)
     {
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         $CurentYear = now()->year;
         $userSelect = $this->SelectDataService->getUsers();
         list($previousUrl, $nextUrl) = $this->getNextPrevious(new Companies(), $id->id);
@@ -90,8 +91,8 @@ class CompaniesController extends Controller
         $data['quotesDataRate'] = $this->quoteKPIService->getQuotesDataRate($CurentYear, $id->id);
         $data['orderMonthlyRecap'] = $this->orderKPIService->getOrderMonthlyRecap($CurentYear, $id->id);
         $data['orderAverage'] = $this->orderKPIService->getAverageOrderPriceAttribute($id->id);
-        $data['orderAverage'] = Number::currency($data['orderAverage'], $factory->curency, config('app.locale'));
-        $remainingInvoiceOrder = Number::currency($remainingInvoiceOrder->orderSum ?? 0, $factory->curency, config('app.locale'));
+        $data['orderAverage'] = Number::currency($data['orderAverage'], $currency, config('app.locale'));
+        $remainingInvoiceOrder = Number::currency($remainingInvoiceOrder->orderSum ?? 0, $currency, config('app.locale'));
 
         $customerServiceId = MethodsServices::where('label', 'Customer Service')->value('id');
 
@@ -108,7 +109,7 @@ class CompaniesController extends Controller
             );
         }
 
-        $customerProcessingCost = Number::currency($customerProcessingCost, $factory->curency, config('app.locale'));
+        $customerProcessingCost = Number::currency($customerProcessingCost, $currency, config('app.locale'));
 
         $Companie = $id;
 

--- a/app/Http/Controllers/PrintController.php
+++ b/app/Http/Controllers/PrintController.php
@@ -100,6 +100,7 @@ class PrintController extends Controller
     public function getInvoiceFactureX(Invoices $Document)
     {
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         $typeDocumentName = __('general_content.invoice_trans_key');
         $calculatorService = new InvoiceCalculatorService($Document);
         $Factory = $this->getFactory();
@@ -107,8 +108,8 @@ class PrintController extends Controller
         $subPrice = $calculatorService->getSubTotal();
         $vatPrice = $calculatorService->getVatTotal();
         
-        $formattedTotalPrice = Number::currency($totalPrice, $factory->curency, config('app.locale'));
-        $formattedSubPrice = Number::currency($subPrice, $factory->curency, config('app.locale'));
+        $formattedTotalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
+        $formattedSubPrice = Number::currency($subPrice, $currency, config('app.locale'));
 
         $this->getDocumentLines($Document, 'invoiceLines');
         $image = $Factory->getImageFactoryPath();
@@ -123,7 +124,7 @@ class PrintController extends Controller
 
         $zugferddatas = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_EN16931);
         $zugferddatas
-        ->setDocumentInformation($Document->code, "380", \DateTime::createFromFormat("Ymd", "20180305"), $Factory->curency)
+        ->setDocumentInformation($Document->code, "380", \DateTime::createFromFormat("Ymd", "20180305"), $currency)
         ->addDocumentNote('Facture du ' . $Document->GetPrettyCreatedAttribute())
         
         // Ajout des informations du vendeur (Factory)
@@ -250,13 +251,14 @@ class PrintController extends Controller
     private function generatePdf($Document, $typeDocumentName, $calculatorService, $viewKey)
     {
         $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
         $Factory = $this->getFactory();
         $totalPrice = $calculatorService ? $calculatorService->getTotalPrice() : 0;
         $subPrice = $calculatorService ? $calculatorService->getSubTotal() : 0;
         $vatPrice = $calculatorService ? $calculatorService->getVatTotal() : 0;
 
-        $formattedTotalPrice = Number::currency($totalPrice, $factory->curency, config('app.locale'));
-        $formattedSubPrice = Number::currency($subPrice, $factory->curency, config('app.locale'));
+        $formattedTotalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
+        $formattedSubPrice = Number::currency($subPrice, $currency, config('app.locale'));
 
         $this->getDocumentLines($Document, $this->getDocumentLinesKey($Document));
         $image = $Factory->getImageFactoryPath();

--- a/app/Http/Controllers/Purchases/PurchasesController.php
+++ b/app/Http/Controllers/Purchases/PurchasesController.php
@@ -59,6 +59,7 @@ class PurchasesController extends Controller
     {   
         $currentYear = Carbon::now()->format('Y');
         $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
         $data['purchasesDataRate'] = $this->purchaseKPIService->getPurchasesDataRate();
         $data['purchaseMonthlyRecap'] = $this->purchaseKPIService->getPurchaseMonthlyRecap($currentYear);
 
@@ -71,9 +72,9 @@ class PurchasesController extends Controller
         $suppliersToRequalify = $this->purchaseKPIService->getSuppliersToRequalify(30);
 
         $topProducts = $this->purchaseKPIService->getTopProducts();
-        $averageAmount = Number::currency($this->purchaseKPIService->getAverageAmount(),$factory->curency, config('app.locale'));
+        $averageAmount = Number::currency($this->purchaseKPIService->getAverageAmount(), $currency, config('app.locale'));
         $totalPurchaseLineCount = $this->purchaseKPIService->getTotalPurchaseCount();
-        $totalPurchasesAmount = Number::currency($this->purchaseKPIService->getTotalPurchaseAmount(),$factory->curency, config('app.locale'));
+        $totalPurchasesAmount = Number::currency($this->purchaseKPIService->getTotalPurchaseAmount(), $currency, config('app.locale'));
 
         $userSelect = $this->SelectDataService->getUsers();
         $CompanieSelect = $this->SelectDataService->getSupplier();

--- a/app/Http/Controllers/Workflow/CreditNoteController.php
+++ b/app/Http/Controllers/Workflow/CreditNoteController.php
@@ -103,13 +103,14 @@ class CreditNoteController extends Controller
     public function show(CreditNotes $id)
     {
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         
         $CreditNoteCalculatorService = new CreditNoteCalculatorService($id);
         $totalPrice = $CreditNoteCalculatorService->getTotalPrice();
         $subPrice = $CreditNoteCalculatorService->getSubTotal();
         $vatPrice = $CreditNoteCalculatorService->getVatTotal();
-        $totalPrice = Number::currency($totalPrice, $factory->curency, config('app.locale'));
-        $subPrice = Number::currency($subPrice, $factory->curency, config('app.locale'));
+        $totalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
+        $subPrice = Number::currency($subPrice, $currency, config('app.locale'));
 
         list($previousUrl, $nextUrl) = $this->getNextPrevious(new CreditNotes(), $id->id);
         return view('workflow/credit-notes-show', [

--- a/app/Http/Controllers/Workflow/InvoicesController.php
+++ b/app/Http/Controllers/Workflow/InvoicesController.php
@@ -46,6 +46,7 @@ class InvoicesController extends Controller
     public function index()
     {    
         $factory = app('Factory');  
+        $currency = $factory->curency ?? 'EUR';
         $CurentYear = Carbon::now()->format('Y');
 
         $data['invoicesDataRate'] = $this->invoiceKPIService->getInvoicesDataRate();
@@ -61,9 +62,9 @@ class InvoicesController extends Controller
         $topClients = $this->invoiceKPIService->getTopClients();
         $topProducts = $this->invoiceKPIService->getTopProducts();
 
-        $totalInvoices = Number::currency($totalInvoices , $factory->curency, config('app.locale'));
-        $totalInvoiceAmount = Number::currency($totalInvoiceAmount , $factory->curency, config('app.locale'));
-        $totalPaymentsReceived = Number::currency($totalPaymentsReceived , $factory->curency, config('app.locale'));
+        $totalInvoices = Number::currency($totalInvoices, $currency, config('app.locale'));
+        $totalInvoiceAmount = Number::currency($totalInvoiceAmount, $currency, config('app.locale'));
+        $totalPaymentsReceived = Number::currency($totalPaymentsReceived, $currency, config('app.locale'));
 
         return view('workflow/invoices-index', compact(
                                                         'totalInvoices',
@@ -159,13 +160,14 @@ class InvoicesController extends Controller
     public function show(Invoices $id)
     {
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         
         $InvoiceCalculatorService = new InvoiceCalculatorService($id);
         $totalPrice = $InvoiceCalculatorService->getTotalPrice();
         $subPrice = $InvoiceCalculatorService->getSubTotal();
         
-        $totalPrice = Number::currency($totalPrice, $factory->curency, config('app.locale'));
-        $subPrice = Number::currency($subPrice, $factory->curency, config('app.locale'));
+        $totalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
+        $subPrice = Number::currency($subPrice, $currency, config('app.locale'));
 
         $vatPrice = $InvoiceCalculatorService->getVatTotal();
         list($previousUrl, $nextUrl) = $this->getNextPrevious(new Invoices(), $id->id);

--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -46,6 +46,7 @@ class OrdersController extends Controller
     { 
         $factory = app('Factory');   
         $CurentYear = now()->year;
+        $currency = $factory->curency ?? 'EUR';
 
         // Récupérer les KPI
         $deliveredOrdersPercentage = $this->orderKPIService->getDeliveredOrdersPercentage();
@@ -62,8 +63,8 @@ class OrdersController extends Controller
         $data['orderMonthlyRecapPreviousYear'] = $this->orderKPIService->getOrderMonthlyRecapPreviousYear($CurentYear);
 
         
-        $remainingDeliveryOrder = Number::currency($remainingDeliveryOrder->orderSum , $factory->curency, config('app.locale'));
-        $remainingInvoiceOrder = Number::currency($remainingInvoiceOrder->orderSum , $factory->curency, config('app.locale'));
+        $remainingDeliveryOrder = Number::currency($remainingDeliveryOrder->orderSum ?? 0, $currency, config('app.locale'));
+        $remainingInvoiceOrder = Number::currency($remainingInvoiceOrder->orderSum ?? 0, $currency, config('app.locale'));
 
         return view('workflow/orders-index', compact(
             'deliveredOrdersPercentage',
@@ -138,12 +139,13 @@ class OrdersController extends Controller
 
 
         //format variable after calculation for display
-        $stillInvoiced = Number::currency($totalPrice - $invoicedAmount, $factory->curency, config('app.locale'));
-        $totalPrice = Number::currency($totalPrice, $factory->curency, config('app.locale'));
-        $subPrice = Number::currency($subPrice, $factory->curency, config('app.locale'));
-        $invoicedAmount = Number::currency($invoicedAmount, $factory->curency, config('app.locale'));
-        $forecastMarginFormatted = Number::currency($forecastMargin, $factory->curency, config('app.locale'));
-        $currentMarginFormatted = Number::currency($currentMargin, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        $stillInvoiced = Number::currency($totalPrice - $invoicedAmount, $currency, config('app.locale'));
+        $totalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
+        $subPrice = Number::currency($subPrice, $currency, config('app.locale'));
+        $invoicedAmount = Number::currency($invoicedAmount, $currency, config('app.locale'));
+        $forecastMarginFormatted = Number::currency($forecastMargin, $currency, config('app.locale'));
+        $currentMarginFormatted = Number::currency($currentMargin, $currency, config('app.locale'));
         $forecastMarginPercentageFormatted = number_format($forecastMarginPercentage, 2, '.', ',') . ' %';
         $currentMarginPercentageFormatted = number_format($currentMarginPercentage, 2, '.', ',') . ' %';
 
@@ -230,4 +232,3 @@ class OrdersController extends Controller
         return redirect()->route('orders.show', ['id' => $order->id])->with('success', 'Successfully updated Order');
     }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent runtime errors from `Number::currency()` when the factory currency is null by providing a safe fallback currency.
- Avoid passing `null` as the currency argument (which caused the error `Argument #2 ($in) must be of type string, null given`).
- Ensure KPI and document amount formatting is null-safe when values such as `orderSum` may be missing.

### Description
- Added a local currency fallback (`$currency = $factory->curency ?? 'EUR'`) and switched `Number::currency` calls to use this resolved value in controllers `OrdersController`, `InvoicesController`, `PrintController`, `CompaniesController`, `PurchasesController`, and `CreditNoteController`.
- Made KPI amount formatting null-safe by using `->orderSum ?? 0` when calling `Number::currency` for remaining order sums.
- Updated invoice PDF generation to reuse the resolved `$currency` (including passing it to `setDocumentInformation`) and to format totals using the fallback.
- Small cleanups to ensure consistent use of the resolved currency across various formatted outputs (totals, subtotals, margins).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610f16c4e8832d8376f7ce02504e62)