### PR TITLE
Normalize PDF currency spacing for DomPDF output

### DIFF
--- a/app/Http/Controllers/PrintController.php
+++ b/app/Http/Controllers/PrintController.php
@@ -110,13 +110,14 @@ class PrintController extends Controller
         
         $formattedTotalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
         $formattedSubPrice = Number::currency($subPrice, $currency, config('app.locale'));
+        $normalizeCurrency = fn ($value) => $this->normalizePdfCurrency($value);
 
         $this->getDocumentLines($Document, 'invoiceLines');
         $image = $Factory->getImageFactoryPath();
         $resolver = app(PdfThemeResolver::class);
         $view = $resolver->resolveForDocument($Document, 'print/pdf-invoice', $Factory);
         $customCss = $Factory->pdf_custom_css;
-        $dompdf = PDF::loadView($view, compact('typeDocumentName', 'Document', 'Factory', 'image', 'formattedTotalPrice', 'formattedSubPrice', 'vatPrice', 'customCss'));
+        $dompdf = PDF::loadView($view, compact('typeDocumentName', 'Document', 'Factory', 'image', 'formattedTotalPrice', 'formattedSubPrice', 'vatPrice', 'customCss', 'normalizeCurrency'));
 
         // Récupération des informations client depuis le modèle associé
         $client = $Document->companie;
@@ -259,13 +260,14 @@ class PrintController extends Controller
 
         $formattedTotalPrice = Number::currency($totalPrice, $currency, config('app.locale'));
         $formattedSubPrice = Number::currency($subPrice, $currency, config('app.locale'));
+        $normalizeCurrency = fn ($value) => $this->normalizePdfCurrency($value);
 
         $this->getDocumentLines($Document, $this->getDocumentLinesKey($Document));
         $image = $Factory->getImageFactoryPath();
         $resolver = app(PdfThemeResolver::class);
         $resolvedView = $resolver->resolveForDocument($Document, $viewKey, $Factory);
         $customCss = $Factory->pdf_custom_css;
-        $pdf = PDF::loadView($resolvedView, compact('typeDocumentName', 'Document', 'Factory', 'formattedTotalPrice', 'formattedSubPrice', 'vatPrice', 'image', 'customCss'));
+        $pdf = PDF::loadView($resolvedView, compact('typeDocumentName', 'Document', 'Factory', 'formattedTotalPrice', 'formattedSubPrice', 'vatPrice', 'image', 'customCss', 'normalizeCurrency'));
 
         return response()->streamDownload(function () use ($pdf) {
             echo $pdf->stream();
@@ -324,5 +326,16 @@ class PrintController extends Controller
             default:
                 throw new \Exception('Unknown document type');
         }
+    }
+
+    /**
+     * Normalize currency spacing for PDF fonts.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    private function normalizePdfCurrency($value): string
+    {
+        return str_replace(["\u{00A0}", "\u{202F}"], ' ', (string) $value);
     }
 }

--- a/resources/views/print/pdf-credit-note.blade.php
+++ b/resources/views/print/pdf-credit-note.blade.php
@@ -123,7 +123,7 @@
                         </td>
                         <td>{{ $DocumentLine->qty }}</td>
                         <td>{{ $DocumentLine->OrderLine->Unit['label'] }}</td>
-                        <td>{{ $DocumentLine->OrderLine->formatted_selling_price }}</td>
+                        <td>{{ $normalizeCurrency($DocumentLine->OrderLine->formatted_selling_price) }}</td>
                         <td align="center">{{ $DocumentLine->OrderLine->discount }} %</td>
                         <td>{{ $DocumentLine->OrderLine->VAT['rate'] }} %</td>
                         @if($DocumentLine->OrderLine->delivery_date )

--- a/resources/views/print/pdf-invoice.blade.php
+++ b/resources/views/print/pdf-invoice.blade.php
@@ -123,7 +123,7 @@
                         </td>
                         <td>{{ $DocumentLine->qty }}</td>
                         <td>{{ $DocumentLine->OrderLine->Unit['label'] }}</td>
-                        <td>{{ $DocumentLine->OrderLine->formatted_selling_price }}</td>
+                        <td>{{ $normalizeCurrency($DocumentLine->OrderLine->formatted_selling_price) }}</td>
                         <td align="center">{{ $DocumentLine->OrderLine->discount }} %</td>
                         <td>{{ $DocumentLine->OrderLine->VAT['rate'] }} %</td>
                         @if($DocumentLine->OrderLine->delivery_date )
@@ -156,7 +156,7 @@
                         <table width="80%">
                             <tr>
                                 <th align="right" style="width:50%">{{ __('general_content.sub_total_trans_key') }}:</th> 
-                                <td align="right" style="width:30%">{{ $formattedSubPrice }} </td>
+                                <td align="right" style="width:30%">{{ $normalizeCurrency($formattedSubPrice) }} </td>
                             </tr>
                             @forelse($vatPrice as $key => $value)
                             <tr>
@@ -171,7 +171,7 @@
                             @endforelse
                             <tr  style=" background-color: {{ $Factory->pdf_header_font_color }}">
                                 <th align="right" style="width:50%">{{ __('general_content.total_trans_key') }} :</th> 
-                                <td align="right" style="width:30%">{{ $formattedTotalPrice }}</td>
+                                <td align="right" style="width:30%">{{ $normalizeCurrency($formattedTotalPrice) }}</td>
                             </tr>
                         </table>
                     </td>

--- a/resources/views/print/pdf-purchases.blade.php
+++ b/resources/views/print/pdf-purchases.blade.php
@@ -133,7 +133,7 @@
                         </td>
                         <td>{{ $DocumentLine->supplier_ref }}</td>
                         <td>{{ $DocumentLine->qty }}</td>
-                        <td>{{ $DocumentLine->formatted_selling_price }}</td>
+                        <td>{{ $normalizeCurrency($DocumentLine->formatted_selling_price) }}</td>
                         <td>{{ $DocumentLine->discount }} %</td>
                         <td> 
                             @if($DocumentLine->accounting_vats_id)

--- a/resources/views/print/pdf-sales.blade.php
+++ b/resources/views/print/pdf-sales.blade.php
@@ -125,7 +125,7 @@
                         </td>
                         <td align="center">{{ $DocumentLine->qty }}</td>
                         <td>{{ $DocumentLine->Unit['label'] }}</td>
-                        <td>{{ $DocumentLine->formatted_selling_price }}</td>
+                        <td>{{ $normalizeCurrency($DocumentLine->formatted_selling_price) }}</td>
                         <td align="center">{{ $DocumentLine->discount }} %</td>
                         <td>{{ $DocumentLine->VAT['rate'] }} %</td>
                         @if($DocumentLine->delivery_date )
@@ -162,7 +162,7 @@
                         <table width="80%">
                             <tr>
                                 <th align="right" style="width:50%">{{ __('general_content.sub_total_trans_key') }}:</th> 
-                                <td align="right" style="width:30%">{{ $formattedSubPrice }} </td>
+                                <td align="right" style="width:30%">{{ $normalizeCurrency($formattedSubPrice) }} </td>
                             </tr>
                             @forelse($vatPrice as $key => $value)
                             <tr>
@@ -177,7 +177,7 @@
                             @endforelse
                             <tr  style=" background-color: {{ $Factory->pdf_header_font_color }}">
                                 <th align="right" style="width:50%">{{ __('general_content.total_trans_key') }} :</th> 
-                                <td align="right" style="width:30%">{{ $formattedTotalPrice }}</td>
+                                <td align="right" style="width:30%">{{ $normalizeCurrency($formattedTotalPrice) }}</td>
                             </tr>
                         </table>
                     </td>


### PR DESCRIPTION
### Motivation
- DomPDF was rendering non‑breaking spaces in formatted currency strings as a “?” character in generated PDFs, making amounts unreadable.
- The change normalizes those special space characters to regular spaces before the view is rendered so PDF-safe text is produced.

### Description
- Add a `normalizePdfCurrency` helper on `PrintController` that replaces `\u{00A0}` and `\u{202F}` with a normal space. 
- Expose a `normalizeCurrency` closure to PDF views by adding it to the data passed to `PDF::loadView` in `generatePdf` and `getInvoiceFactureX`. 
- Update PDF templates to use `{{ $normalizeCurrency(...) }}` for unit prices and totals in `resources/views/print/pdf-sales.blade.php`, `pdf-invoice.blade.php`, `pdf-purchases.blade.php`, and `pdf-credit-note.blade.php`. 
- Keep existing currency formatting calls (`Number::currency`) and only normalize spacing for DomPDF-safe output.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676a8336bc832db0f4c87473003288)