### PR TITLE
Add currency fallback for task formatting

### DIFF
--- a/app/Models/Planning/Task.php
+++ b/app/Models/Planning/Task.php
@@ -335,8 +335,9 @@ class Task extends Model
      */
     public function getFormattedUnitCostAttribute()
     {
-        $factory = app('Factory'); 
-        return Number::currency($this->unit_cost, $factory->curency, config('app.locale'));
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->unit_cost, $currency, config('app.locale'));
 
     }
 
@@ -351,8 +352,9 @@ class Task extends Model
      */
     public function getFormattedUnitPriceAttribute()
     {
-        $factory = app('Factory'); 
-        return Number::currency($this->unit_price, $factory->curency, config('app.locale'));
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->unit_price, $currency, config('app.locale'));
     }
 
     /**
@@ -379,8 +381,9 @@ class Task extends Model
      */
     public function getFormattedTotalCostAttribute()
     {
-        $factory = app('Factory'); 
-        return Number::currency($this->TotalCost(), $factory->curency, config('app.locale'));
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->TotalCost(), $currency, config('app.locale'));
     }
 
     /**
@@ -407,8 +410,9 @@ class Task extends Model
      */
     public function getFormattedTotalPriceAttribute()
     {
-        $factory = app('Factory'); 
-        return Number::currency($this->TotalPrice(), $factory->curency, config('app.locale'));
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->TotalPrice(), $currency, config('app.locale'));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Fix a runtime error where `Illuminate\Support\Number::currency()` received `null` for the currency argument when the factory currency was unset.
- Ensure monetary formatting in the `Task` model always receives a valid currency code.

### Description
- Introduced a fallback value with `$currency = $factory->curency ?? 'EUR'` in formatting accessors.
- Updated `getFormattedUnitCostAttribute`, `getFormattedUnitPriceAttribute`, `getFormattedTotalCostAttribute`, and `getFormattedTotalPriceAttribute` to pass `$currency` to `Number::currency`.
- Changes are confined to `app/Models/Planning/Task.php` and do not alter other logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617fe5b388832d83d6a993ead20cec)