### PR TITLE
Validate picture uploads and generate safe filenames in QuoteLinesController and OrderLinesController

### DIFF
--- a/app/Http/Controllers/Workflow/OrderLinesController.php
+++ b/app/Http/Controllers/Workflow/OrderLinesController.php
@@ -58,14 +58,15 @@ class OrderLinesController extends Controller
     {
         
         $request->validate([
-            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture' => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ]);
         
         if($request->hasFile('picture')){
             $OrderLineDetails = OrderLineDetails::findOrFail($request->id);
             $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/order-lines'), $filename);
+            $extension = $file->getClientOriginalExtension();
+            $filename = time() . '_' . uniqid() . '.' . $extension;
+            $file->move(public_path('images/order-lines'), $filename);
             $OrderLineDetails->update(['picture' => $filename]);
             $OrderLineDetails->save();
             return redirect()->route('orders.show', ['id' =>  $idOrder])->with('success', 'Successfully updated image');

--- a/app/Http/Controllers/Workflow/QuoteLinesController.php
+++ b/app/Http/Controllers/Workflow/QuoteLinesController.php
@@ -103,14 +103,15 @@ class QuoteLinesController extends Controller
     {
         
         $request->validate([
-            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'picture' => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
         ]);
         
         if($request->hasFile('picture')){
             $QuoteLineDetails = QuoteLineDetails::findOrFail($request->id);
             $file =  $request->file('picture');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $request->picture->move(public_path('images/quote-lines'), $filename);
+            $extension = $file->getClientOriginalExtension();
+            $filename = time() . '_' . uniqid() . '.' . $extension;
+            $file->move(public_path('images/quote-lines'), $filename);
             $QuoteLineDetails->update(['picture' => $filename]);
             $QuoteLineDetails->save();
             return redirect()->route('quotes.show', ['id' =>  $idQuote])->with('success', 'Successfully updated image');


### PR DESCRIPTION
### Motivation
- Fix an upload validation bypass where controllers validated `image` but processed the `picture` field, allowing unvalidated file uploads that could lead to RCE.
- Apply the same safe-upload pattern used elsewhere in the codebase to additional endpoints handling line-item images. 

### Description
- Updated `QuoteLinesController::StoreImage` to validate the `picture` field with `required|image|mimes:jpeg,png,jpg,gif,svg|max:10240` and to generate a safe filename using `getClientOriginalExtension()` and `uniqid()` before moving the file.
- Updated `OrderLinesController::StoreImage` with the same `picture` field validation and safe filename generation, replacing the use of the original client filename. 
- Replaced `$request->picture->move(...)` that used the original filename with `$file->move(...)` using the generated filename to reduce risk from malicious filenames.

### Testing
- No automated tests were run against these changes.
- Code changes were committed successfully and the modified files are `app/Http/Controllers/Workflow/QuoteLinesController.php` and `app/Http/Controllers/Workflow/OrderLinesController.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b361e78c832db7bab4c5473b164c)