### PR TITLE
Add currency fallbacks for formatted amounts

### DIFF
--- a/app/Models/Accounting/AccountingEntry.php
+++ b/app/Models/Accounting/AccountingEntry.php
@@ -99,7 +99,8 @@ class AccountingEntry extends Model
     public function getFormattedDebitAmountAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->debit_amount, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->debit_amount, $currency, config('app.locale'));
     }
 
     /**
@@ -114,7 +115,8 @@ class AccountingEntry extends Model
     public function getFormattedCreditAmountAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->credit_amount, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->credit_amount, $currency, config('app.locale'));
     }
 
 }

--- a/app/Models/Products/StockMove.php
+++ b/app/Models/Products/StockMove.php
@@ -96,7 +96,8 @@ class StockMove extends Model
     public function getFormattedComponentPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->component_price, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->component_price, $currency, config('app.locale'));
     }
     
     /**

--- a/app/Models/Purchases/PurchaseLines.php
+++ b/app/Models/Purchases/PurchaseLines.php
@@ -77,6 +77,7 @@ class PurchaseLines extends Model
     public function getTotalAttribute()
     {
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         
         $price = $this->selling_price;
         $qty = $this->qty;
@@ -85,7 +86,7 @@ class PurchaseLines extends Model
         $total = $price * $qty;
         $discountedTotal = $total - ($total * ($discount / 100));
 
-        return Number::currency($discountedTotal, $factory->curency, config('app.locale'));
+        return Number::currency($discountedTotal, $currency, config('app.locale'));
     }
 
     /**
@@ -100,7 +101,8 @@ class PurchaseLines extends Model
     public function getFormattedSellingPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->selling_price, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->selling_price, $currency, config('app.locale'));
     }
 
     /**

--- a/app/Models/Purchases/PurchaseQuotationLines.php
+++ b/app/Models/Purchases/PurchaseQuotationLines.php
@@ -45,7 +45,8 @@ class PurchaseQuotationLines extends Model
     public function getFormattedSellingPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->unit_price, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->unit_price, $currency, config('app.locale'));
     }
 
     /**
@@ -60,7 +61,8 @@ class PurchaseQuotationLines extends Model
     public function getFormattedTotalPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->total_price, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->total_price, $currency, config('app.locale'));
 
     }
 

--- a/app/Models/Purchases/Purchases.php
+++ b/app/Models/Purchases/Purchases.php
@@ -124,7 +124,8 @@ class Purchases extends Model
     public function getFormattedTotalPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getTotalPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getTotalPriceAttribute(), $currency, config('app.locale'));
 
     }
 

--- a/app/Models/Workflow/CreditNoteLines.php
+++ b/app/Models/Workflow/CreditNoteLines.php
@@ -52,7 +52,8 @@ class CreditNoteLines extends Model
     public function getFormattedSellingPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->unit_price, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->unit_price, $currency, config('app.locale'));
     }
 
     /**

--- a/app/Models/Workflow/CreditNotes.php
+++ b/app/Models/Workflow/CreditNotes.php
@@ -100,7 +100,8 @@ class CreditNotes extends Model
     public function getFormattedTotalPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getTotalPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getTotalPriceAttribute(), $currency, config('app.locale'));
 
     }
     

--- a/app/Models/Workflow/InvoiceLines.php
+++ b/app/Models/Workflow/InvoiceLines.php
@@ -59,7 +59,8 @@ class InvoiceLines extends Model
     public function getFormattedSellingPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->orderLine->selling_price, $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->orderLine->selling_price, $currency, config('app.locale'));
     }
 
     /**

--- a/app/Models/Workflow/Invoices.php
+++ b/app/Models/Workflow/Invoices.php
@@ -118,7 +118,8 @@ class Invoices extends Model
     public function getFormattedTotalPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getTotalPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getTotalPriceAttribute(), $currency, config('app.locale'));
 
     }
 

--- a/app/Models/Workflow/OrderLines.php
+++ b/app/Models/Workflow/OrderLines.php
@@ -294,7 +294,8 @@ class OrderLines extends Model
     public function getFormattedSellingPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getSellingPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getSellingPriceAttribute(), $currency, config('app.locale'));
     }
 
     /**

--- a/app/Models/Workflow/Quotes.php
+++ b/app/Models/Workflow/Quotes.php
@@ -192,7 +192,8 @@ class Quotes extends Model
     public function getFormattedTotalPriceAttribute()
     {
         $factory = app('Factory'); 
-        return Number::currency($this->getTotalPriceAttribute(), $factory->curency, config('app.locale'));
+        $currency = $factory->curency ?? 'EUR';
+        return Number::currency($this->getTotalPriceAttribute(), $currency, config('app.locale'));
 
     }
 

--- a/app/Services/OpportunitiesKPIService.php
+++ b/app/Services/OpportunitiesKPIService.php
@@ -118,15 +118,16 @@ class OpportunitiesKPIService
     public function getQuotesSummary()
     {
         $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
         $quotesWon = Quotes::where('statu', 3)->whereNotNull('opportunities_id')->get();
         $totalQuotesWon = Number::currency($quotesWon->sum(function ($quote) {
             return $quote->getTotalPriceAttribute();
-        }),$factory->curency, config('app.locale'));
+        }), $currency, config('app.locale'));
 
         $quotesLost = Quotes::where('statu', 4)->whereNotNull('opportunities_id')->get();
         $totalQuotesLost = Number::currency($quotesLost->sum(function ($quote) {
             return $quote->getTotalPriceAttribute();
-        }),$factory->curency, config('app.locale')); 
+        }), $currency, config('app.locale')); 
 
         return compact('totalQuotesWon', 'totalQuotesLost');
     }

--- a/app/Services/OrderBusinessBalanceService.php
+++ b/app/Services/OrderBusinessBalanceService.php
@@ -58,12 +58,13 @@ class OrderBusinessBalanceService
 
         // Ajout des versions formatées AVANT de retourner le tableau
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         foreach ($businessBalance as $taskName => &$balance) {
             // Valeurs formatées (pour affichage)
-            $balance['total_display_cost'] = Number::currency($balance['total_cost'], $factory->curency, config('app.locale'));
-            $balance['total_display_price'] = Number::currency($balance['total_price'], $factory->curency, config('app.locale'));
-            $balance['realized_display_cost'] = Number::currency($balance['realized_cost'], $factory->curency, config('app.locale'));
-            $balance['difference_display_cost'] = Number::currency($balance['difference_cost'], $factory->curency, config('app.locale'));
+            $balance['total_display_cost'] = Number::currency($balance['total_cost'], $currency, config('app.locale'));
+            $balance['total_display_price'] = Number::currency($balance['total_price'], $currency, config('app.locale'));
+            $balance['realized_display_cost'] = Number::currency($balance['realized_cost'], $currency, config('app.locale'));
+            $balance['difference_display_cost'] = Number::currency($balance['difference_cost'], $currency, config('app.locale'));
         }
 
         return $businessBalance;
@@ -89,6 +90,7 @@ class OrderBusinessBalanceService
     {
         $businessBalance = $this->getBusinessBalance($order);
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
 
         $totals = [
             'total_hours' => 0,
@@ -111,10 +113,10 @@ class OrderBusinessBalanceService
         }
 
         // Ajouter une version formatée des valeurs monétaires
-        $totals['total_display_cost'] = Number::currency($totals['total_cost'], $factory->curency, config('app.locale'));
-        $totals['total_display_price'] = Number::currency($totals['total_price'], $factory->curency, config('app.locale'));
-        $totals['realized_display_cost'] = Number::currency($totals['realized_cost'], $factory->curency, config('app.locale'));
-        $totals['difference_display_cost'] = Number::currency($totals['difference_cost'], $factory->curency, config('app.locale'));
+        $totals['total_display_cost'] = Number::currency($totals['total_cost'], $currency, config('app.locale'));
+        $totals['total_display_price'] = Number::currency($totals['total_price'], $currency, config('app.locale'));
+        $totals['realized_display_cost'] = Number::currency($totals['realized_cost'], $currency, config('app.locale'));
+        $totals['difference_display_cost'] = Number::currency($totals['difference_cost'], $currency, config('app.locale'));
 
         return $totals;
     }

--- a/app/Services/OrderInvoiceDataService.php
+++ b/app/Services/OrderInvoiceDataService.php
@@ -43,6 +43,7 @@ class OrderInvoiceDataService
     {
         
         $factory = app('Factory'); 
+        $currency = $factory->curency ?? 'EUR';
         
         $receivedPayment = $order->orderLines->sum(function ($line) {
             return $line->invoiceLines->sum(function ($invoiceLine) use ($line) {
@@ -54,6 +55,6 @@ class OrderInvoiceDataService
             });
         });
         
-        return Number::currency($receivedPayment, $factory->curency, config('app.locale'));;
+        return Number::currency($receivedPayment, $currency, config('app.locale'));;
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` from `Number::currency()` when the factory currency is `null` by ensuring a string currency is always passed. 
- Avoid runtime errors in services and model accessors that format monetary values when `app('Factory')->curency` is missing. 

### Description
- Introduced a local fallback `$currency = $factory->curency ?? 'EUR'` and replaced direct uses of `$factory->curency` when calling `Number::currency` in services and models. 
- Fixed formatting in `app/Services/OrderBusinessBalanceService.php`, `app/Services/OrderInvoiceDataService.php`, and `app/Services/OpportunitiesKPIService.php` to use the fallback. 
- Applied the same safe-currency pattern to model accessors in `app/Models/*` including `AccountingEntry`, `StockMove`, `Purchases`, `PurchaseLines`, `PurchaseQuotationLines`, `InvoiceLines`, `Invoices`, `Quotes`, `CreditNoteLines`, `CreditNotes`, and `OrderLines`.

### Testing
- No automated test suite was executed for this change. 
- Changes were validated by searching and updating all occurrences of `Number::currency(..., $factory->curency, ...)` in the codebase to use the fallback variable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b829b15c832d833ebbcbb0236737)