### PR TITLE
Allow multiple suppliers on services

### DIFF
--- a/app/Http/Controllers/Methods/ServicesController.php
+++ b/app/Http/Controllers/Methods/ServicesController.php
@@ -24,7 +24,7 @@ class ServicesController extends Controller
      */
     public function index()
     {
-        $MethodsServices = MethodsServices::orderBy('ordre')->get();
+        $MethodsServices = MethodsServices::with('Suppliers')->orderBy('ordre')->get();
         $CompanieSelect = $this->SelectDataService->getSupplier();
         return view('methods/methods-services', [
             'MethodsServices' => $MethodsServices,
@@ -40,7 +40,15 @@ class ServicesController extends Controller
      */
     public function store(StoreServicesRequest $request)
     {
-        $Service =  MethodsServices::create($request->only('code','ordre', 'label','type', 'hourly_rate','margin', 'color', 'companies_id'));
+        $supplierIds = collect($request->input('companies_ids', []))
+            ->filter()
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values();
+        $serviceData = $request->only('code', 'ordre', 'label', 'type', 'hourly_rate', 'margin', 'color');
+        $serviceData['companies_id'] = $supplierIds->first();
+        $Service = MethodsServices::create($serviceData);
+        $Service->Suppliers()->sync($supplierIds);
         
         if($request->hasFile('picture')){
             $Service = MethodsServices::findOrFail($Service->id);
@@ -66,7 +74,7 @@ class ServicesController extends Controller
     public function show($id)
     {
         $factory = app('Factory');  
-        $service = MethodsServices::findOrFail($id);
+        $service = MethodsServices::with('Suppliers')->findOrFail($id);
         return view('methods/methods-services-show', [
             'service' => $service,
             'factory' => $factory,
@@ -82,7 +90,15 @@ class ServicesController extends Controller
     public function update(UpdateServicesRequest $request)
     {
         $service = MethodsServices::findOrFail($request->id);
-        $service->update($request->only(['ordre', 'label', 'type', 'hourly_rate', 'margin', 'color', 'companies_id']));
+        $supplierIds = collect($request->input('companies_ids', []))
+            ->filter()
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values();
+        $serviceData = $request->only(['ordre', 'label', 'type', 'hourly_rate', 'margin', 'color']);
+        $serviceData['companies_id'] = $supplierIds->first();
+        $service->update($serviceData);
+        $service->Suppliers()->sync($supplierIds);
         return redirect()->route('methods.service')->with('success', 'Successfully updated service.');
     }
 

--- a/app/Http/Requests/Methods/StoreServicesRequest.php
+++ b/app/Http/Requests/Methods/StoreServicesRequest.php
@@ -31,6 +31,8 @@ class StoreServicesRequest extends FormRequest
             'hourly_rate'=>'required',
             'margin'=>'required',
             'picture'=>'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'companies_ids' => 'nullable|array',
+            'companies_ids.*' => 'integer|exists:companies,id',
         ];
     }
 }

--- a/app/Http/Requests/Methods/UpdateServicesRequest.php
+++ b/app/Http/Requests/Methods/UpdateServicesRequest.php
@@ -29,6 +29,8 @@ class UpdateServicesRequest extends FormRequest
             'hourly_rate'=>'required',
             'margin'=>'required',
             'picture'=>'image|mimes:jpeg,png,jpg,gif,svg|max:10240',
+            'companies_ids' => 'nullable|array',
+            'companies_ids.*' => 'integer|exists:companies,id',
         ];
     }
 }

--- a/app/Models/Methods/MethodsServices.php
+++ b/app/Models/Methods/MethodsServices.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Methods;
 
+use App\Models\Companies\Companies;
 use App\Models\Products\Products;
 use App\Models\Methods\MethodsFamilies;
 use Illuminate\Database\Eloquent\Model;
@@ -40,6 +41,12 @@ class MethodsServices extends Model
     public function Tasks()
     {
         return $this->hasMany(Task::class);
+    }
+
+    public function Suppliers()
+    {
+        return $this->belongsToMany(Companies::class, 'methods_service_suppliers', 'methods_service_id', 'companies_id')
+            ->withTimestamps();
     }
 
     /**

--- a/database/migrations/2025_02_14_120000_create_methods_service_suppliers_table.php
+++ b/database/migrations/2025_02_14_120000_create_methods_service_suppliers_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('methods_service_suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('methods_service_id')->constrained('methods_services')->cascadeOnDelete();
+            $table->foreignId('companies_id')->constrained('companies')->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['methods_service_id', 'companies_id']);
+        });
+
+        $services = DB::table('methods_services')
+            ->select('id', 'companies_id')
+            ->whereNotNull('companies_id')
+            ->get();
+
+        foreach ($services as $service) {
+            if (!is_numeric($service->companies_id)) {
+                continue;
+            }
+
+            DB::table('methods_service_suppliers')->insert([
+                'methods_service_id' => $service->id,
+                'companies_id' => (int) $service->companies_id,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('methods_service_suppliers');
+    }
+};

--- a/database/migrations/2025_02_14_120000_create_methods_service_suppliers_table.php
+++ b/database/migrations/2025_02_14_120000_create_methods_service_suppliers_table.php
@@ -21,15 +21,13 @@ return new class extends Migration
         });
 
         $services = DB::table('methods_services')
-            ->select('id', 'companies_id')
-            ->whereNotNull('companies_id')
+            ->select('methods_services.id', 'methods_services.companies_id')
+            ->whereNotNull('methods_services.companies_id')
+            ->whereRaw('methods_services.companies_id REGEXP "^[0-9]+$"')
+            ->join('companies', 'companies.id', '=', DB::raw('methods_services.companies_id'))
             ->get();
 
         foreach ($services as $service) {
-            if (!is_numeric($service->companies_id)) {
-                continue;
-            }
-
             DB::table('methods_service_suppliers')->insert([
                 'methods_service_id' => $service->id,
                 'companies_id' => (int) $service->companies_id,

--- a/resources/views/methods/methods-services-show.blade.php
+++ b/resources/views/methods/methods-services-show.blade.php
@@ -18,6 +18,13 @@
             <p><strong>Type :</strong> {{ $service->type }}</p>
             <p><strong>Taux Horaire :</strong> {{ number_format($service->hourly_rate, 2, ',', ' ') }} {{ $factory->curency }}</p>
             <p><strong>Marge :</strong> {{ number_format($service->margin, 2, ',', ' ') }} %</p>
+            <p><strong>{{ __('general_content.supplier_trans_key') }} :</strong>
+              @if($service->Suppliers->isNotEmpty())
+                {{ $service->Suppliers->pluck('label')->implode(', ') }}
+              @else
+                -
+              @endif
+            </p>
             <p><strong>Créé le :</strong> {{ $service->getPrettyCreatedAttribute() }}</p>
 
             <div class="card-footer">

--- a/resources/views/methods/methods-services.blade.php
+++ b/resources/views/methods/methods-services.blade.php
@@ -121,13 +121,13 @@
                           <input type="color" class="form-control"  name="color" id="color" value="{{ $MethodsService->color }}">
                         </div>
                         <div class="form-group">
-                          <label for="companies_id_{{ $MethodsService->id }}">{{ __('general_content.supplier_trans_key') }}</label>
-                            <select class="form-control" name="companies_id" id="companies_id_{{ $MethodsService->id }}">
-                              <option value="NULL">-</option>
+                          @php($selectedSuppliers = $MethodsService->Suppliers->pluck('id')->all())
+                          <label for="companies_ids_{{ $MethodsService->id }}">{{ __('general_content.supplier_trans_key') }}</label>
+                            <select class="form-control" name="companies_ids[]" id="companies_ids_{{ $MethodsService->id }}" multiple>
                               @forelse ($CompanieSelect as $item)
-                              <option value="{{ $item->id }}" @if($MethodsService->companies_id == $item->id  ) Selected @endif>{{ $item->label }}</option>
+                              <option value="{{ $item->id }}" @if(in_array($item->id, $selectedSuppliers, true)) Selected @endif>{{ $item->label }}</option>
                               @empty
-                              <option value="NULL">{{ __('general_content.no_select_company_trans_key') }}</option>
+                              <option value="" disabled>{{ __('general_content.no_select_company_trans_key') }}</option>
                               @endforelse
                             </select>
                         </div>
@@ -264,7 +264,14 @@
                 </div>
             </div>
             <div class="form-group">
-              @include('include.form.form-select-companie',['companiesId' =>  null])
+              <label for="companies_ids">{{ __('general_content.supplier_trans_key') }}</label>
+              <select class="form-control" name="companies_ids[]" id="companies_ids" multiple>
+                @forelse ($CompanieSelect as $item)
+                  <option value="{{ $item->id }}">{{ $item->label }}</option>
+                @empty
+                  <option value="" disabled>{{ __('general_content.no_select_company_trans_key') }}</option>
+                @endforelse
+              </select>
             </div>
           <!-- /.form-group -->
           </div>


### PR DESCRIPTION
### Motivation
- Services currently store a single supplier via `companies_id`, but a service may be linked to multiple suppliers and the model and UI need to support that while preserving existing links.
- Provide a dedicated pivot table to model many-to-many supplier relationships and migrate existing single-supplier data into it.

### Description
- Add a pivot table and migration `methods_service_suppliers` that creates `methods_service_id` / `companies_id` pairs and migrates existing `companies_id` values from `methods_services` into the new table.
- Add a `Suppliers()` `belongsToMany` relation to `App\Models\Methods\MethodsServices` to expose linked suppliers via the pivot table.
- Update `App\Http\Controllers\Methods\ServicesController` to accept `companies_ids[]`, compute a primary `companies_id` (first selected) for backward compatibility, and `sync()` the full supplier list on create/update, and eager-load the `Suppliers` relation in `index`/`show`.
- Add validation rules for `companies_ids` in `StoreServicesRequest` and `UpdateServicesRequest`, and update views `resources/views/methods/methods-services.blade.php` and `methods-services-show.blade.php` to provide a multi-select supplier input and display all linked suppliers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ccef372c832db3ed89a558058c89)