### PR TITLE
Add missing `success_trans_key` translations for multiple locales

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -156,6 +156,7 @@ return [
     'action_trans_key'                         => 'الإجراءات',
     'save_trans_key'                           => 'حفظ',
     'user_trans_key'                           => 'المستخدم',
+    'success_trans_key'                        => 'تمت العملية بنجاح.',
     'status_client_trans_key'                  => 'حالة العميل',
     'status_supplier_trans_key'                => 'حالة المورد',
     'color_trans_key'                          => 'اللون',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -187,6 +187,7 @@ return [
     'attendance_entry_trans_key'               => 'Entry',
     'attendance_exit_trans_key'                => 'Exit',
     'attendance_success_trans_key'             => 'Attendance recorded.',
+    'success_trans_key'                        => 'Operation completed successfully.',
     'status_client_trans_key'                  => 'Status client',
     'status_supplier_trans_key'                => 'Status supplier',
     'color_trans_key'                          => 'Color',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -156,6 +156,7 @@ return [
     'action_trans_key'                         => 'Acciones',
     'save_trans_key'                           => 'Guardar',
     'user_trans_key'                           => 'Usuario',
+    'success_trans_key'                        => 'Operación realizada correctamente.',
     'status_client_trans_key'                  => 'Estado del cliente',
     'status_supplier_trans_key'                => 'Estado del proveedor',
     'color_trans_key'                          => 'Color',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -187,6 +187,7 @@ return [
     'attendance_entry_trans_key'               => 'Entrée',
     'attendance_exit_trans_key'                => 'Sortie',
     'attendance_success_trans_key'             => 'Pointage enregistré.',
+    'success_trans_key'                        => 'Opération réalisée avec succès.',
     'status_client_trans_key'                  => 'Etat client',
     'status_supplier_trans_key'                => 'Etat fournisseur',
     'color_trans_key'                          => 'Couleur',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -182,6 +182,7 @@ return [
     'action_trans_key'                         => '操作',
     'save_trans_key'                           => '保存',
     'user_trans_key'                           => '用户',
+    'success_trans_key'                        => '操作成功。',
     'status_client_trans_key'                  => '客户状态',
     'status_supplier_trans_key'                => '供应商状态',
     'color_trans_key'                          => '颜色',


### PR DESCRIPTION
### Motivation
- The application references `__('general_content.success_trans_key')` (for example in the N2P settings alert), but the translation key was missing in several locales which caused the raw key to appear in the UI.
- Add a reusable, generic success message to avoid missing-key display and keep messaging consistent across views and controllers.

### Description
- Added the `success_trans_key` entry to these files: `resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`, `resources/lang/es/general_content.php`, `resources/lang/ar/general_content.php`, and `resources/lang/zh-CN/general_content.php`.
- Provided localized values: English `Operation completed successfully.`, French `Opération réalisée avec succès.`, Spanish `Operación realizada correctamente.`, Arabic `تمت العملية بنجاح.`, and Chinese `操作成功。`.
- Inserted the new keys alongside existing header/footer translations near `user_trans_key` to keep the locale files organized.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696558a35838832da9b758c9bfd6b30a)