### PR TITLE
Exclude stopped/canceled orders from delivery requests

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,7 +58,8 @@ class AppServiceProvider extends ServiceProvider
                         ->orWhere('delivery_status', '=', '2');
                 })
                 ->whereHas('order', function($q){
-                    $q->where('type', '=', '1');
+                    $q->whereNotIn('statu', [5, 6])
+                        ->where('type', '=', '1');
                 })->count();
 
             $InvoicesRequestsCount =  DeliveryLines::where(

--- a/app/Services/DeliveryDataService.php
+++ b/app/Services/DeliveryDataService.php
@@ -16,6 +16,8 @@ class DeliveryDataService
     {
         return OrderLines::whereIn('delivery_status', ['1', '2'])
             ->leftJoin('orders', 'order_lines.orders_id', '=', 'orders.id')
+            ->whereNotIn('orders.statu', [5, 6])
+            ->where('orders.type', '=', '1')
             ->pluck('orders.companies_id')
             ->filter()
             ->unique()
@@ -39,7 +41,8 @@ class DeliveryDataService
                 if (!empty($companyId)) {
                     $q->where('companies_id', '=', (int)$companyId);
                 }
-                $q->where('type', '=', '1');
+                $q->whereNotIn('statu', [5, 6])
+                    ->where('type', '=', '1');
             })->get();
     }
 }


### PR DESCRIPTION
### Motivation
- Stopped or canceled orders were appearing in the delivery requests list and the delivery menu count, which is not logical for creating delivery notes.
- The goal is to only show active sales orders as candidates for delivery requests and in the menu badge.

### Description
- Filter `OrderLines` queries in `DeliveryDataService` to only include related `orders` where `statu` is not `5` or `6` and `type` is `1` for both `getUniqueCompanyIdsWithOpenOrderLines` and `getDeliveryRequestsLines`.
- Update the delivery requests count computation in `AppServiceProvider` to exclude orders with `statu` 5 and 6 when building the menu badge.
- Files changed: `app/Services/DeliveryDataService.php` and `app/Providers/AppServiceProvider.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964255ce044832d9c5bec32bf8f2883)