### PR TITLE
Add inspection project module foundations

### DIFF
--- a/app/Exports/InspectionMeasuresExport.php
+++ b/app/Exports/InspectionMeasuresExport.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Inspection\InspectionMeasure;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+class InspectionMeasuresExport implements FromCollection, WithHeadings, WithMapping
+{
+    private $inspectionProjectId;
+
+    public function __construct($inspectionProjectId)
+    {
+        $this->inspectionProjectId = $inspectionProjectId;
+    }
+
+    public function headings(): array
+    {
+        return [
+            'SESSION_CODE',
+            'SESSION_TYPE',
+            'POINT_NUMBER',
+            'POINT_LABEL',
+            'SERIAL_NUMBER',
+            'MEASURED_VALUE',
+            'RESULT',
+            'DEVIATION',
+            'MEASURED_BY',
+            'MEASURED_AT',
+            'INSTRUMENT',
+            'COMMENT',
+        ];
+    }
+
+    public function map($measure): array
+    {
+        return [
+            $measure->Session?->session_code,
+            $measure->Session?->type,
+            $measure->ControlPoint?->number,
+            $measure->ControlPoint?->label,
+            $measure->serial_number,
+            $measure->measured_value,
+            $measure->result,
+            $measure->deviation,
+            $measure->MeasuredBy?->name,
+            optional($measure->measured_at)->format('Y-m-d H:i:s'),
+            $measure->Instrument?->name,
+            $measure->comment,
+        ];
+    }
+
+    public function collection()
+    {
+        return InspectionMeasure::with(['Session', 'ControlPoint', 'MeasuredBy', 'Instrument'])
+            ->whereHas('Session', function ($query) {
+                $query->where('inspection_project_id', $this->inspectionProjectId);
+            })
+            ->orderBy('measured_at')
+            ->get();
+    }
+}

--- a/app/Http/Controllers/Inspection/InspectionControlPointController.php
+++ b/app/Http/Controllers/Inspection/InspectionControlPointController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Inspection;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Models\Inspection\InspectionControlPoint;
+use App\Models\Inspection\InspectionProject;
+
+class InspectionControlPointController extends Controller
+{
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request, $projectId)
+    {
+        $project = InspectionProject::findOrFail($projectId);
+
+        $validated = $request->validate([
+            'points' => ['nullable', 'array'],
+            'points.*.number' => ['required_with:points', 'integer'],
+            'points.*.label' => ['required_with:points', 'string', 'max:255'],
+            'points.*.category' => ['nullable', 'in:dimension,visual,attribute'],
+            'points.*.nominal_value' => ['nullable', 'numeric'],
+            'points.*.tol_min' => ['nullable', 'numeric'],
+            'points.*.tol_max' => ['nullable', 'numeric'],
+            'points.*.unit' => ['nullable', 'string', 'max:20'],
+            'points.*.frequency_type' => ['nullable', 'in:all,one_of_n,first_last,custom'],
+            'points.*.frequency_value' => ['nullable', 'integer'],
+            'points.*.plan_page' => ['nullable', 'integer'],
+            'points.*.plan_ref' => ['nullable', 'string', 'max:100'],
+            'points.*.phase' => ['nullable', 'string', 'max:100'],
+            'points.*.instrument_type' => ['nullable', 'string', 'max:100'],
+            'points.*.is_critical' => ['nullable', 'boolean'],
+            'points.*.order' => ['nullable', 'integer'],
+            'number' => ['required_without:points', 'integer'],
+            'label' => ['required_without:points', 'string', 'max:255'],
+            'category' => ['nullable', 'in:dimension,visual,attribute'],
+            'nominal_value' => ['nullable', 'numeric'],
+            'tol_min' => ['nullable', 'numeric'],
+            'tol_max' => ['nullable', 'numeric'],
+            'unit' => ['nullable', 'string', 'max:20'],
+            'frequency_type' => ['nullable', 'in:all,one_of_n,first_last,custom'],
+            'frequency_value' => ['nullable', 'integer'],
+            'plan_page' => ['nullable', 'integer'],
+            'plan_ref' => ['nullable', 'string', 'max:100'],
+            'phase' => ['nullable', 'string', 'max:100'],
+            'instrument_type' => ['nullable', 'string', 'max:100'],
+            'is_critical' => ['nullable', 'boolean'],
+            'order' => ['nullable', 'integer'],
+        ]);
+
+        if (!empty($validated['points'])) {
+            $created = collect($validated['points'])->map(function ($point) use ($project) {
+                return InspectionControlPoint::create(array_merge($point, [
+                    'inspection_project_id' => $project->id,
+                ]));
+            });
+
+            return response()->json($created, 201);
+        }
+
+        $point = InspectionControlPoint::create(array_merge($validated, [
+            'inspection_project_id' => $project->id,
+        ]));
+
+        return response()->json($point, 201);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request, $id)
+    {
+        $point = InspectionControlPoint::findOrFail($id);
+
+        $validated = $request->validate([
+            'number' => ['sometimes', 'integer'],
+            'label' => ['sometimes', 'string', 'max:255'],
+            'category' => ['nullable', 'in:dimension,visual,attribute'],
+            'nominal_value' => ['nullable', 'numeric'],
+            'tol_min' => ['nullable', 'numeric'],
+            'tol_max' => ['nullable', 'numeric'],
+            'unit' => ['nullable', 'string', 'max:20'],
+            'frequency_type' => ['nullable', 'in:all,one_of_n,first_last,custom'],
+            'frequency_value' => ['nullable', 'integer'],
+            'plan_page' => ['nullable', 'integer'],
+            'plan_ref' => ['nullable', 'string', 'max:100'],
+            'phase' => ['nullable', 'string', 'max:100'],
+            'instrument_type' => ['nullable', 'string', 'max:100'],
+            'is_critical' => ['nullable', 'boolean'],
+            'order' => ['nullable', 'integer'],
+        ]);
+
+        $point->update($validated);
+
+        return response()->json($point);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy($id)
+    {
+        $point = InspectionControlPoint::findOrFail($id);
+        $point->delete();
+
+        return response()->json(['status' => 'deleted']);
+    }
+}

--- a/app/Http/Controllers/Inspection/InspectionDocumentController.php
+++ b/app/Http/Controllers/Inspection/InspectionDocumentController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Inspection;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use App\Models\Inspection\InspectionDocument;
+use App\Models\Inspection\InspectionProject;
+
+class InspectionDocumentController extends Controller
+{
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request, $projectId)
+    {
+        $project = InspectionProject::findOrFail($projectId);
+
+        $validated = $request->validate([
+            'file' => ['required', 'file', 'mimes:pdf,png,jpg,jpeg'],
+            'type' => ['nullable', 'in:plan,spec,photo,other'],
+            'version_label' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $file = $validated['file'];
+        $originalName = $file->getClientOriginalName();
+        $mime = $file->getClientMimeType();
+        $extension = $file->getClientOriginalExtension();
+        $fileName = Auth::id() . '_' . Str::uuid()->toString() . '.' . $extension;
+
+        $directory = public_path('inspection-documents');
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $file->move($directory, $fileName);
+
+        $document = InspectionDocument::create([
+            'inspection_project_id' => $project->id,
+            'type' => $validated['type'] ?? 'plan',
+            'file_path' => 'inspection-documents/' . $fileName,
+            'file_name' => $originalName,
+            'mime' => $mime,
+            'version_label' => $validated['version_label'] ?? null,
+        ]);
+
+        return response()->json($document, 201);
+    }
+}

--- a/app/Http/Controllers/Inspection/InspectionMeasureController.php
+++ b/app/Http/Controllers/Inspection/InspectionMeasureController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers\Inspection;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Inspection\InspectionMeasure;
+use App\Models\Inspection\InspectionControlPoint;
+use App\Models\Inspection\InspectionMeasureSession;
+
+class InspectionMeasureController extends Controller
+{
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'inspection_measure_session_id' => ['required', 'integer'],
+            'inspection_control_point_id' => ['required', 'integer'],
+            'serial_number' => ['nullable', 'string', 'max:100'],
+            'measured_value' => ['nullable', 'numeric'],
+            'result' => ['nullable', 'in:ok,nok,na'],
+            'comment' => ['nullable', 'string'],
+            'measured_at' => ['nullable', 'date'],
+            'instrument_id' => ['nullable', 'integer'],
+        ]);
+
+        $session = InspectionMeasureSession::findOrFail($validated['inspection_measure_session_id']);
+        $controlPoint = InspectionControlPoint::findOrFail($validated['inspection_control_point_id']);
+
+        if ($session->status !== 'open') {
+            return response()->json(['message' => 'Session is not open.'], 422);
+        }
+
+        $project = $controlPoint->Project;
+        if ($project && $project->serial_tracking && empty($validated['serial_number'])) {
+            return response()->json(['message' => 'Serial number is required for this project.'], 422);
+        }
+
+        $resultData = $this->evaluateResult($controlPoint, $validated['measured_value'] ?? null, $validated['result'] ?? null);
+
+        if ($resultData['result'] === 'nok' && empty($validated['comment'])) {
+            return response()->json(['message' => 'Comment is required for non-conforming measures.'], 422);
+        }
+
+        $measure = InspectionMeasure::create([
+            'inspection_measure_session_id' => $session->id,
+            'inspection_control_point_id' => $controlPoint->id,
+            'serial_number' => $validated['serial_number'] ?? null,
+            'measured_value' => $validated['measured_value'] ?? null,
+            'result' => $resultData['result'],
+            'deviation' => $resultData['deviation'],
+            'comment' => $validated['comment'] ?? null,
+            'measured_by' => Auth::id(),
+            'measured_at' => $validated['measured_at'] ?? now(),
+            'instrument_id' => $validated['instrument_id'] ?? null,
+        ]);
+
+        return response()->json($measure, 201);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request, $id)
+    {
+        $measure = InspectionMeasure::findOrFail($id);
+        $session = $measure->Session;
+
+        if ($session && $session->status !== 'open') {
+            return response()->json(['message' => 'Session is not open.'], 422);
+        }
+
+        $validated = $request->validate([
+            'serial_number' => ['nullable', 'string', 'max:100'],
+            'measured_value' => ['nullable', 'numeric'],
+            'result' => ['nullable', 'in:ok,nok,na'],
+            'comment' => ['nullable', 'string'],
+            'measured_at' => ['nullable', 'date'],
+            'instrument_id' => ['nullable', 'integer'],
+        ]);
+
+        $controlPoint = $measure->ControlPoint;
+        $resultData = $this->evaluateResult($controlPoint, $validated['measured_value'] ?? $measure->measured_value, $validated['result'] ?? $measure->result);
+
+        if ($resultData['result'] === 'nok' && empty($validated['comment']) && empty($measure->comment)) {
+            return response()->json(['message' => 'Comment is required for non-conforming measures.'], 422);
+        }
+
+        $measure->update([
+            'serial_number' => $validated['serial_number'] ?? $measure->serial_number,
+            'measured_value' => array_key_exists('measured_value', $validated) ? $validated['measured_value'] : $measure->measured_value,
+            'result' => $resultData['result'],
+            'deviation' => $resultData['deviation'],
+            'comment' => $validated['comment'] ?? $measure->comment,
+            'measured_at' => $validated['measured_at'] ?? $measure->measured_at,
+            'instrument_id' => $validated['instrument_id'] ?? $measure->instrument_id,
+        ]);
+
+        return response()->json($measure);
+    }
+
+    private function evaluateResult(InspectionControlPoint $controlPoint, ?float $measuredValue, ?string $requestedResult): array
+    {
+        $hasTolerance = $controlPoint->nominal_value !== null
+            && $controlPoint->tol_min !== null
+            && $controlPoint->tol_max !== null
+            && $measuredValue !== null;
+
+        if ($hasTolerance) {
+            $deviation = $measuredValue - $controlPoint->nominal_value;
+            $minAllowed = $controlPoint->nominal_value + $controlPoint->tol_min;
+            $maxAllowed = $controlPoint->nominal_value + $controlPoint->tol_max;
+            $result = ($measuredValue >= $minAllowed && $measuredValue <= $maxAllowed) ? 'ok' : 'nok';
+
+            return [
+                'result' => $result,
+                'deviation' => $deviation,
+            ];
+        }
+
+        return [
+            'result' => $requestedResult ?? 'ok',
+            'deviation' => $measuredValue !== null && $controlPoint->nominal_value !== null
+                ? $measuredValue - $controlPoint->nominal_value
+                : null,
+        ];
+    }
+}

--- a/app/Http/Controllers/Inspection/InspectionMeasureSessionController.php
+++ b/app/Http/Controllers/Inspection/InspectionMeasureSessionController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Inspection;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use App\Models\Inspection\InspectionMeasureSession;
+use App\Models\Inspection\InspectionProject;
+
+class InspectionMeasureSessionController extends Controller
+{
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show($id)
+    {
+        $session = InspectionMeasureSession::with('Measures')->findOrFail($id);
+
+        return response()->json($session);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request, $projectId)
+    {
+        $project = InspectionProject::findOrFail($projectId);
+
+        $validated = $request->validate([
+            'type' => ['nullable', 'in:lot,serial,recheck'],
+            'quantity_to_measure' => ['nullable', 'integer', 'min:0'],
+            'started_at' => ['nullable', 'date'],
+        ]);
+
+        $sessionCode = strtoupper(Str::random(8));
+
+        $session = InspectionMeasureSession::create([
+            'inspection_project_id' => $project->id,
+            'session_code' => $sessionCode,
+            'type' => $validated['type'] ?? 'lot',
+            'quantity_to_measure' => $validated['quantity_to_measure'] ?? null,
+            'started_at' => $validated['started_at'] ?? now(),
+            'status' => 'open',
+            'created_by' => Auth::id(),
+        ]);
+
+        return response()->json($session, 201);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function submit($id)
+    {
+        $session = InspectionMeasureSession::findOrFail($id);
+        $session->status = 'submitted';
+        $session->ended_at = now();
+        $session->save();
+
+        return response()->json($session);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function close($id)
+    {
+        $session = InspectionMeasureSession::findOrFail($id);
+        $session->status = 'closed';
+        $session->ended_at = now();
+        $session->save();
+
+        return response()->json($session);
+    }
+}

--- a/app/Http/Controllers/Inspection/InspectionNonconformityController.php
+++ b/app/Http/Controllers/Inspection/InspectionNonconformityController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Inspection;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Inspection\InspectionNonconformity;
+use App\Models\Inspection\InspectionProject;
+
+class InspectionNonconformityController extends Controller
+{
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'inspection_project_id' => ['required', 'integer'],
+            'inspection_measure_id' => ['nullable', 'integer'],
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'status' => ['nullable', 'in:open,in_progress,closed'],
+        ]);
+
+        InspectionProject::findOrFail($validated['inspection_project_id']);
+
+        $nonconformity = InspectionNonconformity::create([
+            'inspection_project_id' => $validated['inspection_project_id'],
+            'inspection_measure_id' => $validated['inspection_measure_id'] ?? null,
+            'title' => $validated['title'],
+            'description' => $validated['description'] ?? null,
+            'status' => $validated['status'] ?? 'open',
+            'created_by' => Auth::id(),
+        ]);
+
+        return response()->json($nonconformity, 201);
+    }
+}

--- a/app/Http/Controllers/Inspection/InspectionProjectController.php
+++ b/app/Http/Controllers/Inspection/InspectionProjectController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers\Inspection;
+
+use Illuminate\Http\Request;
+use App\Exports\InspectionMeasuresExport;
+use App\Services\DocumentCodeGenerator;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Maatwebsite\Excel\Facades\Excel;
+use Barryvdh\DomPDF\Facade\Pdf;
+use App\Models\Inspection\InspectionProject;
+
+class InspectionProjectController extends Controller
+{
+    protected $documentCodeGenerator;
+
+    public function __construct(DocumentCodeGenerator $documentCodeGenerator)
+    {
+        $this->documentCodeGenerator = $documentCodeGenerator;
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index(Request $request)
+    {
+        $query = InspectionProject::query();
+
+        if ($request->filled('companies_id')) {
+            $query->where('companies_id', $request->input('companies_id'));
+        }
+
+        if ($request->filled('orders_id')) {
+            $query->where('orders_id', $request->input('orders_id'));
+        }
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->input('status'));
+        }
+
+        if ($request->filled('from')) {
+            $query->whereDate('created_at', '>=', $request->input('from'));
+        }
+
+        if ($request->filled('to')) {
+            $query->whereDate('created_at', '<=', $request->input('to'));
+        }
+
+        $projects = $query->orderBy('created_at', 'desc')->paginate(20);
+
+        return response()->json($projects);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show($id)
+    {
+        $project = InspectionProject::with(['Documents', 'ControlPoints', 'MeasureSessions', 'NonConformities'])
+            ->findOrFail($id);
+
+        return response()->json($project);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'companies_id' => ['required', 'integer'],
+            'orders_id' => ['nullable', 'integer'],
+            'order_lines_id' => ['nullable', 'integer'],
+            'of_id' => ['nullable', 'integer'],
+            'status' => ['nullable', 'in:draft,active,closed,archived'],
+            'quantity_planned' => ['nullable', 'integer', 'min:0'],
+            'serial_tracking' => ['nullable', 'boolean'],
+        ]);
+
+        $lastProject = InspectionProject::orderBy('id', 'desc')->first();
+        $code = $this->documentCodeGenerator->generateDocumentCode('inspection-projects', $lastProject ? $lastProject->id : 0);
+
+        $project = InspectionProject::create(array_merge($validated, [
+            'code' => $code,
+            'created_by' => Auth::id(),
+        ]));
+
+        return response()->json($project, 201);
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request, $id)
+    {
+        $project = InspectionProject::findOrFail($id);
+
+        $validated = $request->validate([
+            'title' => ['sometimes', 'string', 'max:255'],
+            'companies_id' => ['sometimes', 'integer'],
+            'orders_id' => ['nullable', 'integer'],
+            'order_lines_id' => ['nullable', 'integer'],
+            'of_id' => ['nullable', 'integer'],
+            'status' => ['sometimes', 'in:draft,active,closed,archived'],
+            'quantity_planned' => ['nullable', 'integer', 'min:0'],
+            'serial_tracking' => ['nullable', 'boolean'],
+        ]);
+
+        $project->update($validated);
+
+        return response()->json($project);
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function exportXlsx($id)
+    {
+        $project = InspectionProject::findOrFail($id);
+
+        return Excel::download(new InspectionMeasuresExport($project->id), $project->code . '-mesures.xlsx');
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function exportPdf($id)
+    {
+        $project = InspectionProject::with(['Documents', 'ControlPoints', 'MeasureSessions.Measures', 'NonConformities'])
+            ->findOrFail($id);
+
+        $pdf = Pdf::loadView('inspection/inspection-report', [
+            'project' => $project,
+        ]);
+
+        return $pdf->download($project->code . '-rapport.pdf');
+    }
+}

--- a/app/Models/Inspection/InspectionControlPoint.php
+++ b/app/Models/Inspection/InspectionControlPoint.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionControlPoint extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'inspection_project_id',
+        'number',
+        'label',
+        'category',
+        'nominal_value',
+        'tol_min',
+        'tol_max',
+        'unit',
+        'frequency_type',
+        'frequency_value',
+        'plan_page',
+        'plan_ref',
+        'phase',
+        'instrument_type',
+        'is_critical',
+        'order',
+    ];
+
+    protected $casts = [
+        'is_critical' => 'boolean',
+    ];
+
+    public function Project()
+    {
+        return $this->belongsTo(InspectionProject::class, 'inspection_project_id');
+    }
+
+    public function Measures()
+    {
+        return $this->hasMany(InspectionMeasure::class);
+    }
+}

--- a/app/Models/Inspection/InspectionDocument.php
+++ b/app/Models/Inspection/InspectionDocument.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionDocument extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'inspection_project_id',
+        'type',
+        'file_path',
+        'file_name',
+        'mime',
+        'page_count',
+        'version_label',
+    ];
+
+    public function Project()
+    {
+        return $this->belongsTo(InspectionProject::class, 'inspection_project_id');
+    }
+}

--- a/app/Models/Inspection/InspectionInstrument.php
+++ b/app/Models/Inspection/InspectionInstrument.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionInstrument extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'type',
+        'serial',
+        'calibration_due_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'calibration_due_at' => 'date',
+    ];
+
+    public function Measures()
+    {
+        return $this->hasMany(InspectionMeasure::class, 'instrument_id');
+    }
+}

--- a/app/Models/Inspection/InspectionMeasure.php
+++ b/app/Models/Inspection/InspectionMeasure.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionMeasure extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'inspection_measure_session_id',
+        'inspection_control_point_id',
+        'serial_number',
+        'measured_value',
+        'result',
+        'deviation',
+        'comment',
+        'measured_by',
+        'measured_at',
+        'instrument_id',
+    ];
+
+    protected $casts = [
+        'measured_at' => 'datetime',
+    ];
+
+    public function Session()
+    {
+        return $this->belongsTo(InspectionMeasureSession::class, 'inspection_measure_session_id');
+    }
+
+    public function ControlPoint()
+    {
+        return $this->belongsTo(InspectionControlPoint::class, 'inspection_control_point_id');
+    }
+
+    public function Instrument()
+    {
+        return $this->belongsTo(InspectionInstrument::class, 'instrument_id');
+    }
+
+    public function MeasuredBy()
+    {
+        return $this->belongsTo(User::class, 'measured_by');
+    }
+}

--- a/app/Models/Inspection/InspectionMeasureSession.php
+++ b/app/Models/Inspection/InspectionMeasureSession.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionMeasureSession extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'inspection_project_id',
+        'session_code',
+        'type',
+        'quantity_to_measure',
+        'started_at',
+        'ended_at',
+        'status',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'ended_at' => 'datetime',
+    ];
+
+    public function Project()
+    {
+        return $this->belongsTo(InspectionProject::class, 'inspection_project_id');
+    }
+
+    public function Creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function Measures()
+    {
+        return $this->hasMany(InspectionMeasure::class);
+    }
+}

--- a/app/Models/Inspection/InspectionNonconformity.php
+++ b/app/Models/Inspection/InspectionNonconformity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionNonconformity extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'inspection_project_id',
+        'inspection_measure_id',
+        'title',
+        'description',
+        'status',
+        'created_by',
+    ];
+
+    public function Project()
+    {
+        return $this->belongsTo(InspectionProject::class, 'inspection_project_id');
+    }
+
+    public function Measure()
+    {
+        return $this->belongsTo(InspectionMeasure::class, 'inspection_measure_id');
+    }
+
+    public function Creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/Inspection/InspectionProject.php
+++ b/app/Models/Inspection/InspectionProject.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models\Inspection;
+
+use App\Models\User;
+use App\Models\Companies\Companies;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class InspectionProject extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'code',
+        'title',
+        'companies_id',
+        'orders_id',
+        'order_lines_id',
+        'of_id',
+        'status',
+        'quantity_planned',
+        'serial_tracking',
+        'created_by',
+    ];
+
+    public function Company()
+    {
+        return $this->belongsTo(Companies::class, 'companies_id');
+    }
+
+    public function Creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function Documents()
+    {
+        return $this->hasMany(InspectionDocument::class);
+    }
+
+    public function ControlPoints()
+    {
+        return $this->hasMany(InspectionControlPoint::class)->orderBy('order');
+    }
+
+    public function MeasureSessions()
+    {
+        return $this->hasMany(InspectionMeasureSession::class);
+    }
+
+    public function NonConformities()
+    {
+        return $this->hasMany(InspectionNonconformity::class);
+    }
+}

--- a/database/migrations/2025_02_14_000001_create_inspection_projects_table.php
+++ b/database/migrations/2025_02_14_000001_create_inspection_projects_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_projects', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('title');
+            $table->unsignedBigInteger('companies_id');
+            $table->unsignedBigInteger('orders_id')->nullable();
+            $table->unsignedBigInteger('order_lines_id')->nullable();
+            $table->unsignedBigInteger('of_id')->nullable();
+            $table->string('status')->default('draft');
+            $table->integer('quantity_planned')->nullable();
+            $table->boolean('serial_tracking')->default(false);
+            $table->unsignedBigInteger('created_by');
+            $table->timestamps();
+
+            $table->index(['companies_id', 'orders_id']);
+            $table->index('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_projects');
+    }
+}

--- a/database/migrations/2025_02_14_000002_create_inspection_documents_table.php
+++ b/database/migrations/2025_02_14_000002_create_inspection_documents_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionDocumentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_documents', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('inspection_project_id');
+            $table->string('type')->default('plan');
+            $table->string('file_path');
+            $table->string('file_name');
+            $table->string('mime');
+            $table->integer('page_count')->nullable();
+            $table->string('version_label')->nullable();
+            $table->timestamps();
+
+            $table->index('inspection_project_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_documents');
+    }
+}

--- a/database/migrations/2025_02_14_000003_create_inspection_control_points_table.php
+++ b/database/migrations/2025_02_14_000003_create_inspection_control_points_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionControlPointsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_control_points', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('inspection_project_id');
+            $table->integer('number');
+            $table->string('label');
+            $table->string('category')->default('dimension');
+            $table->decimal('nominal_value', 12, 4)->nullable();
+            $table->decimal('tol_min', 12, 4)->nullable();
+            $table->decimal('tol_max', 12, 4)->nullable();
+            $table->string('unit')->nullable();
+            $table->string('frequency_type')->default('all');
+            $table->integer('frequency_value')->nullable();
+            $table->integer('plan_page')->nullable();
+            $table->string('plan_ref')->nullable();
+            $table->string('phase')->nullable();
+            $table->string('instrument_type')->nullable();
+            $table->boolean('is_critical')->default(false);
+            $table->integer('order')->default(0);
+            $table->timestamps();
+
+            $table->index(['inspection_project_id', 'number']);
+            $table->index('is_critical');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_control_points');
+    }
+}

--- a/database/migrations/2025_02_14_000004_create_inspection_measure_sessions_table.php
+++ b/database/migrations/2025_02_14_000004_create_inspection_measure_sessions_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionMeasureSessionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_measure_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('inspection_project_id');
+            $table->string('session_code');
+            $table->string('type')->default('lot');
+            $table->integer('quantity_to_measure')->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('ended_at')->nullable();
+            $table->string('status')->default('open');
+            $table->unsignedBigInteger('created_by');
+            $table->timestamps();
+
+            $table->index(['inspection_project_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_measure_sessions');
+    }
+}

--- a/database/migrations/2025_02_14_000005_create_inspection_measures_table.php
+++ b/database/migrations/2025_02_14_000005_create_inspection_measures_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionMeasuresTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_measures', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('inspection_measure_session_id');
+            $table->unsignedBigInteger('inspection_control_point_id');
+            $table->string('serial_number')->nullable();
+            $table->decimal('measured_value', 12, 4)->nullable();
+            $table->string('result')->default('ok');
+            $table->decimal('deviation', 12, 4)->nullable();
+            $table->text('comment')->nullable();
+            $table->unsignedBigInteger('measured_by');
+            $table->timestamp('measured_at');
+            $table->unsignedBigInteger('instrument_id')->nullable();
+            $table->timestamps();
+
+            $table->index(['inspection_measure_session_id', 'inspection_control_point_id'], 'inspection_measures_session_point');
+            $table->index('serial_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_measures');
+    }
+}

--- a/database/migrations/2025_02_14_000006_create_inspection_instruments_table.php
+++ b/database/migrations/2025_02_14_000006_create_inspection_instruments_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionInstrumentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_instruments', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('type')->nullable();
+            $table->string('serial')->nullable();
+            $table->date('calibration_due_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['type', 'is_active']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_instruments');
+    }
+}

--- a/database/migrations/2025_02_14_000007_create_inspection_nonconformities_table.php
+++ b/database/migrations/2025_02_14_000007_create_inspection_nonconformities_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInspectionNonconformitiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inspection_nonconformities', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('inspection_project_id');
+            $table->unsignedBigInteger('inspection_measure_id')->nullable();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('status')->default('open');
+            $table->unsignedBigInteger('created_by');
+            $table->timestamps();
+
+            $table->index(['inspection_project_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inspection_nonconformities');
+    }
+}

--- a/resources/views/inspection/inspection-report.blade.php
+++ b/resources/views/inspection/inspection-report.blade.php
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <title>Rapport d'inspection - {{ $project->code }}</title>
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; color: #222; }
+        h1 { font-size: 20px; margin-bottom: 0; }
+        h2 { font-size: 16px; margin-top: 24px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+        th, td { border: 1px solid #ccc; padding: 6px; text-align: left; }
+        th { background: #f1f1f1; }
+        .muted { color: #666; }
+        .badge-ok { color: #0a7d2c; font-weight: bold; }
+        .badge-nok { color: #b00020; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Rapport d'inspection {{ $project->code }}</h1>
+    <p class="muted">Généré le {{ now()->format('d/m/Y H:i') }}</p>
+
+    <h2>Informations projet</h2>
+    <table>
+        <tr>
+            <th>Projet</th>
+            <td>{{ $project->title }}</td>
+        </tr>
+        <tr>
+            <th>Client</th>
+            <td>{{ optional($project->Company)->label }}</td>
+        </tr>
+        <tr>
+            <th>Commande</th>
+            <td>{{ $project->orders_id ?? '-' }}</td>
+        </tr>
+        <tr>
+            <th>Quantité prévue</th>
+            <td>{{ $project->quantity_planned ?? '-' }}</td>
+        </tr>
+        <tr>
+            <th>Statut</th>
+            <td>{{ $project->status }}</td>
+        </tr>
+    </table>
+
+    <h2>Points de contrôle</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Libellé</th>
+                <th>Nominal</th>
+                <th>Tolérance</th>
+                <th>Unité</th>
+                <th>Plan</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($project->ControlPoints as $point)
+                <tr>
+                    <td>{{ $point->number }}</td>
+                    <td>{{ $point->label }}</td>
+                    <td>{{ $point->nominal_value ?? '-' }}</td>
+                    <td>
+                        @if($point->tol_min !== null || $point->tol_max !== null)
+                            {{ $point->tol_min ?? '-' }} / {{ $point->tol_max ?? '-' }}
+                        @else
+                            -
+                        @endif
+                    </td>
+                    <td>{{ $point->unit ?? '-' }}</td>
+                    <td>
+                        @if($point->plan_page || $point->plan_ref)
+                            {{ $point->plan_page ? 'P. ' . $point->plan_page : '' }} {{ $point->plan_ref }}
+                        @else
+                            -
+                        @endif
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <h2>Mesures</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Session</th>
+                <th>Point</th>
+                <th>Série</th>
+                <th>Valeur</th>
+                <th>Résultat</th>
+                <th>Écart</th>
+                <th>Opérateur</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($project->MeasureSessions as $session)
+                @foreach($session->Measures as $measure)
+                    <tr>
+                        <td>{{ $session->session_code }}</td>
+                        <td>{{ optional($measure->ControlPoint)->number }} - {{ optional($measure->ControlPoint)->label }}</td>
+                        <td>{{ $measure->serial_number ?? '-' }}</td>
+                        <td>{{ $measure->measured_value ?? '-' }}</td>
+                        <td>
+                            @if($measure->result === 'ok')
+                                <span class="badge-ok">OK</span>
+                            @elseif($measure->result === 'nok')
+                                <span class="badge-nok">NOK</span>
+                            @else
+                                NA
+                            @endif
+                        </td>
+                        <td>{{ $measure->deviation ?? '-' }}</td>
+                        <td>{{ optional($measure->MeasuredBy)->name ?? '-' }}</td>
+                        <td>{{ optional($measure->measured_at)->format('d/m/Y H:i') }}</td>
+                    </tr>
+                @endforeach
+            @endforeach
+        </tbody>
+    </table>
+
+    <h2>Non-conformités</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Titre</th>
+                <th>Description</th>
+                <th>Statut</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($project->NonConformities as $nc)
+                <tr>
+                    <td>{{ $nc->title }}</td>
+                    <td>{{ $nc->description ?? '-' }}</td>
+                    <td>{{ $nc->status }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3">Aucune non-conformité.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,3 +54,11 @@ Route::prefix('collaboration/whiteboards')->name('api.collaboration.whiteboards.
     Route::get('/{whiteboard}/files', [WhiteboardFileController::class, 'index'])->name('files.index');
     Route::post('/{whiteboard}/files', [WhiteboardFileController::class, 'store'])->name('files.store');
 });
+
+Route::middleware('auth:api')->group(function () {
+    Route::get('/inspection-projects/{id}', 'App\Http\Controllers\Inspection\InspectionProjectController@show');
+    Route::get('/inspection-sessions/{id}', 'App\Http\Controllers\Inspection\InspectionMeasureSessionController@show');
+    Route::post('/inspection-measures', 'App\Http\Controllers\Inspection\InspectionMeasureController@store');
+    Route::put('/inspection-measures/{id}', 'App\Http\Controllers\Inspection\InspectionMeasureController@update');
+    Route::post('/inspection-nonconformities', 'App\Http\Controllers\Inspection\InspectionNonconformityController@store');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -567,6 +567,22 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         });
     });
 
+    Route::group(['prefix' => 'inspection-projects', 'middleware' => ['auth', 'check.factory']], function () {
+        Route::get('/', 'App\Http\Controllers\Inspection\InspectionProjectController@index')->name('inspection.projects.index');
+        Route::post('/', 'App\Http\Controllers\Inspection\InspectionProjectController@store')->name('inspection.projects.store');
+        Route::get('/{id}', 'App\Http\Controllers\Inspection\InspectionProjectController@show')->name('inspection.projects.show');
+        Route::put('/{id}', 'App\Http\Controllers\Inspection\InspectionProjectController@update')->name('inspection.projects.update');
+        Route::post('/{id}/documents', 'App\Http\Controllers\Inspection\InspectionDocumentController@store')->name('inspection.projects.documents.store');
+        Route::post('/{id}/control-points', 'App\Http\Controllers\Inspection\InspectionControlPointController@store')->name('inspection.projects.points.store');
+        Route::put('/control-points/{id}', 'App\Http\Controllers\Inspection\InspectionControlPointController@update')->name('inspection.points.update');
+        Route::delete('/control-points/{id}', 'App\Http\Controllers\Inspection\InspectionControlPointController@destroy')->name('inspection.points.destroy');
+        Route::post('/{id}/sessions', 'App\Http\Controllers\Inspection\InspectionMeasureSessionController@store')->name('inspection.projects.sessions.store');
+        Route::post('/sessions/{id}/submit', 'App\Http\Controllers\Inspection\InspectionMeasureSessionController@submit')->name('inspection.sessions.submit');
+        Route::post('/sessions/{id}/close', 'App\Http\Controllers\Inspection\InspectionMeasureSessionController@close')->name('inspection.sessions.close');
+        Route::get('/{id}/export/pdf', 'App\Http\Controllers\Inspection\InspectionProjectController@exportPdf')->name('inspection.projects.export.pdf');
+        Route::get('/{id}/export/xlsx', 'App\Http\Controllers\Inspection\InspectionProjectController@exportXlsx')->name('inspection.projects.export.xlsx');
+    });
+
     Route::group(['prefix' => 'methods', 'middleware' => ['auth', 'check.factory']], function () {
         // Index route
         Route::get('/', 'App\Http\Controllers\Methods\MethodsController@index')->name('methods');


### PR DESCRIPTION
### Motivation

- Fournir les bases du module « inspection » V1 pour créer des projets d'inspection liés à commande/OF, attacher des plans, définir des points de contrôle, saisir des sessions de mesure, tracer opérateur/instrument et produire des exports (PDF/XLSX).
- Couvrir le périmètre V1 (import PDF/images, gestion projet, points de contrôle structurés, sessions, saisie mesures with verdicts, NC simple, exports) sans annotation graphique sur PDF.

### Description

- Ajout des migrations pour les tables `inspection_projects`, `inspection_documents`, `inspection_control_points`, `inspection_measure_sessions`, `inspection_measures`, `inspection_instruments` et `inspection_nonconformities`.
- Création des modèles sous `App\Models\Inspection\*` et des contrôleurs REST sous `App\Http\Controllers\Inspection\*` pour gérer projets, documents, points, sessions, mesures et non‑conformités.
- Routage web et API ajouté (`routes/web.php` et `routes/api.php`) avec endpoints pour création/édition/listing, upload de documents, gestion des points, sessions, mesures et exports PDF/XLSX.
- Export XLSX via `App\Exports\InspectionMeasuresExport` et rapport PDF via la vue `resources/views/inspection/inspection-report.blade.php` en utilisant `maatwebsite/excel` et `barryvdh/laravel-dompdf`.
- Logique métier implémentée pour l'évaluation automatique des mesures (`evaluateResult`), validations côté serveur (contrôle de `serial_tracking`, obligation de commentaire pour `nok`, état de session ouvert pour saisie), et gestion simple du cycle de session (`open|submitted|closed`).

### Testing

- Aucun test automatisé n'a été exécuté dans cette modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680e79d86c832db8d7f8139ba8cb59)