### PR TITLE
Neutralize 'Realized' color and add red/green highlighting for gaps in business balance

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -207,9 +207,9 @@
     color: #0b1f2a;
 }
 
-.business-balance-table__group--danger {
-    background-color: #e76161;
-    color: #3a0f0f;
+.business-balance-table__group--neutral {
+    background-color: #d7dde5;
+    color: #1f2933;
 }
 
 .business-balance-table__group--warning {
@@ -231,14 +231,24 @@
     background-color: #e6f5ff;
 }
 
-.business-balance-table__subhead--danger,
-.business-balance-table__cell--danger {
-    background-color: #fde9e9;
+.business-balance-table__subhead--neutral,
+.business-balance-table__cell--neutral {
+    background-color: #eff2f6;
 }
 
 .business-balance-table__subhead--warning,
 .business-balance-table__cell--warning {
     background-color: #fff2e2;
+}
+
+.business-balance-table__cell--gap-positive {
+    background-color: #e6f7ed;
+    color: #0f3d1e;
+}
+
+.business-balance-table__cell--gap-negative {
+    background-color: #fde9e9;
+    color: #3a0f0f;
 }
 
 .business-balance-table__service-cell {
@@ -253,6 +263,16 @@
 .business-balance-table__total-row td {
     background-color: #f0f1f5;
     font-weight: 600;
+}
+
+.business-balance-table__total-row .business-balance-table__cell--gap-positive {
+    background-color: #d8f3e3;
+    color: #0f3d1e;
+}
+
+.business-balance-table__total-row .business-balance-table__cell--gap-negative {
+    background-color: #f9d6d6;
+    color: #3a0f0f;
 }
 
 .business-balance-info {

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -358,7 +358,7 @@
                 <tr class="business-balance-table__group-row">
                     <th></th>
                     <th colspan="3" class="business-balance-table__group business-balance-table__group--info">{{ __('general_content.manufacturing_range_trans_key') }}</th>
-                    <th colspan="2" class="business-balance-table__group business-balance-table__group--danger">{{ __('general_content.accomplished_trans_key') }}</th>
+                    <th colspan="2" class="business-balance-table__group business-balance-table__group--neutral">{{ __('general_content.accomplished_trans_key') }}</th>
                     <th colspan="2" class="business-balance-table__group business-balance-table__group--warning">{{ __('general_content.gap_trans_key') }}</th>
                 </tr>
                   <tr class="business-balance-table__subhead-row">
@@ -366,8 +366,8 @@
                       <th class="business-balance-table__subhead business-balance-table__subhead--info">{{ __('general_content.hours_trans_key') }}</th>
                       <th class="business-balance-table__subhead business-balance-table__subhead--info">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
                       <th class="business-balance-table__subhead business-balance-table__subhead--info">{{ __('general_content.selling_price_trans_key') }} ({{ $Factory->curency }})</th>
-                      <th class="business-balance-table__subhead business-balance-table__subhead--danger">{{ __('general_content.hours_trans_key') }}</th>
-                      <th class="business-balance-table__subhead business-balance-table__subhead--danger">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--neutral">{{ __('general_content.hours_trans_key') }}</th>
+                      <th class="business-balance-table__subhead business-balance-table__subhead--neutral">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
                       <th class="business-balance-table__subhead business-balance-table__subhead--warning">{{ __('general_content.hours_trans_key') }}</th>
                       <th class="business-balance-table__subhead business-balance-table__subhead--warning">{{ __('general_content.cost_trans_key') }} ({{ $Factory->curency }})</th>
                   </tr>
@@ -379,10 +379,10 @@
                           <td class="business-balance-table__cell business-balance-table__cell--info">{{ $data['total_hours'] }} h</td>
                           <td class="business-balance-table__cell business-balance-table__cell--info">{{ $data['total_display_cost'] }}</td>
                           <td class="business-balance-table__cell business-balance-table__cell--info">{{ $data['total_display_price'] }}</td>
-                          <td class="business-balance-table__cell business-balance-table__cell--danger">{{ $data['realized_hours'] }} h</td>
-                          <td class="business-balance-table__cell business-balance-table__cell--danger">{{ $data['realized_display_cost'] }}</td>
-                          <td class="business-balance-table__cell business-balance-table__cell--warning">{{ $data['difference_hours'] }} h</td>
-                          <td class="business-balance-table__cell business-balance-table__cell--warning">{{ $data['difference_display_cost'] }}</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--neutral">{{ $data['realized_hours'] }} h</td>
+                          <td class="business-balance-table__cell business-balance-table__cell--neutral">{{ $data['realized_display_cost'] }}</td>
+                          <td class="business-balance-table__cell {{ $data['difference_hours'] >= 0 ? 'business-balance-table__cell--gap-positive' : 'business-balance-table__cell--gap-negative' }}">{{ $data['difference_hours'] }} h</td>
+                          <td class="business-balance-table__cell {{ $data['difference_cost'] >= 0 ? 'business-balance-table__cell--gap-positive' : 'business-balance-table__cell--gap-negative' }}">{{ $data['difference_display_cost'] }}</td>
                       </tr>
                   @empty
                   <x-EmptyDataLine col="14" text="{{ __('general_content.no_data_trans_key') }}"  />
@@ -396,8 +396,8 @@
                   <td><strong>{{ $businessBalancetotals['total_display_price'] }} </strong></td>
                   <td><strong>{{ $businessBalancetotals['realized_hours'] }} h</strong></td>
                   <td><strong>{{ $businessBalancetotals['realized_display_cost'] }} </strong></td>
-                  <td><strong>{{ $businessBalancetotals['difference_hours'] }} h</strong></td>
-                  <td><strong>{{ $businessBalancetotals['difference_display_cost'] }} </strong></td>
+                  <td class="business-balance-table__cell {{ $businessBalancetotals['difference_hours'] >= 0 ? 'business-balance-table__cell--gap-positive' : 'business-balance-table__cell--gap-negative' }}"><strong>{{ $businessBalancetotals['difference_hours'] }} h</strong></td>
+                  <td class="business-balance-table__cell {{ $businessBalancetotals['difference_cost'] >= 0 ? 'business-balance-table__cell--gap-positive' : 'business-balance-table__cell--gap-negative' }}"><strong>{{ $businessBalancetotals['difference_display_cost'] }} </strong></td>
                 </tr>
               </tfoot>
             </table>


### PR DESCRIPTION
### Motivation
- Replace the strong red used for the "Réalisé" (realized) column with a more neutral color to reduce emphasis.
- Add clear visual feedback (green/red background) on the "Écart" (gap) columns to show positive vs negative differences at a glance.

### Description
- Updated the business balance view `resources/views/workflow/orders-show.blade.php` to use `business-balance-table__group--neutral` / `--subhead--neutral` and `--cell--neutral` for the accomplished/realized columns and to apply conditional classes for gap cells: `business-balance-table__cell--gap-positive` or `business-balance-table__cell--gap-negative` based on sign for both per-row and totals.
- Added new CSS rules in `public/css/custom.css` for `.business-balance-table__group--neutral`, `.business-balance-table__subhead--neutral`, `.business-balance-table__cell--neutral`, `.business-balance-table__cell--gap-positive`, and `.business-balance-table__cell--gap-negative` and adjusted total-row gap styles.
- The changes affect rendering only and keep existing numeric formatting and totals logic intact (no changes to service/business logic code).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696766681e80832db326b8fbc340ccfb)