### PR TITLE
Use settings `n2p_base_url` for Nest2Prod link on non-open orders

### DIFF
--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -264,6 +264,9 @@
             <x-adminlte-card title="{{ __('general_content.options_trans_key') }}" theme="warning" collapsible="collapsed" maximizable>
               <div class="table-responsive p-0">
                 <table class="table table-hover">
+                    @php
+                      $nest2prodUrl = rtrim((string) app(\App\Services\Settings\SettingsService::class)->get('n2p_base_url'), '/');
+                    @endphp
                     @if($Order->type == 1)
                     <tr>
                         <td style="width:50%">{{  __('general_content.orders_trans_key') }}</td>
@@ -287,6 +290,16 @@
                         <a href="{{ route('print.manufacturing.instruction', ['Document' => $Order->id])}}" rel="noopener" target="_blank" class="btn btn-info btn-sm"><i class="fas fa-print"></i>Print</a>
                       </td>
                     </tr>
+                    @if($Order->statu != 1 && $nest2prodUrl !== '')
+                    <tr>
+                      <td style="width:50%">Nest2Prod</td>
+                      <td>
+                        <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm">
+                          <i class="fas fa-external-link-alt"></i> {{ __('general_content.view_trans_key') }}
+                        </a>
+                      </td>
+                    </tr>
+                    @endif
                     
                     @if($Order->type == 1 && $Order->uuid)
                       <tr>


### PR DESCRIPTION
### Motivation
- Show a Nest2Prod link in the order options only when a configured base URL exists in the application settings and the order is not in the open state.
- Reuse the existing `n2p_base_url` entry stored in the settings table instead of relying on a `services` env configuration.
- Prevent displaying the link when no value is set to avoid broken external links.

### Description
- Updated `resources/views/workflow/orders-show.blade.php` to read the Nest2Prod base URL via `app(\App\Services\Settings\SettingsService::class)->get('n2p_base_url')`, trim trailing slashes with `rtrim`, and only render the link when the value is non-empty and `$Order->statu != 1`.
- Construct the external link as `{$n2p_base_url}/fr/orders/{rawurlencode($Order->code)}` and open it in a new tab with an external-link icon and the `view` translation key for consistency.
- Removed the previously added `nest2prod` entry from `config/services.php` to avoid confusion with the settings-based configuration.

### Testing
- No automated tests were run for this change.
- Changes are limited to a Blade view and a config cleanup and should be validated by setting `n2p_base_url` in the settings table and verifying the link appears only for orders where `statu != 1`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696556d2ae24832db937c8d4c614997c)