### PR TITLE
Move table vertical alignment to custom stylesheet

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -143,6 +143,16 @@
 
 #tblDemo th,
 #tblDemo td {
+    vertical-align: middle;
+}
+
+.table th,
+.table td {
+    vertical-align: middle;
+}
+
+#tblDemo th,
+#tblDemo td {
     width: 100px;
     text-align: center; 
     white-space: nowrap; 


### PR DESCRIPTION
### Motivation
- Ensure the table cell vertical alignment rule lives in the `custom.css` file (which is referenced by the affected views) as requested, and avoid duplicate rules in the compiled `app.scss`.

### Description
- Remove the `vertical-align: middle` rule for table cells from `resources/sass/app.scss`.
- Add `#tblDemo th, #tblDemo td { vertical-align: middle; }` and `.table th, .table td { vertical-align: middle; }` to `public/css/custom.css`.
- Modified files are `public/css/custom.css` and `resources/sass/app.scss`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f3746eb8832dad7f3187d777b421)