### PR TITLE
Default orders status filter to open

### DIFF
--- a/app/Livewire/OrdersIndex.php
+++ b/app/Livewire/OrdersIndex.php
@@ -31,7 +31,7 @@ class OrdersIndex extends Component
     public $search = '';
     public $sortField = 'created_at'; // default sorting field
     public $sortAsc = false; // default sort direction
-    public $searchIdStatus = '';
+    public $searchIdStatus = '1';
 
     public $userSelect = [];
     public $LastOrder = null;

--- a/resources/views/livewire/orders-index.blade.php
+++ b/resources/views/livewire/orders-index.blade.php
@@ -238,7 +238,7 @@
                                 <span class="input-group-text"><i class="fas fa-list"></i></span>
                             </div>
                             <select class="form-control" name="searchIdStatus" id="searchIdStatus" wire:model.live="searchIdStatus">
-                                <option value="" selected>{{ __('general_content.select_statu_trans_key') }}</option>
+                                <option value="">{{ __('general_content.select_statu_trans_key') }}</option>
                                 <option value="1">{{ __('general_content.open_trans_key') }}</option>
                                 <option value="2">{{ __('general_content.in_progress_trans_key') }}</option>
                                 <option value="3">{{ __('general_content.delivered_trans_key') }}</option>


### PR DESCRIPTION
### Motivation
- Ensure the orders list at `/orders` shows open orders by default so users see active work on first load.
- Rely on Livewire model binding to control the selected status instead of forcing a hard-coded `selected` attribute in the view.

### Description
- Set the Livewire component default for `searchIdStatus` to `'1'` in `app/Livewire/OrdersIndex.php` so the Open status is selected on mount (`public $searchIdStatus = '1';`).
- Removed the forced `selected` attribute from the status `<option>` in `resources/views/livewire/orders-index.blade.php` so Livewire fully controls the selection via the bound model `wire:model.live="searchIdStatus"`.
- Files modified: `app/Livewire/OrdersIndex.php`, `resources/views/livewire/orders-index.blade.php`.
- Effect: when visiting `/orders` the status filter defaults to Open and the list shows open orders immediately.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965547d57e8832d8a615a4965c43560)