### PR TITLE
Guard Factory singleton when `factory` table is unavailable

### DIFF
--- a/app/Providers/FactoryServiceProvider.php
+++ b/app/Providers/FactoryServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\Admin\Factory;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
@@ -23,6 +24,10 @@ class FactoryServiceProvider extends ServiceProvider
     {
         // Charger Factory UNE SEULE FOIS avec un singleton
         app()->singleton('Factory', function () {
+            if (!Schema::hasTable('factory')) {
+                return new Factory();
+            }
+
             return Factory::first() ?? new Factory(); // Retourne un objet vide si null
         });
 


### PR DESCRIPTION
### Motivation

- Prevent application boot and tests from querying the `factory` table before migrations exist, which caused `no such table: factory` errors.
- Avoid failures during in-memory SQLite test runs and early bootstrapping when the `factory` table is not yet present.

### Description

- Import the `Schema` facade and add a `Schema::hasTable('factory')` guard in `app/Providers/FactoryServiceProvider.php`.
- Return a new `Factory` model when the `factory` table is missing instead of calling `Factory::first()`.
- Preserve the previous behavior of sharing `app('Factory')` with all views when the table exists.

### Testing

- No automated tests were executed after this change.
- Prior to the fix, the test run produced multiple failing Feature tests reporting `SQLSTATE[HY000] General error: 1 no such table: factory` during setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cf02a668832db9334b9ff881e97d)