### PR TITLE
Filter purchase product dropdown by preferred supplier

### DIFF
--- a/app/Livewire/PurchasesLinesIndex.php
+++ b/app/Livewire/PurchasesLinesIndex.php
@@ -92,7 +92,14 @@ class PurchasesLinesIndex extends Component
         $this->order_Statu = $OrderStatu;
         $this->Factory = Factory::first();
         $this->status_id = Status::select('id')->orderBy('order')->first();
-        $this->ProductsSelect = Products::select('id', 'label', 'code')->orderBy('code')->get();
+        $purchase = Purchases::select('companies_id')->find($this->purchase_id);
+        $productsQuery = Products::select('id', 'label', 'code');
+        if ($purchase && $purchase->companies_id) {
+            $productsQuery->whereHas('preferredSuppliers', function ($query) use ($purchase) {
+                $query->where('companies_id', $purchase->companies_id);
+            });
+        }
+        $this->ProductsSelect = $productsQuery->orderBy('code')->get();
         $this->UnitsSelect = MethodsUnits::select('id', 'label', 'code')->orderBy('label')->get();
         $this->ProductSelect = Products::select('id', 'code','label', 'methods_services_id')->get();
 }


### PR DESCRIPTION
### Motivation
- When creating or editing purchase lines the product dropdown should only list products for which the purchase's supplier is marked as a preferred supplier. 
- The same Livewire component is used in multiple purchase-related contexts, so the filter must be scoped to the current purchase company. 

### Description
- Updated `mount` in `app/Livewire/PurchasesLinesIndex.php` to load `ProductsSelect` via a query that retrieves the purchase's `companies_id` and applies `whereHas('preferredSuppliers', ...)` to filter products by the purchase company. 
- The query falls back to the unfiltered product list when no purchase company is found, and other selects (`UnitsSelect`, `ProductSelect`) are left unchanged. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965543b813c832d98f2effc4c9a64d8)