### PR TITLE
Guard quote line drawing link against missing product

### DIFF
--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -474,7 +474,7 @@
                                         </x-adminlte-modal>
                                     </div>
                                     <div class="input-group-prepend">
-                                        @if( $QuoteLine->product_id && $QuoteLine->Product->drawing_file)
+                                        @if($QuoteLine->product_id && $QuoteLine->Product && $QuoteLine->Product->drawing_file)
                                             <!-- Drawing link -->
                                             <x-button-text-view :bankFile="$QuoteLine->Product->drawing_file" />
                                         @endif


### PR DESCRIPTION
### Motivation
- Prevent a runtime error when rendering quote lines by ensuring the related `Product` relation exists before accessing its `drawing_file` property.

### Description
- Add a null-check to the conditional in `resources/views/livewire/quote-lines.blade.php` so it now verifies ` $QuoteLine->Product` before accessing ` $QuoteLine->Product->drawing_file`.

### Testing
- No automated tests were run for this view-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69674ba9ccd0832d852c9bacc16f28a1)