### PR TITLE
Block delivery/invoice creation for canceled orders

### DIFF
--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -1022,6 +1022,11 @@ class OrderLine extends Component
         }
 
         $OrderData = Orders::find($orderId);
+        if (! $OrderData || $OrderData->statu == 6) {
+            $errors = $this->getErrorBag();
+            $errors->add('errors', __('general_content.order_canceled_no_document_trans_key'));
+            return;
+        }
         $LastDelivery = Deliverys::orderBy('id', 'desc')->first();
         $deliveryId = $LastDelivery ? $LastDelivery->id : 0;
         $deliveryCode = $this->documentCodeGenerator->generateDocumentCode('delivery', $deliveryId);
@@ -1061,6 +1066,11 @@ class OrderLine extends Component
         }
 
         $OrderData = Orders::find($orderId);
+        if (! $OrderData || $OrderData->statu == 6) {
+            $errors = $this->getErrorBag();
+            $errors->add('errors', __('general_content.order_canceled_no_document_trans_key'));
+            return;
+        }
         $LastInvoice = Invoices::orderBy('id', 'desc')->first();
         $invoiceId = $LastInvoice ? $LastInvoice->id : 0;
         $invoiceCode = $this->documentCodeGenerator->generateDocumentCode('invoice', $invoiceId);

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -33,6 +33,7 @@ return [
     'partly_received_trans_key'                => 'تم الاستلام جزئيًا',
     'received_trans_key'                       => 'تم الاستلام',
     'canceled_trans_key'                       => 'تم الإلغاء',
+    'order_canceled_no_document_trans_key'     => 'تم إلغاء الطلب: تم تعطيل إنشاء بوليصة التسليم والفاتورة.',
     'no_task_trans_key'                        => 'لا مهمة',
     'created_trans_key'                        => 'تم الإنشاء',
     'to_be_posted_trans_key'                   => 'للنشر',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -35,6 +35,7 @@ return [
     'po_partly_created_trans_key'              => 'PO partly created',
     'po_created_trans_key'                     => 'PO Created',
     'canceled_trans_key'                       => 'Canceled',
+    'order_canceled_no_document_trans_key'     => 'Order canceled: delivery note and invoice creation are disabled.',
     'stopped_trans_key'                        => 'Stopped',
     'no_task_trans_key'                        => 'No task',
     'created_trans_key'                        => 'Created',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -33,6 +33,7 @@ return [
     'partly_received_trans_key'                => 'Parcialmente recibido',
     'received_trans_key'                       => 'Recibido',
     'canceled_trans_key'                       => 'Cancelado',
+    'order_canceled_no_document_trans_key'     => 'Pedido cancelado: la creación de albarán y factura está desactivada.',
     'no_task_trans_key'                        => 'Sin tarea',
     'created_trans_key'                        => 'Creado',
     'to_be_posted_trans_key'                   => 'A ser publicado',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -35,6 +35,7 @@ return [
     'po_partly_created_trans_key'              => 'CA partiellement créé',
     'po_created_trans_key'                     => 'CA créé',
     'canceled_trans_key'                       => 'Annulé',
+    'order_canceled_no_document_trans_key'     => 'Commande annulée : création de BL et de facture désactivée.',
     'stopped_trans_key'                        => 'Stopé',
     'no_task_trans_key'                        => 'Aucune taches',
     'created_trans_key'                        => 'Créer',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -35,6 +35,7 @@ return [
     'po_partly_created_trans_key'              => '采购订单部分创建',
     'po_created_trans_key'                     => '采购订单已创建',
     'canceled_trans_key'                       => '已取消',
+    'order_canceled_no_document_trans_key'     => '订单已取消：已禁用创建送货单和发票。',
     'stopped_trans_key'                        => '已停止',
     'no_task_trans_key'                        => '无任务',
     'created_trans_key'                        => '已创建',

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -608,7 +608,7 @@
                                 </div>
                             </td>
                             <td>
-                                @if ((($OrderLine->delivery_status != 3 && $OrderLine->order->type != 2) && ($OrderLine->delivery_status != 4 && $OrderLine->order->type != 2)))
+                                @if($OrderStatu != 6 && (($OrderLine->delivery_status != 3 && $OrderLine->order->type != 2) && ($OrderLine->delivery_status != 4 && $OrderLine->order->type != 2)))
                                 <div class="custom-control custom-checkbox">
                                     <input class="custom-control-input" value="{{ $OrderLine->id }}" wire:model.live="data.{{ $OrderLine->id }}.order_line_id" id="data.{{ $OrderLine->id }}.order_line_id"  type="checkbox">
                                     <label for="data.{{ $OrderLine->id }}.order_line_id" class="custom-control-label">+</label>
@@ -650,17 +650,22 @@
                                     <input type="checkbox" id="CreateSerialNumber" wire:model.live="CreateSerialNumber" >
                                 </div>
                                 <div>
-                                    <a class="btn btn-primary btn-sm" wire:click="storeDelevery({{ $OrderId }})" href="#">
-                                        <i class="fas fa-folder"></i>
-                                        {{ __('general_content.new_delivery_note_trans_key') }}
-                                    </a>
-                                    
-                                    or
+                                    @if($OrderStatu != 6)
+                                        <a class="btn btn-primary btn-sm" wire:click="storeDelevery({{ $OrderId }})" href="#">
+                                            <i class="fas fa-folder"></i>
+                                            {{ __('general_content.new_delivery_note_trans_key') }}
+                                        </a>
+                                        
+                                        or
 
-                                    <a class="btn btn-primary btn-sm" wire:click="storeInvoice({{ $OrderId }})" href="#">
-                                        <i class="fas fa-folder"></i>
-                                        {{ __('general_content.new_invoice_trans_key') }}
-                                    </a>
+                                        <a class="btn btn-primary btn-sm" wire:click="storeInvoice({{ $OrderId }})" href="#">
+                                            <i class="fas fa-folder"></i>
+                                            {{ __('general_content.new_invoice_trans_key') }}
+                                        </a>
+                                    @else
+                                        <span class="badge badge-danger">{{ __('general_content.canceled_trans_key') }}</span>
+                                        <small class="text-muted ms-2">{{ __('general_content.order_canceled_no_document_trans_key') }}</small>
+                                    @endif
                                 </div>
                             </th>
                         </tr>


### PR DESCRIPTION
### Motivation
- Prevent creating delivery notes or invoices for orders that are marked canceled, because the UI allowed generating documents for canceled orders.

### Description
- Add guards in `app/Livewire/OrderLine.php` (`storeDelevery` and `storeInvoice`) to return an error when the order is missing or its `statu == 6` (canceled).
- Hide the per-line selection checkbox and the `new_delivery_note`/`new_invoice` action buttons in `resources/views/livewire/order-lines.blade.php` when `$OrderStatu == 6`, and show a canceled badge with an explanatory message instead.
- Add the new translation key `order_canceled_no_document_trans_key` and localized messages in `resources/lang/{en,fr,es,ar,zh-CN}/general_content.php` used for the UI message and error text.

### Testing
- No automated tests were executed for this change.
- An attempt to run `php artisan serve` failed due to missing dependencies (`vendor/autoload.php`), so no runtime verification was performed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696424dfadf4832d8507a3e33742a733)