### PR TITLE
Add delivery note date range filter to invoice requests

### DIFF
--- a/app/Livewire/InvoicesRequest.php
+++ b/app/Livewire/InvoicesRequest.php
@@ -26,6 +26,8 @@ class InvoicesRequest extends Component
     public $code, $label, $companies_id, $companies_addresses_id, $companies_contacts_id, $user_id; 
     public $updateLines = false;
     public $CompanieSelect = [];
+    public $deliveryDateStart;
+    public $deliveryDateEnd;
     public $data = [];
     public $qty = [];
     public $idCompanie = '';
@@ -92,7 +94,13 @@ class InvoicesRequest extends Component
         
         //Select delevery line where not Partly invoiced or Invoiced
         $this->InvoicesRequestsLineslist = $this->InvoiceDataService
-        ->getInvoiceRequestsLines($this->companies_id ? (int) $this->companies_id : null,$this->sortField, $this->sortAsc);
+        ->getInvoiceRequestsLines(
+            $this->companies_id ? (int) $this->companies_id : null,
+            $this->deliveryDateStart,
+            $this->deliveryDateEnd,
+            $this->sortField,
+            $this->sortAsc
+        );
 
         return view('livewire.invoices-request', [
             'InvoicesRequestsLineslist' => $this->InvoicesRequestsLineslist,

--- a/app/Services/InvoiceDataService.php
+++ b/app/Services/InvoiceDataService.php
@@ -27,17 +27,31 @@ class InvoiceDataService
      * Get invoice request lines filtered by company ID and sorted by provided parameters.
      *
      * @param int|null $companyId
+     * @param string|null $dateStart
+     * @param string|null $dateEnd
      * @param string $sortField
      * @param bool $sortAsc
      * @return Collection
      */
-    public function getInvoiceRequestsLines(?int $companyId, string $sortField = 'id', bool $sortAsc = true): Collection
+    public function getInvoiceRequestsLines(
+        ?int $companyId,
+        ?string $dateStart = null,
+        ?string $dateEnd = null,
+        string $sortField = 'id',
+        bool $sortAsc = true
+    ): Collection
     {
         return DeliveryLines::orderBy($sortField, $sortAsc ? 'asc' : 'desc')
             ->whereIn('invoice_status', ['1', '2'])
-            ->whereHas('delivery', function ($q) use ($companyId) {
+            ->whereHas('delivery', function ($q) use ($companyId, $dateStart, $dateEnd) {
                 if (!empty($companyId)) {
                     $q->where('companies_id', '=', (int)$companyId);
+                }
+                if (!empty($dateStart)) {
+                    $q->whereDate('created_at', '>=', $dateStart);
+                }
+                if (!empty($dateEnd)) {
+                    $q->whereDate('created_at', '<=', $dateEnd);
                 }
             })->get();
     }

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -193,6 +193,8 @@ return [
     'discount_trans_key'                       => 'الخصم',
     'vat_trans_key'                            => 'ضريبة القيمة المضافة',
     'delivery_date_trans_key'                  => 'تاريخ التسليم',
+    'delivery_note_date_from_trans_key'        => 'تاريخ إشعار التسليم من',
+    'delivery_note_date_to_trans_key'          => 'تاريخ إشعار التسليم إلى',
     'internal_delay_trans_key'                 => 'التأخير الداخلي',
     'tasks_status_trans_key'                   => 'حالة المهام',
     'delivery_status_trans_key'                => 'حالة التسليم',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -229,6 +229,8 @@ return [
     'discount_trans_key'                       => 'Discount',
     'vat_trans_key'                            => 'VAT',
     'delivery_date_trans_key'                  => 'Delivery date',
+    'delivery_note_date_from_trans_key'        => 'Delivery note date from',
+    'delivery_note_date_to_trans_key'          => 'Delivery note date to',
     'internal_delay_trans_key'                 => 'Internal delay',
     'tasks_status_trans_key'                   => 'Tasks status',
     'delivery_status_trans_key'                => 'Delivery status',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -193,6 +193,8 @@ return [
     'discount_trans_key'                       => 'Descuento',
     'vat_trans_key'                            => 'IVA',
     'delivery_date_trans_key'                  => 'Fecha de entrega',
+    'delivery_note_date_from_trans_key'        => 'Fecha del albarán desde',
+    'delivery_note_date_to_trans_key'          => 'Fecha del albarán hasta',
     'tasks_status_trans_key'                   => 'Estado de tareas',
     'delivery_status_trans_key'                => 'Estado de entrega',
     'invoice_status_trans_key'                 => 'Estado de factura',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -229,6 +229,8 @@ return [
     'discount_trans_key'                       => 'Réduction',
     'vat_trans_key'                            => 'TVA',
     'delivery_date_trans_key'                  => 'Date de livraison',
+    'delivery_note_date_from_trans_key'        => 'Date du bon de livraison du',
+    'delivery_note_date_to_trans_key'          => 'Date du bon de livraison au',
     'internal_delay_trans_key'                 => 'délai interne',
     'tasks_status_trans_key'                   => 'Statut des taches',
     'delivery_status_trans_key'                => 'Statut de livraison',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -84,6 +84,8 @@ return [
     'delivery_notes_trans_key'                 => 'Ghi chép giao hàng',
     'deliverys_notes_request_trans_key'        => 'Yêu cầu ghi chép giao hàng',
     'deliverys_notes_list_trans_key'           => 'Danh sách ghi chép giao hàng',
+    'delivery_note_date_from_trans_key'        => 'Ngày phiếu giao hàng từ',
+    'delivery_note_date_to_trans_key'          => 'Ngày phiếu giao hàng đến',
     'invoices_trans_key'                       => 'Hóa đơn',
     'invoices_request_trans_key'               => 'Yêu cầu hóa đơn',
     'invoices_list_trans_key'                  => 'Danh sách hóa đơn',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -220,6 +220,8 @@ return [
     'discount_trans_key'                       => '折扣',
     'vat_trans_key'                            => '增值税',
     'delivery_date_trans_key'                  => '交货日期',
+    'delivery_note_date_from_trans_key'        => '送货单日期从',
+    'delivery_note_date_to_trans_key'          => '送货单日期至',
     'internal_delay_trans_key'                 => '内部周期',
     'tasks_status_trans_key'                   => '任务状态',
     'delivery_status_trans_key'                => '交付状态',

--- a/resources/views/livewire/invoices-request.blade.php
+++ b/resources/views/livewire/invoices-request.blade.php
@@ -23,6 +23,24 @@
                         @error('companies_id') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
                     <div class="form-group col-md-3">
+                        <label for="delivery_date_start">{{ __('general_content.delivery_note_date_from_trans_key') }}</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-calendar-alt"></i></span>
+                            </div>
+                            <input type="date" class="form-control" wire:model.live="deliveryDateStart" name="delivery_date_start" id="delivery_date_start">
+                        </div>
+                    </div>
+                    <div class="form-group col-md-3">
+                        <label for="delivery_date_end">{{ __('general_content.delivery_note_date_to_trans_key') }}</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-calendar-alt"></i></span>
+                            </div>
+                            <input type="date" class="form-control" wire:model.live="deliveryDateEnd" name="delivery_date_end" id="delivery_date_end">
+                        </div>
+                    </div>
+                    <div class="form-group col-md-3">
                         <label for="code">{{ __('general_content.external_id_trans_key') }}</label>
                         <div class="input-group">
                             <div class="input-group-prepend">


### PR DESCRIPTION
### Motivation

- Allow users to filter delivery lines shown on the invoice request screen by a delivery-note date range so only lines "between the ** and **" are available for invoicing. 

### Description

- Add Livewire state properties `deliveryDateStart` and `deliveryDateEnd` to `app/Livewire/InvoicesRequest.php` and pass them into the data query used to build the invoice request list. 
- Update `app/Services/InvoiceDataService.php` to accept `dateStart`/`dateEnd` parameters and apply `whereDate('created_at', '>=', ...)` and `whereDate('created_at', '<=', ...)` filters on the delivery relation when provided. 
- Add two date inputs to the invoice request UI in `resources/views/livewire/invoices-request.blade.php` bound to the new Livewire properties. 
- Add translation keys for the new labels (`delivery_note_date_from_trans_key`, `delivery_note_date_to_trans_key`) across supported locales (`resources/lang/{en,fr,es,ar,vi,zh-CN}/general_content.php`).

### Testing

- No automated test suite was executed against these changes. 
- Attempting to run the app server with `php artisan serve` in this environment failed due to missing dependencies (`vendor/autoload.php`), so runtime verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4309a6a8832d95e4622cce7c28bd)