### PR TITLE
Style purchase quotation line form like purchase order

### DIFF
--- a/app/Livewire/PurchasesQuotationLines.php
+++ b/app/Livewire/PurchasesQuotationLines.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use Livewire\Component;
+use App\Models\Admin\Factory;
 use App\Models\Purchases\PurchasesQuotation;
 use App\Models\Purchases\PurchaseQuotationLines;
 
@@ -17,6 +18,7 @@ class PurchasesQuotationLines extends Component
     public $qty_to_order = 0;
     public $unit_price = 0;
     public $OrderStatu;
+    public $Factory;
 
     public function mount($purchaseQuotationId)
     {
@@ -25,6 +27,7 @@ class PurchasesQuotationLines extends Component
         $this->purchase_quotation_id = $quotation->id;
         $this->OrderStatu = $quotation->statu;
         $this->ordre = $this->getNextQuotationLineOrder($quotation->id);
+        $this->Factory = Factory::first();
     }
 
     public function render()

--- a/resources/views/livewire/purchases-quotation-lines.blade.php
+++ b/resources/views/livewire/purchases-quotation-lines.blade.php
@@ -16,22 +16,42 @@
                             <div class="form-row">
                                 <div class="form-group col-md-2">
                                     <label for="ordre">{{ __('general_content.sort_trans_key') }} :</label>
-                                    <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" min="0" wire:model.live="ordre">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text"><i class="fas fa-sort-numeric-down"></i></span>
+                                        </div>
+                                        <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.live="ordre">
+                                    </div>
                                     @error('ordre') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-4">
                                     <label for="line_label">{{ __('general_content.description_trans_key') }}</label>
-                                    <input type="text" class="form-control @error('line_label') is-invalid @enderror" id="line_label" wire:model.live="line_label">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text"><i class="fas fa-tags"></i></span>
+                                        </div>
+                                        <input type="text" class="form-control @error('line_label') is-invalid @enderror" id="line_label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.live="line_label">
+                                    </div>
                                     @error('line_label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-2">
                                     <label for="qty_to_order">{{ __('general_content.qty_trans_key') }}</label>
-                                    <input type="number" class="form-control @error('qty_to_order') is-invalid @enderror" id="qty_to_order" min="0" wire:model.live="qty_to_order">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text"><i class="fas fa-times"></i></span>
+                                        </div>
+                                        <input type="number" class="form-control @error('qty_to_order') is-invalid @enderror" id="qty_to_order" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.live="qty_to_order">
+                                    </div>
                                     @error('qty_to_order') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-2">
                                     <label for="unit_price">{{ __('general_content.price_trans_key') }}</label>
-                                    <input type="number" class="form-control @error('unit_price') is-invalid @enderror" id="unit_price" min="0" step="0.01" wire:model.live="unit_price">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text">{{ $Factory->curency ?? 'EUR' }}</span>
+                                        </div>
+                                        <input type="number" class="form-control @error('unit_price') is-invalid @enderror" id="unit_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" step="0.01" wire:model.live="unit_price">
+                                    </div>
                                     @error('unit_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-2 d-flex align-items-end">


### PR DESCRIPTION
### Motivation
- Make the purchase quotation lines form match the purchase order form in look and behavior so users get a consistent UI and currency display.
- Ensure the quotation line form displays the factory currency symbol like other purchase forms.

### Description
- Load factory settings into the Livewire component by importing `App\Models\Admin\Factory`, exposing a `Factory` public property, and setting it in `mount()` (`app/Livewire/PurchasesQuotationLines.php`).
- Restyle the purchase quotation line inputs to use Bootstrap input groups, icons and placeholders and add a currency prefix that uses `$Factory->curency ?? 'EUR'` in `resources/views/livewire/purchases-quotation-lines.blade.php`.
- Kept existing validation and create/update logic intact in the Livewire component so functionality is unchanged.

### Testing
- No automated test suite was executed for this change; an attempt to run the app locally with `php artisan serve` failed due to missing `vendor/autoload.php` in the environment (vendor dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696814b8b314832db10271f03255719b)