### PR TITLE
Add company-specific Service Rate KPI to company dashboard

### DIFF
--- a/app/Http/Controllers/Companies/CompaniesController.php
+++ b/app/Http/Controllers/Companies/CompaniesController.php
@@ -88,6 +88,7 @@ class CompaniesController extends Controller
         $remainingInvoiceOrder =  $this->orderKPIService->getOrderMonthlyRemainingToInvoice($id->id);
         $paidInvoices = $this->invoiceKPIService->getPaidInvoicesCount($id->id);
         $unpaidInvoices = $this->invoiceKPIService->getUnpaidInvoicesCount($id->id);
+        $serviceRate = $this->orderKPIService->getServiceRate($id->id);
         $data['quotesDataRate'] = $this->quoteKPIService->getQuotesDataRate($CurentYear, $id->id);
         $data['orderMonthlyRecap'] = $this->orderKPIService->getOrderMonthlyRecap($CurentYear, $id->id);
         $data['orderAverage'] = $this->orderKPIService->getAverageOrderPriceAttribute($id->id);
@@ -147,6 +148,7 @@ class CompaniesController extends Controller
                                                         'customerProcessingCost',
                                                         'paidInvoices',
                                                         'unpaidInvoices',
+                                                        'serviceRate',
                                                         'data',
                                                         'evaluationHistory',
                                                         'latestEvaluation',

--- a/app/Services/OrderKPIService.php
+++ b/app/Services/OrderKPIService.php
@@ -422,18 +422,32 @@ class OrderKPIService
     * fulfilled on time (those with a delivery date less than or equal to the
     * expected date) by the total number of requests, then multiplying the result by 100
     *
+    * @param int|null $companyId
     * @return float Service Rate as a percentage
     */
-    public function getServiceRate()
+    public function getServiceRate($companyId = null)
     {
-        $cacheKey = 'service_rate_' . now()->year;
-        return Cache::remember($cacheKey, now()->addHours(1), function () {
-            $totalOrderLines = OrderLines::where('delivery_status', 3)->count();
+        $cacheKey = 'service_rate_' . now()->year . '_company_' . ($companyId ?? 'all');
+        return Cache::remember($cacheKey, now()->addHours(1), function () use ($companyId) {
+            $totalOrderLinesQuery = OrderLines::where('delivery_status', 3);
 
-            $onTimeDeliveries = OrderLines::where('delivery_status', 3)
-                                            ->whereHas('DeliveryLines', function ($query) {
-                                                $query->whereColumn('delivery_lines.created_at', '<=', 'order_lines.delivery_date');
-                                            })->count();
+            $onTimeDeliveriesQuery = OrderLines::where('delivery_status', 3)
+                ->whereHas('DeliveryLines', function ($query) {
+                    $query->whereColumn('delivery_lines.created_at', '<=', 'order_lines.delivery_date');
+                });
+
+            if ($companyId) {
+                $totalOrderLinesQuery->whereHas('order', function ($query) use ($companyId) {
+                    $query->where('companies_id', $companyId);
+                });
+
+                $onTimeDeliveriesQuery->whereHas('order', function ($query) use ($companyId) {
+                    $query->where('companies_id', $companyId);
+                });
+            }
+
+            $totalOrderLines = $totalOrderLinesQuery->count();
+            $onTimeDeliveries = $onTimeDeliveriesQuery->count();
 
             if ($totalOrderLines === 0) {
                 return 0; // Éviter la division par zéro

--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -54,6 +54,13 @@
           </div>
 
           <div class="col-lg-3 col-md-3">
+            <x-adminlte-small-box title="{{ $serviceRate }}%"
+              text="{{ __('general_content.service_rate_trans_key') }}"
+              icon="icon fas fa-chart-line"
+              theme="primary" />
+          </div>
+
+          <div class="col-lg-3 col-md-3">
             <x-adminlte-card  theme="primary" theme-mode="outline">
               <p class="card-text">{{ __('general_content.bills_paid_trans_key') }} : {{ $paidInvoices }}</p>
               <p class="card-text">{{ __('general_content.bills_unpaid_trans_key') }}  : {{ $unpaidInvoices }}</p>


### PR DESCRIPTION
### Motivation
- Expose the Service Rate KPI per customer so the company detail page can show a customer-specific performance metric.
- Cache the computed KPI to avoid repeated heavy queries when rendering dashboards.

### Description
- Extend `getServiceRate` in `app/Services/OrderKPIService.php` to accept an optional `companyId` parameter and include it in the cache key as `service_rate_<year>_company_<id|all>`.
- Scope the underlying queries to the provided company by adding `whereHas('order', ...)` filters and preserve the original on-time delivery logic using `DeliveryLines` timestamp comparison.
- Wire the new KPI into the company show flow by calling `$this->orderKPIService->getServiceRate($id->id)` in `app/Http/Controllers/Companies/CompaniesController.php` and pass `serviceRate` to the view.
- Add a dashboard tile to `resources/views/companies/companies-show.blade.php` to display the `serviceRate` value with the existing KPI widgets.

### Testing
- No automated tests were executed for this change.
- The change is limited to adding an optional filter and presentation; existing code paths remain unchanged when no `companyId` is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a45f9d250832d8f054952093fbcd9)