### PR TITLE
Derive stock-move unit price from purchase line to fix weighted average (PMP)

### DIFF
--- a/app/Http/Controllers/Products/StockLocationProductsController.php
+++ b/app/Http/Controllers/Products/StockLocationProductsController.php
@@ -11,6 +11,7 @@ use App\Models\Workflow\OrderLines;
 use App\Http\Controllers\Controller;
 use App\Models\Products\StockLocation;
 use App\Services\StockCalculationService;
+use App\Models\Purchases\PurchaseReceiptLines;
 use App\Models\Products\StockLocationProducts;
 use App\Http\Requests\Products\StoreStockMoveRequest;
 use App\Http\Requests\Products\StoreStockLocationProductsRequest;
@@ -167,6 +168,8 @@ class StockLocationProductsController extends Controller
             $tracability = null;
         }
 
+        $componentPrice = $this->resolvePurchaseReceiptUnitPrice($request->purchase_receipt_line_id, $request->component_price);
+
         $data = [
             'user_id' => $request->user_id,
             'qty' => $request->mini_qty,
@@ -174,7 +177,7 @@ class StockLocationProductsController extends Controller
             'task_id' => $request->task_id,
             'purchase_receipt_line_id' => $request->purchase_receipt_line_id,
             'typ_move' => 3,
-            'component_price' => $request->component_price,
+            'component_price' => $componentPrice,
             'x_size' => $product->x_size,
             'y_size' => $product->y_size,
             'z_size' => $product->z_size,
@@ -195,7 +198,10 @@ class StockLocationProductsController extends Controller
      */
     public function entryFromPurchaseOrder(StoreStockMoveRequest $request)
     {
+        $componentPrice = $this->resolvePurchaseReceiptUnitPrice($request->purchase_receipt_line_id, $request->component_price);
+
         $data = $request->only('user_id', 'qty', 'stock_location_products_id', 'task_id', 'purchase_receipt_line_id', 'typ_move', 'component_price');
+        $data['component_price'] = $componentPrice;
         $this->stockService->createStockMove($data);
 
         // Mise à jour de la ligne de réception de l'achat
@@ -253,5 +259,26 @@ class StockLocationProductsController extends Controller
         else{
             return redirect()->route('products.stockline.show', ['id' => $request->stock_location_products_id])->with('error', 'Not enough stock available for this tracability');
         }
+    }
+
+    private function resolvePurchaseReceiptUnitPrice($purchaseReceiptLineId, $fallbackPrice): float
+    {
+        $purchaseReceiptLine = PurchaseReceiptLines::with('purchaseLines')->find($purchaseReceiptLineId);
+
+        if (! $purchaseReceiptLine || ! $purchaseReceiptLine->purchaseLines) {
+            return (float) $fallbackPrice;
+        }
+
+        $purchaseLine = $purchaseReceiptLine->purchaseLines;
+
+        if (! is_null($purchaseLine->unit_price_after_discount)) {
+            return (float) $purchaseLine->unit_price_after_discount;
+        }
+
+        if (! is_null($purchaseLine->total_selling_price) && $purchaseLine->qty > 0) {
+            return (float) ($purchaseLine->total_selling_price / $purchaseLine->qty);
+        }
+
+        return (float) ($purchaseLine->selling_price ?? $fallbackPrice);
     }
 }


### PR DESCRIPTION
### Motivation
- Weighted average cost (PMP) was calculated using the raw `component_price` from the request, which can ignore per-line purchase unit price and quantities.
- The change ensures stock moves created from purchase receipts use the correct unit price derived from the purchase line so PMP reflects actual purchased quantities and amounts.

### Description
- Added `PurchaseReceiptLines` import and compute a normalized unit price before creating stock moves in `storeFromPurchaseOrder` and `entryFromPurchaseOrder` in `StockLocationProductsController`. 
- Introduced helper `resolvePurchaseReceiptUnitPrice($purchaseReceiptLineId, $fallbackPrice)` that returns `unit_price_after_discount`, or `total_selling_price / qty`, or `selling_price`, falling back to the provided value.
- Replaced direct use of `$request->component_price` with the resolved `$componentPrice` when building the `$data` for `createStockMove`.
- Only file changed: `app/Http/Controllers/Products/StockLocationProductsController.php`.

### Testing
- No automated tests were executed for this change.
- Manual verification is recommended by creating purchase receipts and checking that stock moves use the computed unit price so the weighted average cost updates correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655ab39a24832d9c0db64722834077)