### PR TITLE
Show delivery date status on orders index

### DIFF
--- a/resources/views/livewire/orders-index.blade.php
+++ b/resources/views/livewire/orders-index.blade.php
@@ -273,7 +273,9 @@
                                 <th>
                                     <a class="btn btn-secondary" wire:click.prevent="sortBy('companies_id')"   role="button" href="#">{{__('general_content.customer_trans_key') }} @include('include.sort-icon', ['field' => 'companies_id'])</a>
                                 </th>
-                                <th>{{__('general_content.code_trans_key') }}</th>
+                                <th>
+                                    <a class="btn btn-secondary" wire:click.prevent="sortBy('validity_date')" role="button" href="#">{{ __('general_content.delivery_date_trans_key') }} @include('include.sort-icon', ['field' => 'validity_date'])</a>
+                                </th>
                                 <th>{{__('general_content.lines_count_trans_key') }}</th>
                                 <th>{{ __('general_content.progress_trans_key') }}</th>
                                 <th>{{__('general_content.total_price_trans_key') }}</th>
@@ -297,7 +299,28 @@
                                     {{ __('general_content.internal_order_trans_key') }}
                                     @endif
                                 </td>
-                                <td>{{ $Order->customer_reference }}</td>
+                                <td>
+                                    @php
+                                        $deliveryDate = $Order->validity_date ? \Carbon\Carbon::parse($Order->validity_date) : null;
+                                        $today = \Carbon\Carbon::today();
+                                        $deliveryBadgeClass = 'badge-secondary';
+
+                                        if ($deliveryDate) {
+                                            if ($deliveryDate->lt($today)) {
+                                                $deliveryBadgeClass = 'badge-danger';
+                                            } elseif ($deliveryDate->equalTo($today)) {
+                                                $deliveryBadgeClass = 'badge-warning';
+                                            } else {
+                                                $deliveryBadgeClass = 'badge-success';
+                                            }
+                                        }
+                                    @endphp
+                                    @if($deliveryDate)
+                                        <span class="badge {{ $deliveryBadgeClass }}">{{ $deliveryDate->format('d/m/Y') }}</span>
+                                    @else
+                                        <span class="text-muted">-</span>
+                                    @endif
+                                </td>
                                 <td>{{ $Order->order_lines_count }}</td>
                                 <td><x-adminlte-progress theme="teal" value="{{ $Order->getAveragePercentProgressLinesAttribute() }}" with-label animated/></td>
                                 <td>{{ $Order->formatted_total_price }}</td>
@@ -336,7 +359,7 @@
                                 <th>{{__('general_content.id_trans_key') }}</th>
                                 <th>{{__('general_content.label_trans_key') }}</th>
                                 <th>{{__('general_content.customer_trans_key') }}</th>
-                                <th>{{__('general_content.code_trans_key') }}</th>
+                                <th>{{ __('general_content.delivery_date_trans_key') }}</th>
                                 <th>{{__('general_content.lines_count_trans_key') }}</th>
                                 <th>{{ __('general_content.progress_trans_key') }}</th>
                                 <th>{{__('general_content.total_price_trans_key') }}</th>


### PR DESCRIPTION
### Motivation
- Replace the existing project reference column in the orders table with a delivery date to surface delivery information directly in the orders list.
- Provide quick visual status (late/today/future) using colored badges to help users identify delayed or imminent deliveries.
- Make the delivery date sortable so users can order the list by delivery schedule.

### Description
- Updated `resources/views/livewire/orders-index.blade.php` to replace the previous `code`/project reference column with a delivery date column that sorts by `validity_date` using `sortBy('validity_date')`.
- Render the order delivery date from `Order->validity_date` and display it as a badge with color logic: red for past dates, orange for today, and green for future dates, falling back to a muted dash when no date is set.
- Added the delivery date column header to the table footer so header/footer remain consistent and included the sort icon include (`include.sort-icon`) for the new column.

### Testing
- No automated test suite was executed for this change.
- An attempt to run the app with `php artisan serve` was made but failed due to missing dependencies (`vendor/autoload.php`), so runtime verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cd82f718832dbf8e227f60ab34da)