### PR TITLE
Add `planned_trans_key` translation across locales

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -12,6 +12,7 @@ return [
     'closed_trans_key'                         => 'مغلق',
     'obsolete_trans_key'                       => 'مهمل',
     'started_trans_key'                        => 'بدأ',
+    'planned_trans_key'                        => 'مخطط',
     'in_progress_trans_key'                    => 'قيد التقدم',
     'finished_trans_key'                       => 'منتهي',
     'suspended_trans_key'                      => 'معلق',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -12,6 +12,7 @@ return [
     'closed_trans_key'                         => 'Closed',
     'obsolete_trans_key'                       => 'Obsolete',
     'started_trans_key'                        => 'Started',
+    'planned_trans_key'                        => 'Planned',
     'in_progress_trans_key'                    => 'In Progress',
     'finished_trans_key'                       => 'Finished',
     'suspended_trans_key'                      => 'Suspended',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -12,6 +12,7 @@ return [
     'closed_trans_key'                         => 'Cerrado',
     'obsolete_trans_key'                       => 'Obsoleto',
     'started_trans_key'                        => 'Empezado',
+    'planned_trans_key'                        => 'Prevista',
     'in_progress_trans_key'                    => 'En progreso',
     'finished_trans_key'                       => 'Terminado',
     'suspended_trans_key'                      => 'Suspendido',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -12,6 +12,7 @@ return [
     'closed_trans_key'                         => 'Fermée',
     'obsolete_trans_key'                       => 'Obselète',
     'started_trans_key'                        => 'Démarer',
+    'planned_trans_key'                        => 'Prévue',
     'in_progress_trans_key'                    => 'En cours',
     'finished_trans_key'                       => 'Fini',
     'suspended_trans_key'                      => 'Suspendue',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -4,6 +4,7 @@ return [
     //STATUS
     'open_trans_key'                           => 'Mở',
     'started_trans_key'                        => 'Đã bắt đầu',
+    'planned_trans_key'                        => 'Dự kiến',
     'in_progress_trans_key'                    => 'Tiến trình',
     'finished_trans_key'                       => 'Đã kết thúc',
     'delivered_trans_key'                      => 'Đã giao hàng',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -12,6 +12,7 @@ return [
     'closed_trans_key'                         => '已关闭',
     'obsolete_trans_key'                       => '过时',
     'started_trans_key'                        => '已开始',
+    'planned_trans_key'                        => '计划',
     'in_progress_trans_key'                    => '进行中',
     'finished_trans_key'                       => '已完成',
     'suspended_trans_key'                      => '已暂停',


### PR DESCRIPTION
### Motivation

- Introduce a dedicated translation key for the "Planned" status so the UI can display a localized label for planned items.
- Ensure consistency across supported locales by adding the key to the main `general_content.php` language files.

### Description

- Added the `planned_trans_key` entry right after `started_trans_key` in `resources/lang/en/general_content.php` with value `Planned`.
- Added `planned_trans_key` to the French, Spanish, Arabic, Vietnamese and Chinese general language files with values `Prévue`, `Prevista`, `مخطط`, `Dự kiến`, and `计划` respectively.
- Changes were made only in `resources/lang/*/general_content.php` files and do not alter runtime logic.

### Testing

- No automated tests were run because this is a translation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676581f17c832dab11b86b4ec8773c)