### PR TITLE
Add select-all toggle for quote lines (Livewire)

### DIFF
--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -69,6 +69,7 @@ class QuoteLine extends Component
 
     public $data = [];
     public $customRequirements = [];
+    public $selectAllLines = false;
 
     protected $orderService;
 
@@ -153,6 +154,7 @@ class QuoteLine extends Component
                                                             ->where('label','like', '%'.$this->search.'%')->get();
 
         $this->loadProductCustomFields($QuoteLineslist);
+        $this->syncSelectAllState($QuoteLineslist->pluck('id'));
 
         foreach ($QuoteLineslist as $line) {
             $detail = $line->QuoteLineDetails;
@@ -164,6 +166,54 @@ class QuoteLine extends Component
         return view('livewire.quote-lines', [
             'QuoteLineslist' => $QuoteLineslist,
         ]);
+    }
+
+    public function toggleSelectAllLines(): void
+    {
+        $shouldSelect = ! $this->selectAllLines;
+        $lineIds = $this->getSelectableLineIds();
+
+        if ($shouldSelect) {
+            foreach ($lineIds as $lineId) {
+                $this->data[$lineId]['quote_line_id'] = $lineId;
+            }
+        } else {
+            foreach ($lineIds as $lineId) {
+                unset($this->data[$lineId]);
+            }
+        }
+
+        $this->selectAllLines = $shouldSelect;
+    }
+
+    private function syncSelectAllState($lineIds): void
+    {
+        if ($lineIds->isEmpty()) {
+            $this->selectAllLines = false;
+            return;
+        }
+
+        $this->selectAllLines = $lineIds->every(function ($lineId) {
+            return $this->isLineSelected((int) $lineId);
+        });
+    }
+
+    private function isLineSelected(int $lineId): bool
+    {
+        return isset($this->data[$lineId]['quote_line_id'])
+            && (int) $this->data[$lineId]['quote_line_id'] === $lineId;
+    }
+
+    private function getSelectableLineIds(): array
+    {
+        if ($this->QuoteLineslist) {
+            return $this->QuoteLineslist->pluck('id')->all();
+        }
+
+        return QuoteLines::where('quotes_id', '=', $this->quotes_id)
+            ->where('label', 'like', '%' . $this->search . '%')
+            ->pluck('id')
+            ->all();
     }
 
     private function initializeCustomRequirements(): void

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -761,6 +761,8 @@ return [
     'quotes_list_trans_key'                    => 'Quotes list',
     'quotes_lines_list_trans_key'              => 'Quotes lines list',
     'new_quote_trans_key'                      => 'New Quote',
+    'select_all_lines_trans_key'               => 'Select all',
+    'deselect_all_lines_trans_key'             => 'Deselect all',
     'header_line_ask_trans_key'                => 'Header line ?',
     'quote_not_open_trans_key'                 => 'Quote curently not open',
     'name_quote_trans_key'                     => 'Name of quote',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -761,6 +761,8 @@ return [
     'quotes_list_trans_key'                    => 'Liste des devis',
     'quotes_lines_list_trans_key'              => 'Lignes de devis',
     'new_quote_trans_key'                      => 'Nouveau devis',
+    'select_all_lines_trans_key'               => 'Tout sélectionner',
+    'deselect_all_lines_trans_key'             => 'Tout désélectionner',
     'header_line_ask_trans_key'                => 'En-tête ?',
     'quote_not_open_trans_key'                 => 'Devis actuellement non ouvert',
     'name_quote_trans_key'                     => 'Nom du devis',

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -603,6 +603,9 @@
                             <th>{{__('general_content.status_trans_key') }}</th>
                             <th></th>
                             <th >
+                                <button type="button" class="btn btn-outline-primary btn-sm mr-2" wire:click="toggleSelectAllLines">
+                                    {{ $selectAllLines ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
+                                </button>
                                 <a class="btn btn-primary btn-sm" wire:click="storeOrder({{ $QuoteId }})" href="#">
                                     <i class="fas fa-folder"></i>
                                     {{ __('general_content.new_order_trans_key') }}


### PR DESCRIPTION
### Motivation
- Speed up selection of many quote lines by providing a single "select all" control for Livewire-driven checkboxes. 
- Make it possible to toggle selection across the current filtered list of quote lines to simplify creating orders from many lines. 

### Description
- Added a new public property `selectAllLines` and selection-management methods `toggleSelectAllLines`, `syncSelectAllState`, `isLineSelected` and `getSelectableLineIds` to `App\Livewire\QuoteLine` to manage bulk selection state. 
- Call `syncSelectAllState` from `render()` so the select-all state reflects the currently loaded/filtered lines. 
- Added a select/deselect button to `resources/views/livewire/quote-lines.blade.php` that calls the `toggleSelectAllLines` Livewire action. 
- Added translation keys `select_all_lines_trans_key` and `deselect_all_lines_trans_key` in `resources/lang/en/general_content.php` and `resources/lang/fr/general_content.php`. 

### Testing
- No automated tests were executed for this change. 
- Manual verification was not included in automated test output. 
- There were no CI or `phpunit` runs recorded in this rollout. 
- The change was committed locally after applying the code edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696612910358832db12306814108d1ad)