### PR TITLE
Add Nest2Prod links to orders index view

### DIFF
--- a/resources/views/livewire/orders-index.blade.php
+++ b/resources/views/livewire/orders-index.blade.php
@@ -1,5 +1,8 @@
 
 <div>
+    @php
+        $nest2prodUrl = rtrim((string) app(\App\Services\Settings\SettingsService::class)->get('n2p_base_url'), '/');
+    @endphp
     <!-- Modal -->
     <div wire:ignore.self class="modal fade" id="ModalOrder" tabindex="-1" role="dialog" aria-labelledby="ModalOrderTitle" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
@@ -317,6 +320,11 @@
                                 <td>
                                     <x-ButtonTextView route="{{ route('orders.show', ['id' => $Order->id])}}" />
                                     <x-ButtonTextPDF route="{{ route('pdf.order', ['Document' => $Order->id])}}" />
+                                    @if($Order->statu != 1 && $nest2prodUrl !== '')
+                                        <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm">
+                                            <i class="fas fa-external-link-alt"></i> Nest2Prod
+                                        </a>
+                                    @endif
                                 </td>
                             </tr>
                             @empty
@@ -380,6 +388,11 @@
                                         </div>
                                         <div class="col-4">
                                             <x-ButtonTextView route="{{ route('orders.show', ['id' => $Order->id])}}" />
+                                            @if($Order->statu != 1 && $nest2prodUrl !== '')
+                                                <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm mt-1">
+                                                    <i class="fas fa-external-link-alt"></i>
+                                                </a>
+                                            @endif
                                         </div>
                                     </div>
                                 </div>
@@ -466,6 +479,11 @@
                                                             </div>
                                                             <div class="col-4">
                                                                 <x-ButtonTextView route="{{ route('orders.show', ['id' => $Order->id])}}" />
+                                                                @if($Order->statu != 1 && $nest2prodUrl !== '')
+                                                                    <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm mt-1">
+                                                                        <i class="fas fa-external-link-alt"></i>
+                                                                    </a>
+                                                                @endif
                                                             </div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
### Motivation
- Expose the Nest2Prod (N2P) public link on the orders index so users can open the corresponding Nest2Prod order directly from the list/cards/kanban, matching the logic already used on the order show page.

### Description
- Retrieve `n2p_base_url` from `SettingsService` and normalize it with `rtrim` at the top of `orders-index` Livewire view.
- Add a Nest2Prod action link in the table view action column that appears when the order is not in status `1` and the base URL is set.
- Add the same Nest2Prod button in the card footer and kanban card footer so the link is available in all three list views.
- Changed file: `resources/views/livewire/orders-index.blade.php`.

### Testing
- No automated tests were run for this UI-only change; manual inspection and commit were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c88b17ec832db485b5b41d490ea0)