### PR TITLE
Add select-all for order lines

### DIFF
--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -76,6 +76,7 @@ class OrderLine extends Component
     public $customRequirements = [];
     public $RemoveFromStock = false;
     public $CreateSerialNumber = false;
+    public $selectAllLines = false;
     
     private $deleveryOrdre = 10;
     private $invoiceOrdre = 10;
@@ -175,6 +176,8 @@ class OrderLine extends Component
     {
         $OrderLineslist = $this->OrderLineslist = Orderlines::with('OrderLineDetails')->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->where('orders_id', '=', $this->orders_id)->where('label','like', '%'.$this->search.'%')->get();
 
+        $this->syncSelectAllState($this->getSelectableLineIds($OrderLineslist));
+
         foreach ($OrderLineslist as $line) {
             $detail = $line->OrderLineDetails;
             if ($detail && !array_key_exists($detail->id, $this->customRequirements)) {
@@ -185,6 +188,68 @@ class OrderLine extends Component
         return view('livewire.order-lines', [
             'OrderLineslist' => $OrderLineslist,
         ]);
+    }
+
+    public function toggleSelectAllLines(): void
+    {
+        $shouldSelect = ! $this->selectAllLines;
+        $lineIds = $this->getSelectableLineIds();
+
+        if ($shouldSelect) {
+            foreach ($lineIds as $lineId) {
+                $this->data[$lineId]['order_line_id'] = true;
+            }
+        } else {
+            foreach ($lineIds as $lineId) {
+                unset($this->data[$lineId]);
+            }
+        }
+
+        $this->selectAllLines = $shouldSelect;
+    }
+
+    private function syncSelectAllState(array $lineIds): void
+    {
+        if (empty($lineIds)) {
+            $this->selectAllLines = false;
+            return;
+        }
+
+        $this->selectAllLines = collect($lineIds)->every(function ($lineId) {
+            return $this->isLineSelected((int) $lineId);
+        });
+    }
+
+    private function isLineSelected(int $lineId): bool
+    {
+        return !empty($this->data[$lineId]['order_line_id']);
+    }
+
+    private function getSelectableLineIds($lines = null): array
+    {
+        if ($this->OrderStatu == 6 || $this->OrderType == 2) {
+            return [];
+        }
+
+        if ($lines) {
+            return $lines->filter(function ($line) {
+                return $this->isLineSelectable($line);
+            })->pluck('id')->all();
+        }
+
+        return OrderLines::where('orders_id', $this->orders_id)
+            ->whereNotIn('delivery_status', [3, 4])
+            ->pluck('id')
+            ->all();
+    }
+
+    private function isLineSelectable(OrderLines $line): bool
+    {
+        if ($this->OrderStatu == 6 || $this->OrderType == 2) {
+            return false;
+        }
+
+        return !in_array($line->delivery_status, [3, 4], true);
     }
 
     private function initializeCustomRequirements(): void

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -47,7 +47,13 @@
                             <th>{{ __('general_content.delivery_status_trans_key') }}</th>
                             <th>{{ __('general_content.invoice_status_trans_key') }}</th>
                             <th>{{__('general_content.action_trans_key') }}</th>
-                            <th></th>
+                            <th>
+                                @if($OrderStatu != 6 && $OrderType != 2)
+                                    <button type="button" class="btn btn-outline-primary btn-sm" wire:click="toggleSelectAllLines">
+                                        {{ $selectAllLines ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
+                                    </button>
+                                @endif
+                            </th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
### Motivation
- Provide a mass-select/deselect control for order lines similar to the existing quote-lines behavior so users can create deliveries/invoices for multiple lines at once.
- Ensure only selectable lines are affected (respecting order status and delivery statuses) to avoid selecting already delivered/canceled lines.

### Description
- Added `public $selectAllLines` and select-all helpers to `app/Livewire/OrderLine.php`, including `toggleSelectAllLines`, `syncSelectAllState`, `isLineSelected`, `getSelectableLineIds` and `isLineSelectable` to manage selection state and apply it only to eligible lines.
- Updated `render()` in `OrderLine` to synchronize the select-all button state with the current list via `syncSelectAllState` and to set/clear `data[$id]['order_line_id']` when toggling.
- Added a select-all button to the table header in `resources/views/livewire/order-lines.blade.php`, shown only when allowed (checks `OrderStatu` and `OrderType`) and localized using `general_content` keys.
- Selection excludes lines with delivery statuses `3` or `4`, and is disabled when `OrderStatu == 6` or `OrderType == 2` to match existing UI rules.

### Testing
- No automated tests were run for this change.
- No test failures reported because automated tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661eaa5684832d93c101ebfe00d425)