### PR TITLE
Show stopped/canceled order statuses in dashboard list

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -197,6 +197,8 @@
                   @if(2 == $LastOrder->statu )  <span class="badge badge-warning">{{ __('general_content.in_progress_trans_key') }}</span>@endif
                   @if(3 == $LastOrder->statu )  <span class="badge badge-success">{{ __('general_content.delivered_trans_key') }}</span>@endif
                   @if(4 == $LastOrder->statu )  <span class="badge badge-danger">{{ __('general_content.partly_delivered_trans_key') }}</span>@endif
+                  @if(5 == $LastOrder->statu )  <span class="badge badge-danger">{{ __('general_content.stopped_trans_key') }}</span>@endif
+                  @if(6 == $LastOrder->statu )  <span class="badge badge-warning">{{ __('general_content.canceled_trans_key') }}</span>@endif
                 </td>
                 <td>{{ $LastOrder->formatted_total_price }}</td>
                 <td>{{ $LastOrder->GetPrettyCreatedAttribute() }}</td>


### PR DESCRIPTION
### Motivation
- The dashboard latest orders table omitted some order statuses so the list did not match other views that display all statuses. 
- Orders can have `statu` values for "stopped" and "canceled" which should be represented with badges for consistency. 

### Description
- Added checks for `statu == 5` and `statu == 6` in `resources/views/dashboard.blade.php` to render the "stopped" and "canceled" badges. 
- No other files were modified and no business logic was changed. 

### Testing
- No automated unit or integration tests (`phpunit`) were run for this change. 
- An automated UI screenshot attempt using Playwright was executed but failed due to a Chromium headless crash (SIGSEGV), so no screenshot verification completed. 
- The change was committed and the modified file is `resources/views/dashboard.blade.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664bc3094c832da84ec02167f29e74)