### PR TITLE
Move business balance styles to `public/css/custom.css` and update Bilan UI

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -173,3 +173,117 @@
     margin-left: 0.5rem;
     white-space: nowrap;
 }
+
+/** BUSINESS BALANCE **/
+
+.business-balance-table {
+    border-collapse: separate;
+    border-spacing: 0;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.business-balance-table thead th {
+    font-weight: 600;
+    text-align: center;
+    border-color: rgba(0, 0, 0, 0.04);
+}
+
+.business-balance-table td {
+    border-color: rgba(0, 0, 0, 0.04);
+}
+
+.business-balance-table__group-row th:first-child {
+    background-color: #f3f4f6;
+}
+
+.business-balance-table__group {
+    color: #1f2933;
+    font-weight: 600;
+}
+
+.business-balance-table__group--info {
+    background-color: #34a0dc;
+    color: #0b1f2a;
+}
+
+.business-balance-table__group--danger {
+    background-color: #e76161;
+    color: #3a0f0f;
+}
+
+.business-balance-table__group--warning {
+    background-color: #f2a65a;
+    color: #4a2d0f;
+}
+
+.business-balance-table__subhead-row th {
+    font-size: 0.85rem;
+    text-transform: none;
+}
+
+.business-balance-table__service-head {
+    background-color: #e9ecef;
+}
+
+.business-balance-table__subhead--info,
+.business-balance-table__cell--info {
+    background-color: #e6f5ff;
+}
+
+.business-balance-table__subhead--danger,
+.business-balance-table__cell--danger {
+    background-color: #fde9e9;
+}
+
+.business-balance-table__subhead--warning,
+.business-balance-table__cell--warning {
+    background-color: #fff2e2;
+}
+
+.business-balance-table__service-cell {
+    background-color: #f8f9fb;
+    font-weight: 600;
+}
+
+.business-balance-table__cell {
+    text-align: center;
+}
+
+.business-balance-table__total-row td {
+    background-color: #f0f1f5;
+    font-weight: 600;
+}
+
+.business-balance-info {
+    row-gap: 1rem;
+}
+
+.business-balance-info__card {
+    background-color: #f8f9fb;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+    height: 100%;
+}
+
+.business-balance-info__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6b7280;
+    margin-bottom: 0.35rem;
+}
+
+.business-balance-info__value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 0;
+}
+
+.business-balance-info__trend {
+    font-size: 0.75rem;
+    color: #22a06b;
+    margin-left: 0.25rem;
+}

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -352,71 +352,114 @@
       </div> 
       <div class="tab-pane" id="Bilan">
         <x-adminlte-card title="{{ __('general_content.options_trans_key') }}" theme="warning" maximizable>
-          <table class="table table-bordered table-hover">
-            <thead>
-              <tr class="bg-dark disabled color-palette">
-                  <th></th>
-                  <th colspan="3" class="bg-info disabled color-palette">{{ __('general_content.manufacturing_range_trans_key') }}</th>
-                  <th colspan="2" class="bg-danger disabled color-palette">{{ __('general_content.accomplished_trans_key') }}</th>
-                  <th colspan="2" class="bg-orange disabled color-palette">{{ __('general_content.gap_trans_key') }}</th>
-              </tr>
-                <tr >
-                    <th>{{ __('general_content.service_trans_key') }}</th>
-                    <th class="bg-info disabled color-palette">{{ __('general_content.hours_trans_key') }}</th>
-                    <th class="bg-info disabled color-palette">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th> 
-                    <th class="bg-info disabled color-palette">{{ __('general_content.selling_price_trans_key') }} ({{ $Factory->curency }})</th>
-                    <th class="bg-danger disabled color-palette">{{ __('general_content.hours_trans_key') }}</th>
-                    <th class="bg-danger disabled color-palette">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
-                    <th class="bg-orange disabled color-palette">{{ __('general_content.hours_trans_key') }}</th>
-                    <th class="bg-orange disabled color-palette">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
+          <div class="table-responsive">
+            <table class="table table-bordered table-hover business-balance-table">
+              <thead>
+                <tr class="business-balance-table__group-row">
+                    <th></th>
+                    <th colspan="3" class="business-balance-table__group business-balance-table__group--info">{{ __('general_content.manufacturing_range_trans_key') }}</th>
+                    <th colspan="2" class="business-balance-table__group business-balance-table__group--danger">{{ __('general_content.accomplished_trans_key') }}</th>
+                    <th colspan="2" class="business-balance-table__group business-balance-table__group--warning">{{ __('general_content.gap_trans_key') }}</th>
                 </tr>
-            </thead>
-            <tbody>
-                @forelse($businessBalance as $group => $data)
-                    <tr>
-                        <td>{{ strtoupper($group) }}</td>
-                        <td class="bg-info disabled color-palette">{{ $data['total_hours'] }} h</td>
-                        <td class="bg-info disabled color-palette">{{ $data['total_display_cost'] }}</td>
-                        <td class="bg-info disabled color-palette">{{ $data['total_display_price'] }}</td>
-                        <td class="bg-danger disabled color-palette">{{ $data['realized_hours'] }} h</td>
-                        <td class="bg-danger disabled color-palette">{{ $data['realized_display_cost'] }}</td>
-                        <td class="bg-orange disabled color-palette">{{ $data['difference_hours'] }} h</td>
-                        <td class="bg-orange disabled color-palette">{{ $data['difference_display_cost'] }}</td>
-                    </tr>
-                @empty
-                <x-EmptyDataLine col="14" text="{{ __('general_content.no_data_trans_key') }}"  />
-                @endforelse
-            </tbody>
-            <tfoot>
-              <tr class="bg-gray disabled color-palette">
-                <td><strong>{{ __('general_content.total_trans_key') }}</strong></td>
-                <td><strong>{{ $businessBalancetotals['total_hours'] }} h</strong></td>
-                <td><strong>{{ $businessBalancetotals['total_display_cost'] }} </strong></td>
-                <td><strong>{{ $businessBalancetotals['total_display_price'] }} </strong></td>
-                <td><strong>{{ $businessBalancetotals['realized_hours'] }} h</strong></td>
-                <td><strong>{{ $businessBalancetotals['realized_display_cost'] }} </strong></td>
-                <td><strong>{{ $businessBalancetotals['difference_hours'] }} h</strong></td>
-                <td><strong>{{ $businessBalancetotals['difference_display_cost'] }} </strong></td>
-              </tr>
-            </tfoot>
-          </table>
+                  <tr class="business-balance-table__subhead-row">
+                      <th class="business-balance-table__service-head">{{ __('general_content.service_trans_key') }}</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--info">{{ __('general_content.hours_trans_key') }}</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--info">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--info">{{ __('general_content.selling_price_trans_key') }} ({{ $Factory->curency }})</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--danger">{{ __('general_content.hours_trans_key') }}</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--danger">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--warning">{{ __('general_content.hours_trans_key') }}</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--warning">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
+                  </tr>
+              </thead>
+              <tbody>
+                  @forelse($businessBalance as $group => $data)
+                      <tr>
+                          <td class="business-balance-table__service-cell">{{ strtoupper($group) }}</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--info">{{ $data['total_hours'] }} h</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--info">{{ $data['total_display_cost'] }}</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--info">{{ $data['total_display_price'] }}</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--danger">{{ $data['realized_hours'] }} h</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--danger">{{ $data['realized_display_cost'] }}</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--warning">{{ $data['difference_hours'] }} h</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--warning">{{ $data['difference_display_cost'] }}</td>
+                      </tr>
+                  @empty
+                  <x-EmptyDataLine col="14" text="{{ __('general_content.no_data_trans_key') }}"  />
+                  @endforelse
+              </tbody>
+              <tfoot>
+                <tr class="business-balance-table__total-row">
+                  <td><strong>{{ __('general_content.total_trans_key') }}</strong></td>
+                  <td><strong>{{ $businessBalancetotals['total_hours'] }} h</strong></td>
+                  <td><strong>{{ $businessBalancetotals['total_display_cost'] }} </strong></td>
+                  <td><strong>{{ $businessBalancetotals['total_display_price'] }} </strong></td>
+                  <td><strong>{{ $businessBalancetotals['realized_hours'] }} h</strong></td>
+                  <td><strong>{{ $businessBalancetotals['realized_display_cost'] }} </strong></td>
+                  <td><strong>{{ $businessBalancetotals['difference_hours'] }} h</strong></td>
+                  <td><strong>{{ $businessBalancetotals['difference_display_cost'] }} </strong></td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
         </x-adminlte-card>
         
         @if($Order->type == 1)
 
         <x-adminlte-card title="{{ __('general_content.informations_trans_key') }}" theme="warning" maximizable>
-          <p><strong>{{ __('general_content.progress_trans_key') }} :</strong> {{ $Order->average_percent_progress_lines }} %</p>
-          <p><strong>{{ __('general_content.amount_trans_key') }} :</strong> {{ $totalPrices }}</p>
-
-          <p><strong>{{ __('general_content.amount_of_invoice_trans_key') }} :</strong> {{ $invoicedAmount }}</p>
-          <p><strong>{{ __('general_content.still_invoiced_trans_key') }} :</strong> {{ $stillInvoiced }} @if($totalPrices > 0 )({{ $percentageInvoiced }} %)@endif</p>
-          <p><strong>{{ __('general_content.payments_received_of_invoice_trans_key') }} :</strong> {{ $receivedPayment }}</p>          
-          <p><strong>{{ __('general_content.forecast_margin_trans_key') }} :</strong> {{ $forecastMarginFormatted }} 
-            @if($businessBalancetotals['total_cost'] > 0) ({{ $forecastMarginPercentageFormatted }}) @endif
-          </p>
-          <p><strong>{{ __('general_content.current_margin_trans_key') }} :</strong> {{ $currentMarginFormatted }} 
-            @if($businessBalancetotals['realized_cost'] > 0) ({{ $currentMarginPercentageFormatted }}) @endif
-          </p>
+          <div class="row business-balance-info">
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.progress_trans_key') }}</p>
+                <p class="business-balance-info__value">{{ $Order->average_percent_progress_lines }} %</p>
+              </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.amount_trans_key') }}</p>
+                <p class="business-balance-info__value">{{ $totalPrices }}</p>
+              </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.amount_of_invoice_trans_key') }}</p>
+                <p class="business-balance-info__value">{{ $invoicedAmount }}</p>
+              </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.still_invoiced_trans_key') }}</p>
+                <p class="business-balance-info__value">
+                  {{ $stillInvoiced }}
+                  @if($totalPrices > 0 )<span class="business-balance-info__trend">({{ $percentageInvoiced }} %)</span>@endif
+                </p>
+              </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.payments_received_of_invoice_trans_key') }}</p>
+                <p class="business-balance-info__value">{{ $receivedPayment }}</p>
+              </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.forecast_margin_trans_key') }}</p>
+                <p class="business-balance-info__value">
+                  {{ $forecastMarginFormatted }}
+                  @if($businessBalancetotals['total_cost'] > 0) <span class="business-balance-info__trend">({{ $forecastMarginPercentageFormatted }})</span> @endif
+                </p>
+              </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+              <div class="business-balance-info__card">
+                <p class="business-balance-info__label">{{ __('general_content.current_margin_trans_key') }}</p>
+                <p class="business-balance-info__value">
+                  {{ $currentMarginFormatted }}
+                  @if($businessBalancetotals['realized_cost'] > 0) <span class="business-balance-info__trend">({{ $currentMarginPercentageFormatted }})</span> @endif
+                </p>
+              </div>
+            </div>
+          </div>
         </x-adminlte-card>
         
         <x-adminlte-card title="{{ __('general_content.informations_trans_key') }}" theme="warning" maximizable>


### PR DESCRIPTION
### Motivation
- Move the business balance styling out of the compiled Sass and into the runtime `custom.css` as requested to make quick UI tweaks easier.
- Improve the `Bilan` tab markup to be more responsive and visually structured for easier scanning.
- Replace dense inline information paragraphs with compact info-card UI to improve readability.

### Description
- Moved the business balance SCSS block from `resources/sass/app.scss` into `public/css/custom.css` and left `resources/sass/app.scss` with only the base imports (`@import 'variables'` and Bootstrap import). 
- Reworked the `Bilan` tab in `resources/views/workflow/orders-show.blade.php` to use a responsive wrapper (`.table-responsive`), new BEM-like classes on the table (`.business-balance-table*`) and new semantic cell classes to drive the moved styles.
- Replaced the previous list of info paragraphs with a grid of card-style blocks (`.business-balance-info__card`) inside a responsive row so key metrics are presented as compact cards.
- Added the full CSS rules for the table and cards to `public/css/custom.css` using the class names applied in the Blade view.

### Testing
- No automated tests were executed for this change because it is a style/UI-only update.
- Visual verification is recommended by running the application and checking the `Bilan` tab in the order view to ensure styles and layout render as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656746b9c8832db3a106c69a668e51)