### PR TITLE
Default quotes list to 'Open' status

### DIFF
--- a/app/Livewire/QuotesIndex.php
+++ b/app/Livewire/QuotesIndex.php
@@ -32,7 +32,7 @@ class QuotesIndex extends Component
     public $search = '';
     public $sortField = 'created_at'; // default sorting field
     public $sortAsc = false; // default sort direction
-    public $searchIdStatus = '';
+    public $searchIdStatus = '1';
     
     public $userSelect = [];
     public $LastQuote = null;
@@ -114,6 +114,8 @@ class QuotesIndex extends Component
         $this->accounting_deliveries_id = $this->getDefaultId(AccountingDelivery::class);
     
         $this->setQuoteCodeAndLabel();
+
+        $this->searchIdStatus = '1';
 
         
         $this->statuses = [
@@ -293,4 +295,3 @@ class QuotesIndex extends Component
         session()->flash('success','Line added Successfully');
     }
 }
-

--- a/resources/views/livewire/quotes-index.blade.php
+++ b/resources/views/livewire/quotes-index.blade.php
@@ -363,7 +363,7 @@
                                 <span class="input-group-text"><i class="fas fa-list"></i></span>
                             </div>
                             <select class="form-control" name="searchIdStatus" id="searchIdStatus" wire:model.live="searchIdStatus">
-                                <option value="" selected>{{ __('general_content.select_statu_trans_key') }}</option>
+                                <option value="">{{ __('general_content.select_statu_trans_key') }}</option>
                                 <option value="1">{{ __('general_content.open_trans_key') }}</option>
                                 <option value="2">{{ __('general_content.send_trans_key') }}</option>
                                 <option value="3">{{ __('general_content.win_trans_key') }}</option>


### PR DESCRIPTION
### Motivation

- Ensure the `/quotes` page shows open quotes by default so users immediately see active items. 
- Allow Livewire to control the status dropdown selection instead of forcing an empty option.

### Description

- Set the Livewire component default filter to open by initializing `public $searchIdStatus = '1'` in `app/Livewire/QuotesIndex.php`.
- Also set `$this->searchIdStatus = '1'` in the `mount()` method to ensure initial load selects open quotes.
- Removed the hard `selected` attribute from the empty option in `resources/views/livewire/quotes-index.blade.php` so Livewire can reflect the component state.
- Modified files: `app/Livewire/QuotesIndex.php` and `resources/views/livewire/quotes-index.blade.php`.

### Testing

- No automated tests were executed for this change.
- Manual verification expected by loading the `/quotes` page to confirm open quotes are shown by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655984bb64832da7c25dc4046d49c1)