### PR TITLE
Add sheet metal global needs CSV button to purchase request view

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -381,6 +381,8 @@ return [
     'new_invoice_document_trans_key'    => 'مستند فاتورة جديد',
     'new_purchase_document_trans_key'   => 'مستند شراء جديد',
     'export_csv_trans_key'              => 'تصدير CSV',
+    'sheet_metal_global_need_csv_trans_key' => 'CSV لتقدير الاحتياج العالمي للصفائح المعدنية',
+    'sheet_metal_global_need_csv_hint_trans_key' => 'تصدير CSV لتقدير الاحتياج العالمي للصفائح المعدنية.',
     'open_orders_not_started_trans_key' => 'طلبات مفتوحة / مهام غير مبدوءة',
     'open_orders_not_started_hint_trans_key' => 'تصدير أسطر الطلبات المفتوحة مع المهام غير المبدوءة.',
     

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -438,6 +438,8 @@ return [
     'new_invoice_document_trans_key'           => 'New invoice document',
     'new_purchase_document_trans_key'          => 'New purchase document',
     'export_csv_trans_key'                     => 'Export CSV',
+    'sheet_metal_global_need_csv_trans_key'    => 'CSV for global sheet metal needs estimate',
+    'sheet_metal_global_need_csv_hint_trans_key' => 'Export a CSV to estimate the global sheet metal needs.',
     'open_orders_not_started_trans_key'        => 'Open orders / not started tasks',
     'open_orders_not_started_hint_trans_key'   => 'Export lines from open orders with not started tasks.',
     

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -378,6 +378,8 @@ return [
     'new_invoice_document_trans_key'           => 'Nuevo documento de factura',
     'new_purchase_document_trans_key'          => 'Nuevo documento de compra',
     'export_csv_trans_key'                     => 'Exportar CSV',
+    'sheet_metal_global_need_csv_trans_key'    => 'CSV para estimar la necesidad global de chapa',
+    'sheet_metal_global_need_csv_hint_trans_key' => 'Exportar un CSV para estimar la necesidad global de chapa.',
     'open_orders_not_started_trans_key'        => 'Pedidos abiertos / tareas no iniciadas',
     'open_orders_not_started_hint_trans_key'   => 'Exportar líneas de pedidos abiertos con tareas no iniciadas.',
 

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -438,6 +438,8 @@ return [
     'new_invoice_document_trans_key'           => 'Nouvelle facture',
     'new_purchase_document_trans_key'          => 'Nouvelle commande d\'achat',
     'export_csv_trans_key'                     => 'Exporter CSV',
+    'sheet_metal_global_need_csv_trans_key'    => 'CSV pour estimation du besoin de tôle globale',
+    'sheet_metal_global_need_csv_hint_trans_key' => 'Exporter un CSV pour estimer le besoin global en tôle.',
     'open_orders_not_started_trans_key'        => 'Commandes ouvertes / tâches non commencées',
     'open_orders_not_started_hint_trans_key'   => 'Exporter les lignes des commandes ouvertes avec tâches non commencées.',
 

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -428,6 +428,8 @@ return [
     'new_invoice_document_trans_key'           => '新建发票',
     'new_purchase_document_trans_key'          => '新建采购单',
     'export_csv_trans_key'                     => '导出 CSV',
+    'sheet_metal_global_need_csv_trans_key'    => '用于估算全局板材需求的 CSV',
+    'sheet_metal_global_need_csv_hint_trans_key' => '导出 CSV 以估算全局板材需求。',
     'open_orders_not_started_trans_key'        => '开放订单 / 未开始任务',
     'open_orders_not_started_hint_trans_key'   => '导出包含未开始任务的开放订单行。',
 

--- a/resources/views/livewire/purchases-request.blade.php
+++ b/resources/views/livewire/purchases-request.blade.php
@@ -63,6 +63,15 @@
                         </div>
                     </div>
                     <div class="form-group col-md-4">
+                        <label for="sheet-metal-global-need">{{ __('general_content.sheet_metal_global_need_csv_trans_key') }}</label>
+                        <button type="button" id="sheet-metal-global-need" wire:click="exportOpenOrderNotStartedCsv" class="btn btn-outline-info btn-block">
+                            <i class="fas fa-file-csv mr-1"></i>
+                            {{ __('general_content.export_csv_trans_key') }}
+                            <span class="badge badge-light ml-2">{{ $openOrderNotStartedCount }}</span>
+                        </button>
+                        <small class="form-text text-muted">{{ __('general_content.sheet_metal_global_need_csv_hint_trans_key') }}</small>
+                    </div>
+                    <div class="form-group col-md-4">
                         <label for="open-order-not-started">{{ __('general_content.open_orders_not_started_trans_key') }}</label>
                         <button type="button" id="open-order-not-started" wire:click="exportOpenOrderNotStartedCsv" class="btn btn-outline-info btn-block">
                             <i class="fas fa-file-csv mr-1"></i>


### PR DESCRIPTION
### Motivation
- Add a UI control to allow exporting a CSV for estimating global sheet metal needs and place it before the existing "Open orders / not started tasks" CSV action on the purchase request screen.

### Description
- Inserted a new section in `resources/views/livewire/purchases-request.blade.php` that renders a labeled button and hint for the sheet metal needs CSV, placed before the existing open-orders export button.
- The new button currently invokes the same Livewire action (`exportOpenOrderNotStartedCsv`) and displays the same count badge variable (`$openOrderNotStartedCount`).
- Added translation keys `sheet_metal_global_need_csv_trans_key` and `sheet_metal_global_need_csv_hint_trans_key` to language files in English, French, Spanish, Arabic and Chinese: `resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`, `resources/lang/es/general_content.php`, `resources/lang/ar/general_content.php`, and `resources/lang/zh-CN/general_content.php`.
- Changes staged: `resources/views/livewire/purchases-request.blade.php`, `resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`, `resources/lang/es/general_content.php`, `resources/lang/ar/general_content.php`, `resources/lang/zh-CN/general_content.php`.

### Testing
- Attempted to start the application with `php artisan serve --host=0.0.0.0 --port=8000`, which failed with a missing `vendor/autoload.php` error so the runtime test did not complete (failure).
- No automated unit or feature tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69674ea0e9d0832db27267d696d67ab0)