### PR TITLE
Add dashboard KPIs: remaining-to-invoice (monthly) and 3-month forecast

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -155,11 +155,15 @@ class HomeController extends Controller
         $deliveredMonthInProgress = Number::currency($deliveredMonthInProgress->orderSum ?? 0, $currency, config('app.locale'));
                                                 
         $remainingDeliveryOrder =   $this->orderKPIService->getOrderMonthlyRemainingToDelivery($CurentMonth, $CurentYear);
+        $remainingInvoiceOrder =   $this->orderKPIService->getOrderMonthlyRemainingToInvoiceByMonth($CurentMonth, $CurentYear);
+        $forecastNextThreeMonths = $this->orderKPIService->getOrderForecastNextMonths(3, Carbon::create($CurentYear, $CurentMonth, 1));
 
         $orderTotalFormattedDelivered =   Number::currency($orderTotalDelivered ?? 0, $currency, config('app.locale'));
         $orderTotalFormattedInvoiced =   Number::currency($orderTotaInvoiced ?? 0, $currency, config('app.locale'));
         $FormattedEstimatedBudgets =   Number::currency($EstimatedBudgets ?? 0, $currency, config('app.locale'));
         $remainingDeliveryOrder =   Number::currency($remainingDeliveryOrder->orderSum ?? 0, $currency, config('app.locale'));
+        $remainingInvoiceOrder =   Number::currency($remainingInvoiceOrder->orderSum ?? 0, $currency, config('app.locale'));
+        $forecastNextThreeMonths =   Number::currency($forecastNextThreeMonths->orderSum ?? 0, $currency, config('app.locale'));
 
         return view('dashboard', [
             'userRoleCount' => $userRoleCount,
@@ -179,7 +183,9 @@ class HomeController extends Controller
             'EstimatedBudgets' => $EstimatedBudgets,
             'FormattedEstimatedBudgets' => $FormattedEstimatedBudgets,
             'deliveredMonthInProgress' => $deliveredMonthInProgress,
-            'remainingDeliveryOrder' => $remainingDeliveryOrder
+            'remainingDeliveryOrder' => $remainingDeliveryOrder,
+            'remainingInvoiceOrder' => $remainingInvoiceOrder,
+            'forecastNextThreeMonths' => $forecastNextThreeMonths
         ])->with('data',$data);
     }
 

--- a/app/Services/OrderKPIService.php
+++ b/app/Services/OrderKPIService.php
@@ -221,6 +221,79 @@ class OrderKPIService
     }
 
     /**
+     * Retrieves the monthly summary of orders remaining to invoice for a given month.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getOrderMonthlyRemainingToInvoiceByMonth($month, $year, $companyId = null)
+    {
+        $cacheKey = 'order_remaining_invoice_' . $year . '_month_' . $month . '_company_' . ($companyId ?? 'all');
+
+        return Cache::remember($cacheKey, now()->addMinutes(1), function () use ($companyId, $month, $year) {
+            $query = DB::table('order_lines')
+                        ->selectRaw('
+                            FLOOR(SUM((selling_price * invoiced_remaining_qty)-(selling_price * invoiced_remaining_qty)*(discount/100))) AS orderSum
+                        ')
+                        ->join('orders', 'order_lines.orders_id', '=', 'orders.id');
+
+                        $query->where(function ($subQuery) {
+                            $subQuery->where('order_lines.invoice_status', 1)
+                                        ->orWhere('order_lines.invoice_status', 2);
+                        })
+                        ->whereYear('order_lines.delivery_date', $year)
+                        ->whereMonth('order_lines.delivery_date', $month);
+
+                        if ($companyId) {
+                            $query->where('orders.companies_id', $companyId);
+                        }
+
+                        $result = $query->first();
+
+                        if (!$result || $result->orderSum === null) {
+                            return (object) ['orderSum' => 0];
+                        }
+
+                        return $result;
+        });
+    }
+
+    /**
+     * Retrieves the forecast total for the next months starting from a date.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getOrderForecastNextMonths($months = 3, $startDate = null)
+    {
+        $startDate = $startDate ? Carbon::parse($startDate)->startOfMonth() : now()->startOfMonth();
+        $endDate = (clone $startDate)->addMonths($months)->endOfMonth();
+        $cacheKey = 'order_forecast_next_months_' . $startDate->format('Y_m') . '_' . $months;
+
+        return Cache::remember($cacheKey, now()->addMinutes(10), function () use ($startDate, $endDate) {
+            $result = DB::table('order_lines')
+                        ->selectRaw('
+                            ROUND(SUM((selling_price * qty)-(selling_price * qty)*(discount/100)),2) AS orderSum
+                        ')
+                        ->leftJoin('orders', function($join) {
+                            $join->on('order_lines.orders_id', '=', 'orders.id')
+                                ->where('orders.type', '=', 1)
+                                ->where('orders.statu', '!=', 6);
+                        })
+                        ->whereIn('delivery_status', [1, 2])
+                        ->whereBetween('order_lines.delivery_date', [
+                            $startDate->toDateString(),
+                            $endDate->toDateString()
+                        ])
+                        ->first();
+
+            if (!$result || $result->orderSum === null) {
+                return (object) ['orderSum' => 0];
+            }
+
+            return $result;
+        });
+    }
+
+    /**
      * Retrieves the total amount summary of order for the comming current year.
      *
      * @return \Illuminate\Support\Collection

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -629,6 +629,8 @@ return [
     'order_to_be_delivered_trans_key'          => 'الطلبات للتسليم',
     'delivered_month_in_progress_trans_key'    => 'إجمالي التسليم للشهر',
     'remaining_month_trans_key'                => 'الإجمالي المتبقي للتسليم',
+    'remaining_invoice_month_trans_key'        => 'الإجمالي المتبقي للفوترة',
+    'forecast_next_three_months_trans_key'     => 'توقعات الأشهر الثلاثة القادمة',
 
     
     //COMPANIES

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -713,6 +713,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'Total Delivered for the month',
     'remaining_month_trans_key'                => 'Total remaining to deliver',
     'remaining_invoice_month_trans_key'        => 'Total remaining to invoice',
+    'forecast_next_three_months_trans_key'     => 'Forecast for the next 3 months',
     'service_rate_trans_key'                   => 'Service rate',
     'average_order_processing_time_trans_key'  => 'Average order processing time',
     'order_processing_time_trans_key'          => 'Processing time',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -629,6 +629,8 @@ return [
     'order_to_be_delivered_trans_key'          => 'Pedidos pendientes de entrega',
     'delivered_month_in_progress_trans_key'    => 'Total entregado en el mes',
     'remaining_month_trans_key'                => 'Total restante por entregar',
+    'remaining_invoice_month_trans_key'        => 'Total restante por facturar',
+    'forecast_next_three_months_trans_key'     => 'Pronóstico para los próximos 3 meses',
 
         
     //COMPANIES

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -713,6 +713,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'Total livré du mois',
     'remaining_month_trans_key'                => 'Total restant à livrer',
     'remaining_invoice_month_trans_key'        => 'Total restant à facturer',
+    'forecast_next_three_months_trans_key'     => 'Prévision pour les 3 prochains mois',
     'service_rate_trans_key'                   => 'Taux de service',
     'average_order_processing_time_trans_key'  => 'Temps moyen de traitement',
     'order_processing_time_trans_key'          => 'Temps de traitement',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -54,6 +54,8 @@ return [
     'order_to_be_delivered_trans_key'          => 'Đơn hàng phải giao',
     'delivered_month_in_progress_trans_key'    => 'Số đơn đã giao trong tháng',
     'remaining_month_trans_key'                => 'Số đơn phải giao',
+    'remaining_invoice_month_trans_key'        => 'Tổng còn lại cần xuất hóa đơn',
+    'forecast_next_three_months_trans_key'     => 'Dự báo cho 3 tháng tới',
     
 
     'companies_trans_key'                      => 'Công ty',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -703,6 +703,7 @@ return [
     'delivered_month_in_progress_trans_key'    => '本月已交付总计',
     'remaining_month_trans_key'                => '本月剩余交付',
     'remaining_invoice_month_trans_key'        => '本月剩余开票',
+    'forecast_next_three_months_trans_key'     => '未来3个月预测',
     'service_rate_trans_key'                   => '服务率',
     'average_order_processing_time_trans_key'  => '平均处理时间',
     'order_processing_time_trans_key'          => '处理时间',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -280,7 +280,7 @@
     </div>
 
     <!-- TABLE: DELIVERED -->
-    <div class="col-lg-6 col-md-12">
+    <div class="col-lg-3 col-md-6">
       <x-adminlte-small-box title="{{ $deliveredMonthInProgress }} " 
                           text="{{ __('general_content.delivered_month_in_progress_trans_key') }}" 
                           icon="icon fas fa-info"
@@ -288,11 +288,27 @@
                           url="{{ route('orders') }}" 
                           url-text="{{ __('general_content.view_details_trans_key') }}"/>
     </div>
-    <div class="col-lg-6 col-md-12">
+    <div class="col-lg-3 col-md-6">
       <x-adminlte-small-box title="{{ $remainingDeliveryOrder }} " 
                           text="{{ __('general_content.remaining_month_trans_key') }}" 
                           icon="icon fas fa-info"
                           theme="danger" 
+                          url="{{ route('orders') }}" 
+                          url-text="{{ __('general_content.view_details_trans_key') }}"/>
+    </div>
+    <div class="col-lg-3 col-md-6">
+      <x-adminlte-small-box title="{{ $remainingInvoiceOrder }} " 
+                          text="{{ __('general_content.remaining_invoice_month_trans_key') }}" 
+                          icon="icon fas fa-file-invoice-dollar"
+                          theme="info" 
+                          url="{{ route('invoices') }}" 
+                          url-text="{{ __('general_content.view_details_trans_key') }}"/>
+    </div>
+    <div class="col-lg-3 col-md-6">
+      <x-adminlte-small-box title="{{ $forecastNextThreeMonths }} " 
+                          text="{{ __('general_content.forecast_next_three_months_trans_key') }}" 
+                          icon="icon fas fa-chart-line"
+                          theme="teal" 
                           url="{{ route('orders') }}" 
                           url-text="{{ __('general_content.view_details_trans_key') }}"/>
     </div>


### PR DESCRIPTION
### Motivation
- Surface the total remaining amount to invoice for the current month and provide a short-term revenue forecast on the dashboard. 
- Provide KPI helpers to calculate monthly remaining-to-invoice and aggregate forecast for upcoming months for reporting and planning.

### Description
- Add `getOrderMonthlyRemainingToInvoiceByMonth($month, $year, $companyId = null)` and `getOrderForecastNextMonths($months = 3, $startDate = null)` to `app/Services/OrderKPIService.php` to compute invoice-remaining and forecast totals. 
- Expose the computed values in `HomeController` and format them with `Number::currency` before passing to the dashboard view. 
- Add two new dashboard tiles in `resources/views/dashboard.blade.php` for `remaining_invoice_month` and `forecast_next_three_months`. 
- Add localization strings for the new tiles in `resources/lang/*/general_content.php` (EN, FR, ES, AR, VI, ZH-CN).

### Testing
- Attempted to start the application with `php artisan serve`, but it failed because `vendor/autoload.php` was missing, so runtime verification could not be completed. 
- No automated test suite was executed for these changes. 
- Performed code inspection and repository searches to verify the new service methods, controller wiring, view variables, and translation keys are present and referenced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664c366b74832d8a1e88b18bab3e68)