### PR TITLE
Remplacer le bouton « sélectionner tout » par une case à cocher

### DIFF
--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -49,9 +49,18 @@
                             <th>{{__('general_content.action_trans_key') }}</th>
                             <th>
                                 @if($OrderStatu != 6 && $OrderType != 2)
-                                    <button type="button" class="btn btn-outline-primary btn-sm" wire:click="toggleSelectAllLines">
-                                        {{ $selectAllLines ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
-                                    </button>
+                                    <div class="custom-control custom-checkbox">
+                                        <input
+                                            class="custom-control-input"
+                                            id="select-all-order-lines"
+                                            type="checkbox"
+                                            wire:click="toggleSelectAllLines"
+                                            @checked($selectAllLines)
+                                        >
+                                        <label class="custom-control-label" for="select-all-order-lines">
+                                            {{ $selectAllLines ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
+                                        </label>
+                                    </div>
                                 @endif
                             </th>
                         </tr>

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -603,9 +603,18 @@
                             <th>{{__('general_content.status_trans_key') }}</th>
                             <th></th>
                             <th >
-                                <button type="button" class="btn btn-outline-primary btn-sm mr-2" wire:click="toggleSelectAllLines">
-                                    {{ $selectAllLines ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
-                                </button>
+                                <div class="custom-control custom-checkbox d-inline-block mr-2">
+                                    <input
+                                        class="custom-control-input"
+                                        id="select-all-quote-lines"
+                                        type="checkbox"
+                                        wire:click="toggleSelectAllLines"
+                                        @checked($selectAllLines)
+                                    >
+                                    <label class="custom-control-label" for="select-all-quote-lines">
+                                        {{ $selectAllLines ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
+                                    </label>
+                                </div>
                                 <a class="btn btn-primary btn-sm" wire:click="storeOrder({{ $QuoteId }})" href="#">
                                     <i class="fas fa-folder"></i>
                                     {{ __('general_content.new_order_trans_key') }}


### PR DESCRIPTION
### Motivation
- Simplifier l'interface des lignes de devis/commande en remplaçant le bouton "Tout sélectionner" par une case à cocher plus standard. 
- Conserver le même comportement Livewire (`toggleSelectAllLines`) tout en rendant l'action plus ergonomique.

### Description
- Remplacé le bouton dans l'en-tête du tableau des lignes de commande par une case à cocher HTML avec `id="select-all-order-lines"` et `wire:click="toggleSelectAllLines"` in `resources/views/livewire/order-lines.blade.php`.
- Remplacé le bouton dans le pied de tableau des lignes de devis par une case à cocher HTML avec `id="select-all-quote-lines"` et `wire:click="toggleSelectAllLines"` in `resources/views/livewire/quote-lines.blade.php`.
- Les cases utilisent `@checked($selectAllLines)` pour refléter l'état courant et conservent les libellés de traduction existants (`select_all_lines_trans_key` / `deselect_all_lines_trans_key`).

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d330e2e4832dab6c21298fb3db12)