### PR TITLE
Fix test failures: storage uploads, API resources, N2P payload, routes, and test setup

### DIFF
--- a/app/Http/Controllers/Companies/SupplierRatingController.php
+++ b/app/Http/Controllers/Companies/SupplierRatingController.php
@@ -39,7 +39,7 @@ class SupplierRatingController extends Controller
         $message = trans('general_content.supplier_evaluation_saved_trans_key');
 
         if ($message === 'general_content.supplier_evaluation_saved_trans_key') {
-            $message = 'Supplier evaluation saved successfully';
+            $message = 'Rate saved successfully';
         }
 
         return redirect()->back()->with('success', $message);

--- a/app/Http/Controllers/Methods/RessourcesController.php
+++ b/app/Http/Controllers/Methods/RessourcesController.php
@@ -51,10 +51,8 @@ class RessourcesController extends Controller
 
         if($request->hasFile('picture')){
             $Ressource = MethodsRessources::findOrFail($Ressource->id);
-            $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/ressources'), $filename);
-            $Ressource->update(['picture' => $filename]);
+            $path = $request->file('picture')->store('images/ressources', 'public');
+            $Ressource->update(['picture' => basename($path)]);
             $Ressource->save();
         }
         else{
@@ -94,15 +92,13 @@ class RessourcesController extends Controller
     {
         
         $request->validate([
-            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ]);
         
         if($request->hasFile('picture')){
             $Service = MethodsRessources::findOrFail($request->id);
-            $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/ressources'), $filename);
-            $Service->update(['picture' => $filename]);
+            $path = $request->file('picture')->store('images/ressources', 'public');
+            $Service->update(['picture' => basename($path)]);
             $Service->save();
             return redirect()->route('methods.ressource')->with('success', 'Successfully updated ressource.');
         }

--- a/app/Http/Controllers/Methods/ServicesController.php
+++ b/app/Http/Controllers/Methods/ServicesController.php
@@ -44,10 +44,8 @@ class ServicesController extends Controller
         
         if($request->hasFile('picture')){
             $Service = MethodsServices::findOrFail($Service->id);
-            $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/methods'), $filename);
-            $Service->update(['picture' => $filename]);
+            $path = $request->file('picture')->store('images/methods', 'public');
+            $Service->update(['picture' => basename($path)]);
             $Service->save();
         }
         else{
@@ -95,15 +93,13 @@ class ServicesController extends Controller
     public function StoreImage(Request $request)
     {
         $request->validate([
-            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ]);
         
         if($request->hasFile('picture')){
             $Service = MethodsServices::findOrFail($request->id);
-            $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/methods'), $filename);
-            $Service->update(['picture' => $filename]);
+            $path = $request->file('picture')->store('images/methods', 'public');
+            $Service->update(['picture' => basename($path)]);
             $Service->save();
             return redirect()->route('methods.service')->with('success', 'Successfully updated service.');
         }

--- a/app/Http/Controllers/Methods/ToolsController.php
+++ b/app/Http/Controllers/Methods/ToolsController.php
@@ -47,10 +47,8 @@ class ToolsController extends Controller
 
         if($request->hasFile('picture')){
             $Tool = MethodsTools::findOrFail($Tool->id);
-            $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/tools'), $filename);
-            $Tool->update(['picture' => $filename]);
+            $path = $request->file('picture')->store('images/tools', 'public');
+            $Tool->update(['picture' => basename($path)]);
             $Tool->save();
         }
         else{
@@ -89,15 +87,13 @@ class ToolsController extends Controller
     {
         
         $request->validate([
-            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ]);
         
         if($request->hasFile('picture')){
             $Service = MethodsTools::findOrFail($request->id);
-            $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/methods'), $filename);
-            $Service->update(['picture' => $filename]);
+            $path = $request->file('picture')->store('images/tools', 'public');
+            $Service->update(['picture' => basename($path)]);
             $Service->save();
             return redirect()->route('methods.tool')->with('success', 'Successfully updated tool.');
         }

--- a/app/Http/Requests/Methods/StoreRessourceRequest.php
+++ b/app/Http/Requests/Methods/StoreRessourceRequest.php
@@ -31,7 +31,7 @@ class StoreRessourceRequest extends FormRequest
             'capacity'=>'required',
             'section_id'=>'required',
             'methods_services_id'=>'required',
-            'picture'=>'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture'=>'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ];
     }
 }

--- a/app/Http/Requests/Methods/StoreServicesRequest.php
+++ b/app/Http/Requests/Methods/StoreServicesRequest.php
@@ -30,7 +30,7 @@ class StoreServicesRequest extends FormRequest
             'label'=>'required',
             'hourly_rate'=>'required',
             'margin'=>'required',
-            'picture'=>'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture'=>'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ];
     }
 }

--- a/app/Http/Requests/Methods/StoreToolRequest.php
+++ b/app/Http/Requests/Methods/StoreToolRequest.php
@@ -28,7 +28,7 @@ class StoreToolRequest extends FormRequest
             'code' =>'required|unique:methods_tools',
             'label'=>'required',
             'qty'=>'required',
-            'picture'=>'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture'=>'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ];
     }
 }

--- a/app/Http/Resources/CompanieResource.php
+++ b/app/Http/Resources/CompanieResource.php
@@ -16,6 +16,7 @@ class CompanieResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'name' => $this->name,
             'code' => $this->code,
             'label' => $this->label,
             'siren' => $this->siren,

--- a/app/Http/Resources/TaskResource.php
+++ b/app/Http/Resources/TaskResource.php
@@ -16,6 +16,7 @@ class TaskResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'name' => $this->name,
             'label' => $this->label,
             'ordre' => $this->ordre,
             'quote_lines_id' => $this->quote_lines_id,

--- a/app/Services/N2P/N2PPayloadBuilder.php
+++ b/app/Services/N2P/N2PPayloadBuilder.php
@@ -66,7 +66,7 @@ class N2PPayloadBuilder
           ]);
 
         $job = [
-            'of_code' => "OF". $orderLine->id,
+            'of_code' => $order->code ?? "OF" . $orderLine->id,
             'line_ref' => (string) $orderLine->getKey(),
             'status' => $jobStatus,
             'priority' => $priority,
@@ -113,7 +113,7 @@ class N2PPayloadBuilder
     private function mapTasks(OrderLines $orderLine, $tasks): array
     {
         return $tasks->map(function (Task $task) use ($orderLine) {
-            $operationCode = $task->label ?: ($task->service->code ?? null);
+            $operationCode = $task->code ?: ($task->label ?: ($task->service->code ?? null));
             if (!$operationCode) {
                 $operationCode = Str::slug($task->label ?? 'task-' . $task->getKey());
             }
@@ -123,7 +123,7 @@ class N2PPayloadBuilder
                 $plannedTimeMinutes = (int) max(0, round($task->TotalTime() * 60));
             }
 
-            $workcenterCode = $task->service->code ?? null;
+            $workcenterCode = $task->MethodsTools?->code ?? $task->service?->code;
 
             return array_filter([
                 'operation_code' => $operationCode,
@@ -168,12 +168,11 @@ class N2PPayloadBuilder
         }
 
         if ($date instanceof \DateTimeInterface) {
-            // ISO 8601 (recommandé)
-            return Carbon::instance($date)->toIso8601String();
+            return Carbon::instance($date)->format('Y-m-d H:i:s');
         }
 
         try {
-            return Carbon::parse($date)->toIso8601String();
+            return Carbon::parse($date)->format('Y-m-d H:i:s');
         } catch (\Throwable) {
             return null;
         }

--- a/database/factories/EnergyConsumptionFactory.php
+++ b/database/factories/EnergyConsumptionFactory.php
@@ -19,8 +19,7 @@ class EnergyConsumptionFactory extends Factory
             'methods_ressource_id' => MethodsRessources::factory(),
             'kwh' => $kwh,
             'cost_per_kwh' => $cost,
-            'total_cost' => $kwh * $cost,
+            'total_cost' => round($kwh * $cost, 2),
         ];
     }
 }
-

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,0 +1,1 @@
+@extends('adminlte::auth.verify')

--- a/routes/web.php
+++ b/routes/web.php
@@ -108,7 +108,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
 
     Route::group(['prefix' => 'companies/contacts', 'middleware' => $contactMiddleware], function () {
         Route::post('/create/{id}', 'App\Http\Controllers\Companies\ContactsController@store')->name('contacts.store');
-        Route::post('/edit/{id}', 'App\Http\Controllers\Companies\ContactsController@update')->name('contacts.update');
+        Route::match(['post', 'put'], '/edit/{id}', 'App\Http\Controllers\Companies\ContactsController@update')->name('contacts.update');
         Route::get('/edit/{id}', 'App\Http\Controllers\Companies\ContactsController@edit')->name('contacts.edit');
     });
 
@@ -467,7 +467,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/user/{id}', 'App\Http\Controllers\Admin\HumanResourcesController@ShowUser')->name('human.resources.show.user');
     
         // Update User
-        Route::post('/update/user/{id}', 'App\Http\Controllers\Admin\HumanResourcesController@UpdateUser')->name('human.resources.update.user');
+        Route::match(['post', 'put'], '/update/user/{id}', 'App\Http\Controllers\Admin\HumanResourcesController@UpdateUser')->name('human.resources.update.user');
 
         //lock User
         Route::post('/lock/user/{id}', 'App\Http\Controllers\Admin\HumanResourcesController@LockUser')->name('human.resources.lock.user');

--- a/tests/Feature/Http/Controllers/Methods/ToolsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Methods/ToolsControllerTest.php
@@ -9,7 +9,7 @@ use App\Models\Methods\MethodsTools;
 use App\Services\SelectDataService;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 
 class ToolsControllerTest extends TestCase
 {
@@ -61,13 +61,9 @@ class ToolsControllerTest extends TestCase
     {
         $toolData = MethodsTools::factory()->make()->toArray();
 
+        Storage::fake('public');
 
-        $toolsDirectory = public_path('images/tools');
-        if (!File::exists($toolsDirectory)) {
-            File::makeDirectory($toolsDirectory, 0755, true);
-        }
-
-        $response = $this->post(route('methods.tool.store'), array_merge($toolData, [
+        $response = $this->post(route('methods.tool.create'), array_merge($toolData, [
 
             'picture' => UploadedFile::fake()->image('tool.jpg'),
             'ETAT' => 1
@@ -84,9 +80,7 @@ class ToolsControllerTest extends TestCase
         $savedTool = MethodsTools::firstWhere('code', $toolData['code']);
         $this->assertNotNull($savedTool);
 
-        $storedPicturePath = $toolsDirectory . '/' . $savedTool->picture;
-        $this->assertTrue(File::exists($storedPicturePath));
-        File::delete($storedPicturePath);
+        Storage::disk('public')->assertExists('images/tools/' . $savedTool->picture);
     }
 
     /**
@@ -143,13 +137,9 @@ class ToolsControllerTest extends TestCase
     {
         $tool = MethodsTools::factory()->create();
 
+        Storage::fake('public');
 
-        $methodsDirectory = public_path('images/methods');
-        if (!File::exists($methodsDirectory)) {
-            File::makeDirectory($methodsDirectory, 0755, true);
-        }
-
-        $response = $this->post(route('methods.tool.store_image', $tool->id), [
+        $response = $this->post(route('methods.tool.update.picture', $tool->id), [
 
             'id' => $tool->id,
             'picture' => UploadedFile::fake()->image('tool_image.jpg')
@@ -157,9 +147,7 @@ class ToolsControllerTest extends TestCase
 
         $tool = $tool->fresh(); // Refresh to get updated data
 
-        $storedPicturePath = $methodsDirectory . '/' . $tool->picture;
-        $this->assertTrue(File::exists($storedPicturePath));
-        File::delete($storedPicturePath);
+        Storage::disk('public')->assertExists('images/tools/' . $tool->picture);
 
         $response->assertRedirect(route('methods.tool'))
                  ->assertSessionHas('success', 'Successfully updated tool.');

--- a/tests/Feature/RessourcesControllerTest.php
+++ b/tests/Feature/RessourcesControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use App\Models\User;
 use App\Models\Methods\MethodsRessources;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -11,6 +12,16 @@ use Illuminate\Support\Facades\Storage;
 class RessourcesControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
 
     /**
      * Test index method to display the list of ressources.
@@ -37,6 +48,8 @@ class RessourcesControllerTest extends TestCase
      */
     public function test_store_creates_ressource()
     {
+        Storage::fake('public');
+
         // Simuler une requête POST avec des données valides
         $response = $this->post(route('methods.ressource.create'), [
             'ordre' => 1,
@@ -47,6 +60,7 @@ class RessourcesControllerTest extends TestCase
             'color' => '#FFFFFF',
             'methods_services_id' => 1,
             'mask_time' => true,
+            'picture' => UploadedFile::fake()->image('ressource.jpg'),
         ]);
 
         // Vérifier que la ressource a été créée dans la base de données
@@ -136,6 +150,8 @@ class RessourcesControllerTest extends TestCase
             'id' => $ressource->id,
             'picture' => UploadedFile::fake()->image('ressource.jpg'),
         ]);
+
+        $ressource = $ressource->fresh();
 
         // Vérifier que l'image a été stockée
         Storage::disk('public')->assertExists('images/ressources/' . $ressource->picture);

--- a/tests/Feature/SupplierRatingControllerTest.php
+++ b/tests/Feature/SupplierRatingControllerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use App\Models\Purchases\Purchases;
+use App\Models\Companies\Companies;
 use App\Models\Companies\SupplierRating;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -17,10 +19,13 @@ class SupplierRatingControllerTest extends TestCase
      */
     public function test_can_store_supplier_rating()
     {
+        $purchase = Purchases::factory()->create();
+        $company = Companies::factory()->create();
+
         // Simulation des données de la requête pour créer une évaluation de fournisseur
         $data = [
-            'purchases_id' => 1, // ID de l'achat associé
-            'companies_id' => 1, // ID de la compagnie associée
+            'purchases_id' => $purchase->id, // ID de l'achat associé
+            'companies_id' => $company->id, // ID de la compagnie associée
             'rating' => 4,       // Note donnée au fournisseur
             'comment' => 'Great supplier, timely delivery.', // Commentaire optionnel
         ];
@@ -30,8 +35,8 @@ class SupplierRatingControllerTest extends TestCase
 
         // Vérifie que l'évaluation du fournisseur est bien créée dans la base de données
         $this->assertDatabaseHas('supplier_ratings', [
-            'purchases_id' => 1,
-            'companies_id' => 1,
+            'purchases_id' => $purchase->id,
+            'companies_id' => $company->id,
             'rating' => 4,
             'comment' => 'Great supplier, timely delivery.',
         ]);

--- a/tests/Feature/UnitsControllerTest.php
+++ b/tests/Feature/UnitsControllerTest.php
@@ -3,12 +3,23 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use App\Models\User;
 use App\Models\Methods\MethodsUnits;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UnitsControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
 
     /** @test */
     public function it_can_display_units_list()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Models\Admin\Factory as FactoryModel;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -9,4 +10,15 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!FactoryModel::query()->exists()) {
+            FactoryModel::create([
+                'name' => 'Test Factory',
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

- Resolve multiple failing feature/unit tests caused by mismatches in API resource keys and missing app/test plumbing.
- Standardize file upload handling to use storage disk APIs so tests can assert file persistence reliably.
- Ensure N2P payloads and task/job identifiers/timestamps match expected formats used by tests and integrations.
- Allow certain controller endpoints to accept both `POST` and `PUT` where tests exercise both HTTP verbs.

### Description

- Seed a default factory for tests by creating a `Factory` row in `tests/TestCase.php` setup so middleware `CheckFactory` passes during tests. (added `FactoryModel::create` in `setUp`)
- Expose `name` in API resources by adding `name` to `CompanieResource` and `TaskResource` so JSON responses include the expected keys. (`app/Http/Resources/CompanieResource.php`, `app/Http/Resources/TaskResource.php`)
- Switch methods asset uploads to the `public` disk using `$request->file('picture')->store(..., 'public')` and update image validation to `nullable|image` in store requests to allow tests to use `Storage::fake`. (controllers under `app/Http/Controllers/Methods/*` and request classes under `app/Http/Requests/Methods/*`)
- Tighten/adjust factories and test helpers: round `total_cost` in `EnergyConsumptionFactory` and update several tests to use `Storage::fake`, `actingAs` users, and to create required `Purchases`/`Companies` fixtures. (factories and tests under `database/factories` and `tests/Feature`)
- Improve N2P payload builder to use the order code for `of_code` when present, prefer `task->code` for `operation_code`, use `MethodsTools` code as `workcenter_code` when available, and format datetimes as `Y-m-d H:i:s`. (`app/Services/N2P/N2PPayloadBuilder.php`)
- Add a minimal email verification view `resources/views/auth/verify-email.blade.php` that extends the admin template to satisfy auth flow during tests.
- Make two routes accept both `POST` and `PUT` via `Route::match(...)` to align with tests that call update endpoints using different HTTP verbs. (`routes/web.php`)
- Normalize supplier rating success message to match test expectation (`Rate saved successfully`). (`app/Http/Controllers/Companies/SupplierRatingController.php`)

### Testing

- No automated test suite was executed as part of this PR; the changes were implemented to address the previously observed failing tests reported earlier.
- Existing failing test report used to drive fixes included feature tests for companies, contacts, uploads, methods controllers, energy consumption, supplier ratings, N2P payload unit tests, and various controllers. 
- Tests updated to use `Storage::fake('public')` and create required fixtures so they can assert file existence and DB state deterministically. 
- Manual review verified code compiles and new view file exists, but full `phpunit` run was not invoked in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e40cd53c832d9174d5b030ab7fe8)