### PR TITLE
Use MySQL for PHPUnit database connection

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="mysql"/>
     </php>
 </phpunit>


### PR DESCRIPTION
### Motivation
- The project uses MySQL in development (see `.env.example`), so PHPUnit should run using the same DB driver to avoid environment mismatches.
- Prior configurations set `DB_CONNECTION` to `sqlite` which did not match the expected MySQL setup.

### Description
- Updated `phpunit.xml` to set `DB_CONNECTION` to `mysql` and removed the SQLite-specific `DB_DATABASE`/`:memory:` entries.
- The change is confined to `phpunit.xml` and does not modify runtime application configuration files.

### Testing
- No automated test suites (`phpunit`) were executed as part of this change.
- No CI or other automated checks were run during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cef1f6c0832db18070a815348390)