### PR TITLE
Exclude canceled orders from open-order menu counter

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,7 +49,7 @@ class AppServiceProvider extends ServiceProvider
 
         $events->listen(BuildingMenu::class, function (BuildingMenu $event) {
 
-            $OrdersNotFinishCount = Orders::where('statu', '!=', '3')->count();
+            $OrdersNotFinishCount = Orders::whereNotIn('statu', [3, 6])->count();
             
             $DeliverysRequestsCount = OrderLines::where(
                 function($query) {


### PR DESCRIPTION
### Motivation
- The menu badge for open orders counted any order not in status 3, unintentionally including canceled orders, so canceled orders (`statu == 6`) should be excluded from the open-order count.

### Description
- Update `app/Providers/AppServiceProvider.php` to compute `$OrdersNotFinishCount` using `Orders::whereNotIn('statu', [3, 6])->count()` instead of the previous `where('statu', '!=', '3')`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677032b3a0832d953662ed503cf44a)