### PR TITLE
Add apply-delivery-date button and propagate date to order lines

### DIFF
--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -6,12 +6,14 @@ use Illuminate\Support\Number;
 use App\Models\Workflow\Orders;
 use App\Services\OrderKPIService;
 use App\Traits\NextPreviousTrait;
+use App\Models\Admin\Factory;
 use App\Services\SelectDataService;
 use App\Http\Controllers\Controller;
 use App\Services\CustomFieldService;
 use App\Services\OrderCalculatorService;
 use App\Services\OrderInvoiceDataService;
 use App\Services\OrderBusinessBalanceService;
+use App\Models\Workflow\OrderLines;
 use App\Http\Requests\Workflow\UpdateOrderRequest;
 use Spatie\Activitylog\Models\Activity;
 
@@ -227,6 +229,22 @@ class OrdersController extends Controller
 
         // Update the order using mass assignment
         $order->update($request->validated());
+
+        if ($request->boolean('apply_delivery_date') && $order->validity_date) {
+            $factory = Factory::first();
+            $updates = ['delivery_date' => $order->validity_date];
+
+            if ($factory) {
+                $date = date_create($order->validity_date);
+                $internalDelay = date_format(
+                    date_sub($date, date_interval_create_from_date_string($factory->add_delivery_delay_order . ' days')),
+                    'Y-m-d'
+                );
+                $updates['internal_delay'] = $internalDelay;
+            }
+
+            OrderLines::where('orders_id', $order->id)->update($updates);
+        }
 
         // Redirect with success message
         return redirect()->route('orders.show', ['id' => $order->id])->with('success', 'Successfully updated Order');

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -112,6 +112,11 @@
                           <i class="fas fa-calendar-day"></i>
                         </div>
                         <input type="date" class="form-control" name="validity_date"  id="validity_date" value="{{  $Order->validity_date }}">
+                        <div class="input-group-append">
+                          <button class="btn btn-outline-secondary" type="submit" name="apply_delivery_date" value="1" title="Appliquer aux lignes" aria-label="Appliquer aux lignes">
+                            <i class="fas fa-level-down-alt"></i>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -124,6 +129,11 @@
                           <i class="fas fa-calendar-day"></i>
                         </div>
                         <input type="date" class="form-control" name="validity_date"  id="validity_date" value="{{  $Order->validity_date }}">
+                        <div class="input-group-append">
+                          <button class="btn btn-outline-secondary" type="submit" name="apply_delivery_date" value="1" title="Appliquer aux lignes" aria-label="Appliquer aux lignes">
+                            <i class="fas fa-level-down-alt"></i>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
### Motivation
- Provide a small icon-only action next to the `validity_date` ("Date de livraison") field so users can apply the order delivery date to all order lines in one click. 
- Ensure order line `delivery_date` consistency with the order header when requested. 
- Compute and update the related `internal_delay` on order lines using factory settings when applying the date. 

### Description
- Added an icon-only submit button next to the `validity_date` input in `resources/views/workflow/orders-show.blade.php` that submits `apply_delivery_date=1` when clicked. 
- Updated `app/Http/Controllers/Workflow/OrdersController.php` `update` method to check `if ($request->boolean('apply_delivery_date') && $order->validity_date)` and propagate `delivery_date` to all `OrderLines` for the order. 
- When a `Factory` record exists the controller also computes `internal_delay` using `Factory::first()->add_delivery_delay_order` and includes it in the mass update to `OrderLines`. 
- Added necessary imports for `App\Models\Admin\Factory` and `App\Models\Workflow\OrderLines`. 

### Testing
- Attempted to start the application with `php artisan serve`, but the command failed due to a missing `vendor/autoload.php` so the app could not be run. 
- No automated test suite was executed as part of this change due to the missing dependencies. 
- The changes were staged and committed locally (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c484f23c832d88479831169e4890)