### PR TITLE
Add Inspection link to Quality menu and update AdminLTE menu translations

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -545,6 +545,11 @@ return [
                     'icon_color' => 'danger',
                 ],
                 [
+                    'text' => 'inspection_trans_key',
+                    'url'  => 'inspection-projects',
+                    'icon_color' => 'info',
+                ],
+                [
                     'text' => 'amdec_trans_key',
                     'url'  => 'quality/amdec',
                     'icon_color' => 'teal',

--- a/resources/lang/vendor/adminlte/de/menu.php
+++ b/resources/lang/vendor/adminlte/de/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Wichtig',
     'warning'                       => 'Warnung',
     'information'                   => 'Information',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -54,6 +54,7 @@ return [
     'derogations_trans_key'                    => 'Derogations',
     'non_conformities_trans_key'               => 'Non conformities',
     'amdec_trans_key'                          => 'FMEA',
+    'inspection_trans_key'                 => 'Inspection',
     'settings_trans_key'                       => 'Settings',
     'settings_time_trans_key'                  => 'Settings time',
     'methods_trans_key'                        => 'Methods',

--- a/resources/lang/vendor/adminlte/es/menu.php
+++ b/resources/lang/vendor/adminlte/es/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Advertencia',
     'information'                   => 'Información',
     'whiteboard_trans_key'          => 'Pizarra',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/fr/menu.php
+++ b/resources/lang/vendor/adminlte/fr/menu.php
@@ -54,6 +54,7 @@ return [
     'derogations_trans_key'                    => 'Dérogations',
     'non_conformities_trans_key'               => 'Non conformités',
     'amdec_trans_key'                          => 'AMDEC',
+    'inspection_trans_key'                 => 'Inspection',
     'settings_trans_key'                       => 'Paramètres',
     'settings_time_trans_key'                  => 'Temps management',
     'methods_trans_key'                        => 'Méthodes',

--- a/resources/lang/vendor/adminlte/id/menu.php
+++ b/resources/lang/vendor/adminlte/id/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Penting',
     'warning'                       => 'Peringatan',
     'information'                   => 'Informasi',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/it/menu.php
+++ b/resources/lang/vendor/adminlte/it/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Importante',
     'warning'                       => 'Avvertimento',
     'information'                   => 'Informazione',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/ja/menu.php
+++ b/resources/lang/vendor/adminlte/ja/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => '重要',
     'warning'                       => '警告',
     'information'                   => 'インフォメーション',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/la/menu.php
+++ b/resources/lang/vendor/adminlte/la/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'ສຳຄັນ',
     'warning'                       => 'ຄຳເຕືອນ',
     'information'                   => 'ຂໍ້ມູນ',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/pl/menu.php
+++ b/resources/lang/vendor/adminlte/pl/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Ważne',
     'warning'                       => 'Ostrzeżenie',
     'information'                   => 'Informacja',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/pt-br/menu.php
+++ b/resources/lang/vendor/adminlte/pt-br/menu.php
@@ -16,4 +16,5 @@ return [
     'Important'                     => 'Importante',
     'Warning'                       => 'Aviso',
     'Information'                   => 'Informação',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/ru/menu.php
+++ b/resources/lang/vendor/adminlte/ru/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Важно',
     'warning'                       => 'Внимание',
     'information'                   => 'Информация',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/sr/menu.php
+++ b/resources/lang/vendor/adminlte/sr/menu.php
@@ -18,4 +18,5 @@ return [
     'information'                   => 'Informacije',
     'menu'                          => 'MENI',
     'users'                         => 'Korisnici',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/tr/menu.php
+++ b/resources/lang/vendor/adminlte/tr/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Önemli',
     'warning'                       => 'Uyarı',
     'information'                   => 'Bilgi',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/uk/menu.php
+++ b/resources/lang/vendor/adminlte/uk/menu.php
@@ -16,4 +16,5 @@ return [
     'important'                     => 'Важливо',
     'warning'                       => 'Увага',
     'information'                   => 'Інформація',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/vi/menu.php
+++ b/resources/lang/vendor/adminlte/vi/menu.php
@@ -55,4 +55,5 @@ return [
     'energy_consumption_trans_key'             => 'Mức tiêu thụ năng lượng',
     'licence_trans_key'                        => 'Bản quyền',
     'release_note_trans_key'                   => 'Ghi chú phát hành',
+    'inspection_trans_key'                 => 'Inspection',
 ];

--- a/resources/lang/vendor/adminlte/zh-CN/menu.php
+++ b/resources/lang/vendor/adminlte/zh-CN/menu.php
@@ -54,6 +54,7 @@ return [
     'derogations_trans_key'                    => '特批',
     'non_conformities_trans_key'               => '不合格',
     'amdec_trans_key'                          => '失效模式分析 (AMDEC)',
+    'inspection_trans_key'                 => 'Inspection',
     'settings_trans_key'                       => '设置',
     'settings_time_trans_key'                  => '时间管理',
     'methods_trans_key'                        => '方法',


### PR DESCRIPTION
### Motivation
- Expose the inspection functionality from the UI by adding a direct link under the `Quality` submenu so inspection projects are easier to access.
- Ensure the new menu label is available in the AdminLTE menu translations across locales so the menu renders correctly for all supported languages.

### Description
- Added a new submenu item to `Quality` in `config/adminlte.php` that links to `inspection-projects` with the translatable key `inspection_trans_key`.
- Added the `inspection_trans_key` label to multiple AdminLTE menu translation files under `resources/lang/vendor/adminlte/*/menu.php` (examples: `en/menu.php`, `fr/menu.php`) so the menu label is available in all locales.
- Updated a number of locale files to keep AdminLTE menu strings consistent with the new entry across supported languages.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968151bfe40832dae62faf406597afb)