### PR TITLE
Show product details on stock location product page

### DIFF
--- a/app/Http/Controllers/Products/StockLocationProductsController.php
+++ b/app/Http/Controllers/Products/StockLocationProductsController.php
@@ -38,6 +38,7 @@ class StockLocationProductsController extends Controller
         
         $StockMoves = StockMove::where('stock_location_products_id', $id)->orderby('created_at', 'desc')->get();
         $StockLocationProduct = StockLocationProducts::findOrFail($id);
+        $Product = Products::findOrFail($StockLocationProduct->products_id);
         $StockLocation = StockLocation::findOrFail($StockLocationProduct->stock_locations_id);
         $Stock = Stocks::findOrFail($StockLocation->stocks_id);
         $TaskList = Task::where('component_id', $id)
@@ -52,6 +53,7 @@ class StockLocationProductsController extends Controller
             'Stock' => $Stock,
             'StockLocation' => $StockLocation,
             'StockLocationProduct' => $StockLocationProduct,
+            'Product' => $Product,
             'StockMoves' => $StockMoves,
             'TaskList' => $TaskList,
             'OrderLineList' => $OrderLineList,

--- a/resources/views/products/StockLocationProduct-show.blade.php
+++ b/resources/views/products/StockLocationProduct-show.blade.php
@@ -1,11 +1,14 @@
 @extends('adminlte::page')
 
-@section('title', $StockLocationProduct->code . ' '. __('general_content.stock_location_trans_key')) 
+@section('title', $StockLocationProduct->code . ' - ' . $Product->code . ' ' . __('general_content.stock_location_trans_key')) 
 
 @section('content_header')
     <div class="row mb-2">
       <div class="col-sm-6">
-        <h1>{{ $StockLocationProduct->code }}  {{ __('general_content.stock_location_trans_key') }}</h1>
+        <h1>{{ $StockLocationProduct->code }} {{ __('general_content.stock_location_trans_key') }}</h1>
+        <div class="text-muted">
+          {{ __('general_content.product_trans_key') }}: {{ $Product->code }} - {{ $Product->label }}
+        </div>
       </div>
       <div class="col-sm-6">
           <ol class="breadcrumb float-sm-right">


### PR DESCRIPTION
### Motivation
- The stock location product page did not clearly indicate which product the stock line belonged to, making it hard to identify the item at a glance.
- Improve UX by surfacing the associated product information on the stock location product view.

### Description
- Load the associated `Product` in `StockLocationProductsController::show` via `Products::findOrFail($StockLocationProduct->products_id)` and pass it to the view.
- Update `resources/views/products/StockLocationProduct-show.blade.php` to include the product `code` in the page title and display the product `code` and `label` below the header.
- Modified files: `app/Http/Controllers/Products/StockLocationProductsController.php` and `resources/views/products/StockLocationProduct-show.blade.php`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655be4e420832d82246431b114586d)