### PR TITLE
Fix Spatie permission middleware namespace

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,8 +71,8 @@ class Kernel extends HttpKernel
         'check.factory'           => \App\Http\Middleware\CheckFactory::class,
         'check.task.status'       => \App\Http\Middleware\CheckTaskStatus::class,
         'customer'                => \App\Http\Middleware\EnsureCustomerIsAuthenticated::class,
-        'permission'              => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
-        'role'                    => \Spatie\Permission\Middlewares\RoleMiddleware::class,
-        'role_or_permission'      => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
+        'permission'              => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'role'                    => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'role_or_permission'      => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
     ];
 }


### PR DESCRIPTION
### Motivation
- Fix a `BindingResolutionException` caused by the app referencing the wrong Spatie middleware namespace `Spatie\Permission\Middlewares` which does not exist.
- Ensure route middleware entries resolve to the current package namespace used by `spatie/laravel-permission`.
- Prevent runtime errors when middleware like `permission`, `role`, or `role_or_permission` are used in routes.

### Description
- Updated the route middleware map in `app/Http/Kernel.php` to use `\Spatie\Permission\Middleware\PermissionMiddleware::class` instead of the incorrect `Middlewares` namespace.
- Applied the same namespace fix for `RoleMiddleware` and `RoleOrPermissionMiddleware` entries in the same file.
- Committed the change to the repository.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696415d0892c832d8a6ce62c7051b1e4)