### PR TITLE
Add Spatie permission middleware aliases

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,5 +71,8 @@ class Kernel extends HttpKernel
         'check.factory'           => \App\Http\Middleware\CheckFactory::class,
         'check.task.status'       => \App\Http\Middleware\CheckTaskStatus::class,
         'customer'                => \App\Http\Middleware\EnsureCustomerIsAuthenticated::class,
+        'permission'              => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role'                    => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+        'role_or_permission'      => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
     ];
 }


### PR DESCRIPTION
### Motivation
- Fix a `BindingResolutionException` caused by the `permission` middleware alias being unavailable when routes/controllers use `permission:...` (e.g. `AssetController` uses `permission:asset_manager`).
- Ensure the Spatie permission/role middleware are registered so middleware lookups succeed.

### Description
- Register the Spatie middleware aliases in `app/Http/Kernel.php` by adding `permission`, `role`, and `role_or_permission` mappings to their respective `\Spatie\Permission\Middlewares\*` classes.
- This change makes `permission:...`, `role:...`, and `role_or_permission:...` usable in route/controller middleware declarations.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696412795de4832db8c0468ef59d6a75)