### PR TITLE
Fix quote line currency fallback

### DIFF
--- a/app/Models/Workflow/QuoteLines.php
+++ b/app/Models/Workflow/QuoteLines.php
@@ -190,7 +190,8 @@ class QuoteLines extends Model
     public function getFormattedSellingPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getSellingPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getSellingPriceAttribute(), $currency, config('app.locale'));
 
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` thrown by `Number::currency` when the factory currency value is `null` and passed as the second argument. 
- Ensure formatted selling prices are returned even if the `Factory->curency` field is missing or unset.

### Description
- Updated `app/Models/Workflow/QuoteLines.php` in `getFormattedSellingPriceAttribute()` to compute `$currency = $factory->curency ?? 'EUR'` before calling `Number::currency`.
- The method now passes the resolved `$currency` to `Number::currency` to provide a safe default.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617c436afc832dbe2c8b6e783be54c)