### PR TITLE
Preserve Livewire tab active state for purchase quotation lines

### DIFF
--- a/resources/views/livewire/purchases-quotation-lines.blade.php
+++ b/resources/views/livewire/purchases-quotation-lines.blade.php
@@ -1,4 +1,4 @@
-<div class="tab-pane" id="PurchaseQuotationLines">
+<div class="tab-pane" id="PurchaseQuotationLines" wire:ignore.self>
     <div class="row">
         <div class="col-12">
             <div class="card">


### PR DESCRIPTION
### Motivation
- Prevent the Livewire component from causing the Bootstrap tab pane to be replaced and the tab to disappear after component updates on the purchase quotation lines view.

### Description
- Add `wire:ignore.self` to the root `<div class="tab-pane" id="PurchaseQuotationLines">` in `resources/views/livewire/purchases-quotation-lines.blade.php` to stop Livewire from replacing the tab container on DOM updates.

### Testing
- Ran a Playwright smoke script that opened the app and captured a screenshot (`artifacts/purchase-quotation-lines.png`), which completed successfully; no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696f1e4878832db3b1f50d5ae2005e)