### PR TITLE
Allow purchase document creation without lines and initialize document codes

### DIFF
--- a/app/Livewire/PurchasesRequest.php
+++ b/app/Livewire/PurchasesRequest.php
@@ -70,6 +70,12 @@ class PurchasesRequest extends Component
         // Get the last purchase and quotation codes
         $this->LastPurchase = $this->purchaseOrderService->generatePurchaseCode();
         $this->LastPurchaseQuotation = $this->purchaseQuotationService->generatePurchasesQuotationCode();
+        $this->changeDocument();
+    }
+
+    public function updatedDocumentType()
+    {
+        $this->changeDocument();
     }
     
     public function sortBy($field)
@@ -139,91 +145,88 @@ class PurchasesRequest extends Component
         // Check if any lines are selected
         $taskIds = collect($this->data)->pluck('task_id')->filter()->count();
 
-        if ($taskIds > 0) {
+        // Get default settings for the purchase order or quotation
+        $defaultSettings = [
+            'AccountingVat' => $this->purchaseOrderService->getAccountingVat(),
+            'defaultAddress' => CompaniesAddresses::getDefault(['companies_id' => $this->companies_id]),
+            'defaultContact' => CompaniesContacts::getDefault(['companies_id' => $this->companies_id]),
+        ];
 
-            // Get default settings for the purchase order or quotation
-            $defaultSettings = [
-                'AccountingVat' => $this->purchaseOrderService->getAccountingVat(),
-                'defaultAddress' => CompaniesAddresses::getDefault(['companies_id' => $this->companies_id]),
-                'defaultContact' => CompaniesContacts::getDefault(['companies_id' => $this->companies_id]),
-            ];
-    
-            // Check if all default settings are available
-            foreach ($defaultSettings as $key => $setting) {
-                if (is_null($setting)) {
-                    return redirect()->back()->with('error', 'No default settings for ' . str_replace('_', ' ', $key));
-                }
-                $defaultSettings[$key] = $setting->id;
+        // Check if all default settings are available
+        foreach ($defaultSettings as $key => $setting) {
+            if (is_null($setting)) {
+                return redirect()->back()->with('error', 'No default settings for ' . str_replace('_', ' ', $key));
+            }
+            $defaultSettings[$key] = $setting->id;
+        }
+
+        // Create puchase order
+        if($this->document_type == 'PU'){
+
+            // Get the status update for the purchase order
+            $statusUpdate = $this->purchaseOrderService->getStatusUpdate();
+
+            if (!$statusUpdate) {
+                return redirect()->back()->with('error', 'No status "Supplied" or "In progress" in kanban for defining progress');
             }
 
-            // Create puchase order
-            if($this->document_type == 'PU'){
+            // Create the purchase order
+            $PurchaseOrderCreated = $this->purchaseOrderService->createPurchaseOrder($this->companies_id, 
+                                                                $this->code , 
+                                                                $this->label , 
+                                                                $defaultSettings['defaultAddress'],
+                                                                $defaultSettings['defaultContact']);
 
-                // Get the status update for the purchase order
-                $statusUpdate = $this->purchaseOrderService->getStatusUpdate();
-    
-                if (!$statusUpdate) {
-                    return redirect()->back()->with('error', 'No status "Supplied" or "In progress" in kanban for defining progress');
-                }
+            if (!$PurchaseOrderCreated) {
+                return redirect()->back()->withErrors(['msg' => 'Something went wrong (like no default settings for address, contact or accounting vat)']);
+            }
 
-                // Create the purchase order
-                $PurchaseOrderCreated = $this->purchaseOrderService->createPurchaseOrder($this->companies_id, 
-                                                                    $this->code , 
-                                                                    $this->label , 
-                                                                    $defaultSettings['defaultAddress'],
-                                                                    $defaultSettings['defaultContact']);
-
-                if (!$PurchaseOrderCreated) {
-                    return redirect()->back()->withErrors(['msg' => 'Something went wrong (like no default settings for address, contact or accounting vat)']);
-                }
-
+            if ($taskIds > 0) {
                 // Process the purchase request lines
                 $this->purchaseOrderService->processPurchaseRequestLines(
                     $this->data,
                     $PurchaseOrderCreated,
                     $statusUpdate->id
                 );
-
-                return redirect()->route('purchases.show', ['id' => $PurchaseOrderCreated->id])
-                                    ->with('success', 'Successfully created new purchase order');
             }
-            // Create purchase quotation
-            elseif($this->document_type == 'PQ'){
 
-                // Get the status update for the purchase quotation
-                $statusUpdate = $this->purchaseQuotationService->getStatusUpdate();
-    
-                if (!$statusUpdate) {
-                    return redirect()->back()->with('error', 'No status "RFQ in progress" or "Started" in kanban for defining progress');
-                }
+            return redirect()->route('purchases.show', ['id' => $PurchaseOrderCreated->id])
+                                ->with('success', 'Successfully created new purchase order');
+        }
+        // Create purchase quotation
+        elseif($this->document_type == 'PQ'){
 
-                // Create the purchase quotation
-                $PurchaseQuotationCreated = $this->purchaseQuotationService->createPurchasesQuotation($this->companies_id, 
-                                                                                                    $this->code , 
-                                                                                                    $this->label , 
-                                                                                                    $defaultSettings['defaultAddress'],
-                                                                                                    $defaultSettings['defaultContact']);
+            // Get the status update for the purchase quotation
+            $statusUpdate = $this->purchaseQuotationService->getStatusUpdate();
 
-                if (!$PurchaseQuotationCreated) {
-                    return redirect()->back()->withErrors(['msg' => 'Something went wrong (like no default settings for address, contact or accounting vat)']);
-                }
+            if (!$statusUpdate) {
+                return redirect()->back()->with('error', 'No status "RFQ in progress" or "Started" in kanban for defining progress');
+            }
 
+            // Create the purchase quotation
+            $PurchaseQuotationCreated = $this->purchaseQuotationService->createPurchasesQuotation($this->companies_id, 
+                                                                                                $this->code , 
+                                                                                                $this->label , 
+                                                                                                $defaultSettings['defaultAddress'],
+                                                                                                $defaultSettings['defaultContact']);
+
+            if (!$PurchaseQuotationCreated) {
+                return redirect()->back()->withErrors(['msg' => 'Something went wrong (like no default settings for address, contact or accounting vat)']);
+            }
+
+            if ($taskIds > 0) {
                 // Process the purchase request lines
                 $this->purchaseQuotationService->processPurchaseRequestLines(
                     $this->data,
                     $PurchaseQuotationCreated,
                     $statusUpdate->id
                 );
-                    
-                return redirect()->route('purchases.quotations.show', ['id' => $PurchaseQuotationCreated->id])->with('success', 'Successfully created new purchase quotation');
             }
-            else{
-                return redirect()->back()->with('error', 'no document type');
-            }
+                
+            return redirect()->route('purchases.quotations.show', ['id' => $PurchaseQuotationCreated->id])->with('success', 'Successfully created new purchase quotation');
         }
         else{
-            $errors = $this->getErrorBag();
-            $errors->add('errors', 'no lines selected');
+            return redirect()->back()->with('error', 'no document type');
         }
     }
 }

--- a/resources/views/livewire/purchases-request.blade.php
+++ b/resources/views/livewire/purchases-request.blade.php
@@ -11,7 +11,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <select class="form-control"  wire:click.prevent="changeDocument()" wire:model.live="document_type" name="document_type" id="document_type">
+                            <select class="form-control" wire:model.live="document_type" name="document_type" id="document_type">
                                 <option value="">{{ __('general_content.select_document_trans_key') }}</option>
                                 <option value="PU">{{ __('general_content.purchase_order_trans_key') }}</option>
                                 <option value="PQ">{{ __('general_content.purchase_quotation_trans_key') }}</option>


### PR DESCRIPTION
### Motivation

- Allow creating purchase orders and quotations even when no request lines are selected so users can generate documents without having to attach lines first. 
- Ensure `code` and `label` are populated automatically when the component mounts or when the document type changes to avoid empty external IDs. 
- Retain required default settings and status validations while making line processing optional. 

### Description

- Moved default settings lookup and validation out of the `taskIds` guard so a purchase document is created regardless of selected lines in `storePurchase` in `app/Livewire/PurchasesRequest.php`.
- Only call `processPurchaseRequestLines` when `taskIds > 0`, making line processing conditional instead of required in `storePurchase`.
- Initialize document code/label by calling `changeDocument()` from `mount()` and added `updatedDocumentType()` to trigger `changeDocument()` on Livewire updates, and removed the brittle `wire:click.prevent="changeDocument()"` from the document type `<select>` in `resources/views/livewire/purchases-request.blade.php`.
- Files changed: `app/Livewire/PurchasesRequest.php` and `resources/views/livewire/purchases-request.blade.php`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696608fd0390832d9c0c10ddf987bb52)