### PR TITLE
Fix select-all checkbox behavior for quote lines

### DIFF
--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -175,7 +175,7 @@ class QuoteLine extends Component
 
         if ($shouldSelect) {
             foreach ($lineIds as $lineId) {
-                $this->data[$lineId]['quote_line_id'] = $lineId;
+                $this->data[$lineId]['quote_line_id'] = true;
             }
         } else {
             foreach ($lineIds as $lineId) {
@@ -200,8 +200,7 @@ class QuoteLine extends Component
 
     private function isLineSelected(int $lineId): bool
     {
-        return isset($this->data[$lineId]['quote_line_id'])
-            && (int) $this->data[$lineId]['quote_line_id'] === $lineId;
+        return !empty($this->data[$lineId]['quote_line_id']);
     }
 
     private function getSelectableLineIds(): array

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -579,7 +579,7 @@
                             </td>
                             <td>
                                 <div class="custom-control custom-checkbox">
-                                    <input class="custom-control-input" value="{{ $QuoteLine->id }}" wire:model.live="data.{{ $QuoteLine->id }}.quote_line_id" id="data.{{ $QuoteLine->id }}.quote_line_id"  type="checkbox">
+                                    <input class="custom-control-input" wire:model.live="data.{{ $QuoteLine->id }}.quote_line_id" id="data.{{ $QuoteLine->id }}.quote_line_id" type="checkbox">
                                     <label for="data.{{ $QuoteLine->id }}.quote_line_id" class="custom-control-label">+</label>
                                 </div>
                             </td>


### PR DESCRIPTION
### Motivation
- The global "select all" button did not correctly check individual Livewire-bound checkboxes because each checkbox stored the line ID string/value instead of a boolean, preventing proper two-way binding.
- The intent is to ensure the UI reflects selection state when toggling "select all" and that selected lines are detected reliably when creating an order.

### Description
- Changed `toggleSelectAllLines` to assign a boolean `true` for each selected line instead of the numeric line ID in `app/Livewire/QuoteLine.php`.
- Updated `isLineSelected` to return `!empty($this->data[$lineId]['quote_line_id'])` to detect selection by truthiness.
- Removed the `value="{{ $QuoteLine->id }}` attribute from the checkbox input in `resources/views/livewire/quote-lines.blade.php` so the Livewire binding uses boolean values.
- Modified files: `app/Livewire/QuoteLine.php` and `resources/views/livewire/quote-lines.blade.php`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696616100bb0832d872fc704c2abdb3e)