### PR TITLE
Default orders to delivery date sorting

### DIFF
--- a/app/Livewire/OrdersIndex.php
+++ b/app/Livewire/OrdersIndex.php
@@ -29,8 +29,8 @@ class OrdersIndex extends Component
     public $viewType = 'table'; // Defaults to 'table'
 
     public $search = '';
-    public $sortField = 'created_at'; // default sorting field
-    public $sortAsc = false; // default sort direction
+    public $sortField = 'validity_date'; // default sorting field
+    public $sortAsc = true; // default sort direction
     public $searchIdStatus = '1';
 
     public $userSelect = [];
@@ -212,19 +212,17 @@ class OrdersIndex extends Component
     public function render()
     {
         if(is_numeric($this->idCompanie)){
-            $Orders = Orders::withCount('OrderLines')
+            $OrdersQuery = Orders::withCount('OrderLines')
                             ->where('companies_id', $this->idCompanie)
-                            ->where('statu', 'like', '%'.$this->searchIdStatus.'%')
-                            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
-                            ->paginate(15);
+                            ->where('statu', 'like', '%'.$this->searchIdStatus.'%');
         }
         else{
-            $Orders = Orders::withCount('OrderLines')
+            $OrdersQuery = Orders::withCount('OrderLines')
                             ->where('label','like', '%'.$this->search.'%')
-                            ->where('statu', 'like', '%'.$this->searchIdStatus.'%')
-                            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
-                            ->paginate(15);
+                            ->where('statu', 'like', '%'.$this->searchIdStatus.'%');
         }
+
+        $Orders = $this->applySorting($OrdersQuery)->paginate(15);
 
         $userSelect = User::select('id', 'name')->get();
         $CompanieSelect = Companies::select('id', 'code','client_type','civility','label','last_name')->where('active', 1)->get();
@@ -245,6 +243,17 @@ class OrdersIndex extends Component
             'AccountingDeleveriesSelect' => $AccountingDeleveriesSelect,
             'type' => $this->type,
         ]);
+    }
+
+    private function applySorting($query)
+    {
+        if ($this->sortField === 'validity_date') {
+            return $query
+                ->orderByRaw('validity_date is null')
+                ->orderBy('validity_date', $this->sortAsc ? 'asc' : 'desc');
+        }
+
+        return $query->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc');
     }
 
     public function storeOrder(){


### PR DESCRIPTION
### Motivation
- Set the default order list to be sorted by delivery date (nearest first) so orders with upcoming delivery dates surface by default and those without a delivery date appear last.

### Description
- Change default sorting field from `created_at` to `validity_date` and set default direction to ascending (`$sortField = 'validity_date'`, `$sortAsc = true`).
- Refactor `render()` to build an `OrdersQuery` and apply a centralized `applySorting()` helper that handles the `validity_date` case specially.
- Implement `applySorting()` to place `NULL` `validity_date` values last using `orderByRaw('validity_date is null')` and then `orderBy('validity_date', ...)`, while preserving generic ordering for other fields.

### Testing
- No automated tests were executed for this change (no `phpunit` or other CI jobs were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967af307004832d8e585bd8d1e46281)