### PR TITLE
Limit seeded orders to customer companies

### DIFF
--- a/database/factories/Workflow/OrdersFactory.php
+++ b/database/factories/Workflow/OrdersFactory.php
@@ -31,8 +31,11 @@ class OrdersFactory extends Factory
     public function definition()
     {
         $this->code = $this->faker->unique()->numerify('OR-####');
-        $companyId = Companies::query()->inRandomOrder()->value('id')
-            ?? Companies::factory()->create()->id;
+        $companyId = Companies::query()
+            ->where('statu_customer', 2)
+            ->inRandomOrder()
+            ->value('id')
+            ?? Companies::factory()->create(['statu_customer' => 2])->id;
         $contactId = CompaniesContacts::query()->inRandomOrder()->value('id')
             ?? CompaniesContacts::factory()->create(['companies_id' => $companyId])->id;
         $addressId = CompaniesAddresses::query()->inRandomOrder()->value('id')


### PR DESCRIPTION
### Motivation
- Ensure orders created by the factory reference companies that are marked as customers.
- Prevent seeded orders from being associated with non-customer companies.
- Keep seeded data consistent by making the factory create a customer company when none exist.

### Description
- Updated `database/factories/Workflow/OrdersFactory.php` to restrict company selection with `->where('statu_customer', 2)`.
- Adjusted the fallback to `Companies::factory()->create(['statu_customer' => 2])` so created companies are customers.
- The rest of the factory behavior (contact, address, user, payment/delivery fallbacks) remains unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69642169ba1c832d9585f89fe7bebfce)