### PR TITLE
Add generic RFQ line creation and conversion support

### DIFF
--- a/app/Livewire/PurchasesQuotationIndex.php
+++ b/app/Livewire/PurchasesQuotationIndex.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use Livewire\Component;
 use Livewire\WithPagination;
 use App\Models\Purchases\PurchasesQuotation;
+use App\Models\Purchases\PurchaseQuotationLines;
 
 class PurchasesQuotationIndex extends Component
 {
@@ -26,6 +27,16 @@ class PurchasesQuotationIndex extends Component
     public $user_id;
     public $comment;
 
+    public $purchase_quotation_id;
+    public $purchase_quotation_line_id;
+    public $updateLines = false;
+    public $ordre = 10;
+    public $line_label = '';
+    public $qty_to_order = 0;
+    public $unit_price = 0;
+    public $OrderStatu;
+    public $PurchaseQuotationOptions = [];
+
     public function sortBy($field)
     {
         if ($this->sortField === $field) {
@@ -41,6 +52,18 @@ class PurchasesQuotationIndex extends Component
         $this->resetPage();
     }
 
+    public function updatedPurchaseQuotationId($value)
+    {
+        if (!$value) {
+            $this->OrderStatu = null;
+            return;
+        }
+
+        $quotation = PurchasesQuotation::select('id', 'statu')->find($value);
+        $this->OrderStatu = $quotation?->statu;
+        $this->ordre = $this->getNextQuotationLineOrder($value);
+    }
+
     public function mount()
     {
         // Initialization logic can be added here if needed
@@ -49,6 +72,9 @@ class PurchasesQuotationIndex extends Component
     public function render()
     {
         $purchasesQuotations = $this->getPurchasesQuotations();
+        $this->PurchaseQuotationOptions = PurchasesQuotation::select('id', 'code', 'label', 'statu')
+            ->orderBy('created_at', 'desc')
+            ->get();
 
         return view('livewire.purchases-quotation-index', [
             'PurchasesQuotationList' => $purchasesQuotations,
@@ -61,5 +87,82 @@ class PurchasesQuotationIndex extends Component
                                 ->where('label', 'like', '%' . $this->search . '%')
                                 ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
                                 ->paginate(15);
+    }
+
+    private function getNextQuotationLineOrder($quotationId)
+    {
+        $lastOrder = PurchaseQuotationLines::where('purchases_quotation_id', $quotationId)->max('ordre');
+        return $lastOrder ? $lastOrder + 10 : 10;
+    }
+
+    public function storePurchaseQuotationLine()
+    {
+        $this->validate([
+            'purchase_quotation_id' => 'required|numeric',
+            'ordre' => 'required|numeric|gt:0',
+            'line_label' => 'required|string',
+            'qty_to_order' => 'required|numeric|gt:0',
+            'unit_price' => 'required|numeric|min:0',
+        ]);
+
+        PurchaseQuotationLines::create([
+            'purchases_quotation_id' => $this->purchase_quotation_id,
+            'tasks_id' => 0,
+            'label' => $this->line_label,
+            'ordre' => $this->ordre,
+            'qty_to_order' => $this->qty_to_order,
+            'unit_price' => $this->unit_price,
+            'total_price' => $this->unit_price * $this->qty_to_order,
+        ]);
+
+        session()->flash('success', 'Line added Successfully');
+        $this->resetLineFields();
+    }
+
+    public function editPurchaseQuotationLine($id)
+    {
+        $line = PurchaseQuotationLines::findOrFail($id);
+        $this->purchase_quotation_line_id = $id;
+        $this->purchase_quotation_id = $line->purchases_quotation_id;
+        $this->ordre = $line->ordre;
+        $this->line_label = $line->label;
+        $this->qty_to_order = $line->qty_to_order;
+        $this->unit_price = $line->unit_price;
+        $this->updateLines = true;
+    }
+
+    public function updatePurchaseQuotationLine()
+    {
+        $this->validate([
+            'purchase_quotation_id' => 'required|numeric',
+            'ordre' => 'required|numeric|gt:0',
+            'line_label' => 'required|string',
+            'qty_to_order' => 'required|numeric|gt:0',
+            'unit_price' => 'required|numeric|min:0',
+        ]);
+
+        PurchaseQuotationLines::find($this->purchase_quotation_line_id)->fill([
+            'ordre' => $this->ordre,
+            'label' => $this->line_label,
+            'qty_to_order' => $this->qty_to_order,
+            'unit_price' => $this->unit_price,
+            'total_price' => $this->unit_price * $this->qty_to_order,
+        ])->save();
+
+        session()->flash('success', 'Line Updated Successfully');
+        $this->resetLineFields();
+        $this->updateLines = false;
+    }
+
+    private function resetLineFields()
+    {
+        if ($this->purchase_quotation_id) {
+            $this->ordre = $this->getNextQuotationLineOrder($this->purchase_quotation_id);
+        } else {
+            $this->ordre = 10;
+        }
+        $this->line_label = '';
+        $this->qty_to_order = 0;
+        $this->unit_price = 0;
     }
 }

--- a/app/Models/Purchases/PurchaseQuotationLines.php
+++ b/app/Models/Purchases/PurchaseQuotationLines.php
@@ -14,7 +14,8 @@ class PurchaseQuotationLines extends Model
 
     // Fillable attributes for mass assignment
     protected $fillable= ['purchases_quotation_id', 
-        'tasks_id', 
+        'tasks_id',
+        'label',
         'ordre',
         'qty_to_order',
         'unit_price',

--- a/app/Services/PurchaseOrderService.php
+++ b/app/Services/PurchaseOrderService.php
@@ -110,6 +110,39 @@ class PurchaseOrderService
     }
 
     /**
+     * Create a new purchase order line from a quotation line.
+     *
+     * This method creates a purchase order line based on a generic quotation line.
+     *
+     * @param int $purchaseOrder The ID of the purchase order.
+     * @param \App\Models\Purchases\PurchaseQuotationLines $quotationLine The quotation line to convert.
+     * @param int $accountingVat The ID of the accounting VAT.
+     * @param int $ordre The order of the line.
+     * @param float|null $purchasePrice The purchase price applied to the line.
+     * @return \App\Models\Purchases\PurchaseLines The created purchase order line.
+     */
+    public function createPurchaseOrderLineFromQuotationLine($purchaseOrder, $quotationLine, $accountingVat, $ordre, $purchasePrice = null)
+    {
+        $finalPrice = (!empty($purchasePrice)) ? $purchasePrice : $quotationLine->unit_price;
+        return PurchaseLines::create([
+            'purchases_id' => $purchaseOrder,
+            'tasks_id' => 0,
+            'ordre' => $ordre,
+            'code' => null,
+            'product_id' => null,
+            'label' => $quotationLine->label ?? 'Generic line',
+            'qty' => $quotationLine->qty_to_order,
+            'selling_price' => $finalPrice,
+            'discount' => 0,
+            'unit_price_after_discount' => $finalPrice,
+            'total_selling_price' => $finalPrice * $quotationLine->qty_to_order,
+            'methods_units_id' => null,
+            'accounting_vats_id' => $accountingVat,
+            'statu' => 1,
+        ]);
+    }
+
+    /**
      * Get the default accounting VAT.
      *
      * This method retrieves the default accounting VAT from the database.
@@ -176,11 +209,19 @@ class PurchaseOrderService
         $accountingVat = $this->getAccountingVat();
         $ordre = 10;
         foreach ($quotationLines as $key => $line) {
-            $task = Task::find($taskIds[$key]);
-            $price = $prices[$key];
-            $this->createPurchaseOrderLine($purchaseOrder->id, $task, $accountingVat->id, $ordre, $price);
-            $this->updateTaskStatus($task->id, $statusUpdateId);
-            $this->updateQuotationLine($line, $task->getQualityRequiredAttribute());
+            $taskId = $taskIds[$key] ?? null;
+            $price = $prices[$key] ?? null;
+            $quotationLine = PurchaseQuotationLines::find($line);
+            $task = $taskId ? Task::find($taskId) : null;
+
+            if ($task) {
+                $this->createPurchaseOrderLine($purchaseOrder->id, $task, $accountingVat->id, $ordre, $price);
+                $this->updateTaskStatus($task->id, $statusUpdateId);
+                $this->updateQuotationLine($line, $task->getQualityRequiredAttribute());
+            } elseif ($quotationLine) {
+                $this->createPurchaseOrderLineFromQuotationLine($purchaseOrder->id, $quotationLine, $accountingVat->id, $ordre, $price);
+                $this->updateQuotationLine($line, $quotationLine->qty_to_order);
+            }
             $ordre += 10;
         }
     }

--- a/app/Services/PurchaseQuotationService.php
+++ b/app/Services/PurchaseQuotationService.php
@@ -56,6 +56,7 @@ class PurchaseQuotationService
         return PurchaseQuotationLines::create([
             'purchases_quotation_id' => $purchaseQuotation->id,
             'tasks_id' => $task->id,
+            'label' => $task->label,
             'ordre' => $ordre, 
             //'supplier_ref' => , can be null
             'qty_to_order' => $task->getQualityRequiredAttribute(),

--- a/database/migrations/2025_01_15_000000_add_label_to_purchase_quotation_lines_table.php
+++ b/database/migrations/2025_01_15_000000_add_label_to_purchase_quotation_lines_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('purchase_quotation_lines', function (Blueprint $table) {
+            $table->string('label')->nullable()->after('tasks_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('purchase_quotation_lines', function (Blueprint $table) {
+            $table->dropColumn('label');
+        });
+    }
+};

--- a/resources/views/livewire/purchases-quotation-index.blade.php
+++ b/resources/views/livewire/purchases-quotation-index.blade.php
@@ -2,6 +2,67 @@
 <div>
     <div class="card">
         <div class="card-body">
+            @include('include.alert-result')
+
+            <div class="form-row">
+                <div class="form-group col-md-6">
+                    <label for="purchase_quotation_id">{{ __('general_content.purchase_quotation_trans_key') }}</label>
+                    <select id="purchase_quotation_id" class="form-control" wire:model.live="purchase_quotation_id">
+                        <option value="">{{ __('general_content.select_trans_key') }}</option>
+                        @foreach($PurchaseQuotationOptions as $quotationOption)
+                            <option value="{{ $quotationOption->id }}">
+                                {{ $quotationOption->code }} - {{ $quotationOption->label }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('purchase_quotation_id') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                </div>
+            </div>
+
+            @if($purchase_quotation_id)
+                @if($OrderStatu == 1)
+                    @if($updateLines)
+                    <form wire:submit.prevent="updatePurchaseQuotationLine">
+                        <input type="hidden" wire:model.live="purchase_quotation_line_id">
+                    @else
+                    <form wire:submit.prevent="storePurchaseQuotationLine">
+                    @endif
+                        <div class="form-row">
+                            <div class="form-group col-md-2">
+                                <label for="ordre">{{ __('general_content.sort_trans_key') }} :</label>
+                                <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" min="0" wire:model.live="ordre">
+                                @error('ordre') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                            </div>
+                            <div class="form-group col-md-4">
+                                <label for="line_label">{{ __('general_content.description_trans_key') }}</label>
+                                <input type="text" class="form-control @error('line_label') is-invalid @enderror" id="line_label" wire:model.live="line_label">
+                                @error('line_label') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                            </div>
+                            <div class="form-group col-md-2">
+                                <label for="qty_to_order">{{ __('general_content.qty_trans_key') }}</label>
+                                <input type="number" class="form-control @error('qty_to_order') is-invalid @enderror" id="qty_to_order" min="0" wire:model.live="qty_to_order">
+                                @error('qty_to_order') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                            </div>
+                            <div class="form-group col-md-2">
+                                <label for="unit_price">{{ __('general_content.price_trans_key') }}</label>
+                                <input type="number" class="form-control @error('unit_price') is-invalid @enderror" id="unit_price" min="0" step="0.01" wire:model.live="unit_price">
+                                @error('unit_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                            </div>
+                            <div class="form-group col-md-2 d-flex align-items-end">
+                                <button type="submit" class="btn btn-success btn-block">{{ __('general_content.submit_trans_key') }}</button>
+                            </div>
+                        </div>
+                    </form>
+                @else
+                <x-adminlte-alert theme="info" title="Info">
+                    {{ __('general_content.info_statu_trans_key') }}
+                </x-adminlte-alert>
+                @endif
+            @endif
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-body">
             @include('include.search-card')
         </div>
         <div class="table-responsive p-0">

--- a/resources/views/purchases/purchases-quotation-show.blade.php
+++ b/resources/views/purchases/purchases-quotation-show.blade.php
@@ -143,19 +143,35 @@
                             {{__('general_content.generic_trans_key') }} 
                             @endif
                         </td>
-                        <td>@if($PurchaseQuotationLine->tasks->OrderLines ?? null){{ $PurchaseQuotationLine->tasks->OrderLines->qty }} x {{ $PurchaseQuotationLine->tasks->qty }}@endif</td>
-                        <td>@if($PurchaseQuotationLine->tasks->OrderLines ?? null){{ $PurchaseQuotationLine->tasks->OrderLines->label }}@endif</td>
                         <td>
-                            <a href="{{ route('production.task.statu.id', ['id' => $PurchaseQuotationLine->tasks->id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a>
-                            #{{ $PurchaseQuotationLine->tasks->id }} - {{ $PurchaseQuotationLine->tasks->label }}
-                            @if($PurchaseQuotationLine->tasks->component_id )
-                                - {{ $PurchaseQuotationLine->tasks->Component['label'] }}
+                          @if($PurchaseQuotationLine->tasks->OrderLines ?? null)
+                            {{ $PurchaseQuotationLine->tasks->OrderLines->qty }} x {{ $PurchaseQuotationLine->tasks->qty }}
+                          @else
+                            {{__('general_content.generic_trans_key') }}
+                          @endif
+                        </td>
+                        <td>
+                          @if($PurchaseQuotationLine->tasks->OrderLines ?? null)
+                            {{ $PurchaseQuotationLine->tasks->OrderLines->label }}
+                          @else
+                            {{ $PurchaseQuotationLine->label }}
+                          @endif
+                        </td>
+                        <td>
+                            @if($PurchaseQuotationLine->tasks)
+                              <a href="{{ route('production.task.statu.id', ['id' => $PurchaseQuotationLine->tasks->id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a>
+                              #{{ $PurchaseQuotationLine->tasks->id }} - {{ $PurchaseQuotationLine->tasks->label }}
+                              @if($PurchaseQuotationLine->tasks->component_id )
+                                  - {{ $PurchaseQuotationLine->tasks->Component['label'] }}
+                              @endif
+                            @else
+                              {{ $PurchaseQuotationLine->label }}
                             @endif
                         </td>
                         
                         <td>
-                            @if($PurchaseQuotationLine->tasks->component_id ) 
-                            <x-ButtonTextView route="{{ route('products.show', ['id' => $PurchaseQuotationLine->tasks->component_id])}}" />
+                            @if($PurchaseQuotationLine->tasks?->component_id ) 
+                              <x-ButtonTextView route="{{ route('products.show', ['id' => $PurchaseQuotationLine->tasks->component_id])}}" />
                             @endif
                         </td>
                         <td>{{ number_format($PurchaseQuotationLine->qty_to_order, 0, '', ' ') }}</td>
@@ -165,7 +181,7 @@
                           @if($PurchaseQuotationLine->qty_to_order > $PurchaseQuotationLine->qty_accepted)
                             <div class="form-group">
                               <div class="custom-control custom-checkbox">
-                                <input type="hidden" value="{{ $PurchaseQuotationLine->tasks->id }}" name="PurchaseQuotationLineTaskid[]" >
+                                <input type="hidden" value="{{ $PurchaseQuotationLine->tasks->id ?? 0 }}" name="PurchaseQuotationLineTaskid[]" >
                                 <input class="custom-control-input" value="{{ $PurchaseQuotationLine->id }}" name="PurchaseQuotationLine[]" id="PurchaseQuotationLine.{{ $PurchaseQuotationLine->id }}" type="checkbox">
                                 <label for="PurchaseQuotationLine.{{ $PurchaseQuotationLine->id }}" class="custom-control-label">+</label>
                               </div>

--- a/resources/views/purchases/purchases-quotation-show.blade.php
+++ b/resources/views/purchases/purchases-quotation-show.blade.php
@@ -137,21 +137,21 @@
                       @forelse($PurchaseQuotation->PurchaseQuotationLines as $PurchaseQuotationLine)
                       <tr>
                         <td>
-                            @if($PurchaseQuotationLine->tasks->OrderLines ?? null)
+                            @if($PurchaseQuotationLine->tasks?->OrderLines)
                                 <x-OrderButton id="{{ $PurchaseQuotationLine->tasks->OrderLines->orders_id }}" code="{{ $PurchaseQuotationLine->tasks->OrderLines->order->code }}"  /> 
                             @else
                             {{__('general_content.generic_trans_key') }} 
                             @endif
                         </td>
                         <td>
-                          @if($PurchaseQuotationLine->tasks->OrderLines ?? null)
+                          @if($PurchaseQuotationLine->tasks?->OrderLines)
                             {{ $PurchaseQuotationLine->tasks->OrderLines->qty }} x {{ $PurchaseQuotationLine->tasks->qty }}
                           @else
                             {{__('general_content.generic_trans_key') }}
                           @endif
                         </td>
                         <td>
-                          @if($PurchaseQuotationLine->tasks->OrderLines ?? null)
+                          @if($PurchaseQuotationLine->tasks?->OrderLines)
                             {{ $PurchaseQuotationLine->tasks->OrderLines->label }}
                           @else
                             {{ $PurchaseQuotationLine->label }}


### PR DESCRIPTION
### Motivation

- Allow creating and managing generic (non-task) lines on purchase quotations (RFQs) from the purchases quotation list view. 
- Persist a human-readable `label` for quotation lines so lines not tied to a `Task` can be shown and converted into purchase orders.
- Ensure RFQ → PO conversion works when lines are generic and avoid errors when a quotation line has no `tasks` relation.

### Description

- Add `label` to `purchase_quotation_lines` via a migration and expose it in the model `fillable` array (file: `database/migrations/2025_01_15_000000_add_label_to_purchase_quotation_lines_table.php`, `app/Models/Purchases/PurchaseQuotationLines.php`).
- Populate quotation line `label` when creating lines from tasks in `PurchaseQuotationService::createPurchaseQuotationLine` (file: `app/Services/PurchaseQuotationService.php`).
- Add Livewire logic to `PurchasesQuotationIndex` to create and update generic quotation lines, compute the next `ordre`, and expose options for selecting a quotation in the index view (file: `app/Livewire/PurchasesQuotationIndex.php`).
- Add a generic line form to the purchases quotation index Blade view and wire it to the Livewire methods for storing/updating lines (file: `resources/views/livewire/purchases-quotation-index.blade.php`).
- Make RFQ show page robust to generic lines by rendering the stored `label` when `tasks` is missing and defaulting task id values when building PO request payloads (file: `resources/views/purchases/purchases-quotation-show.blade.php`).
- Enable conversion of generic quotation lines into purchase order lines by adding `createPurchaseOrderLineFromQuotationLine` and adjusting `processPurchaseQuotationLines` to handle both task-based and generic lines (file: `app/Services/PurchaseOrderService.php`).

### Testing

- No automated tests were executed in this change; manual QA/functional testing was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f365a3a4832d9fdf921567f17ef2)