### PR TITLE
Fix print manufacturing instruction template markup

### DIFF
--- a/resources/views/print/print-manufacturing-instruction.blade.php
+++ b/resources/views/print/print-manufacturing-instruction.blade.php
@@ -8,16 +8,15 @@
         <h1>Print document</h1>
         </div>
         <div class="col-sm-6">
-        <a class="btn btn-primary btn-sm" href="{{ url()->previous() }}">
-            <button type="button" class="btn btn-primary float-sm-right" data-toggle="modal" data-target="#ModalQuote">
+        <a class="btn btn-primary btn-sm float-sm-right" href="{{ url()->previous() }}">
             {{ __('general_content.back_trans_key') }}
-            </button>
         </a>
         </div>
     </div>
 @stop
 
 @section('right-sidebar')
+@stop
 
 @section('content')
 <div class="container-fluid">
@@ -94,7 +93,7 @@
                     <div class="row">
                         <div class="col-12 table-responsive">
                         <table class="table table-bordered table-sm">
-                            <thead class="thead-light">
+                            <tbody class="thead-light">
                             @forelse($Document->Lines as $DocumentLine)
                                 <tr>
                                     <th rowspan="2" class="align-middle">
@@ -184,7 +183,7 @@
                                 @empty
                                     <x-EmptyDataLine col="3" text="{{ __('general_content.no_data_trans_key') }}"  />
                                 @endforelse
-                            </thead>
+                            </tbody>
                         </table>
                     </div>
                     <!-- /.col -->
@@ -198,6 +197,6 @@
 
 @section('js')
   <script>
-    window.addEventListener("load", window.print());
+    window.addEventListener("load", () => window.print());
   </script>
 @stop


### PR DESCRIPTION
### Motivation
- The print view contained incorrect markup and an unclosed section which could break layout and Blade rendering. 
- The back link used nested button markup which doubled styling and complexity. 
- Table semantics and the print-on-load handler needed minor fixes to improve HTML correctness and printing behavior.

### Description
- Replace the nested `<button>` inside the anchor with a single anchor link by changing the back link to `<a class="btn btn-primary btn-sm float-sm-right" href="{{ url()->previous() }}">` and the translated label. 
- Close the previously unclosed Blade section by adding `@stop` after `@section('right-sidebar')`. 
- Move the document rows from a `<thead>` to a `<tbody class="thead-light">` to use correct table structure for body rows. 
- Change the print event registration from `window.addEventListener("load", window.print());` to `window.addEventListener("load", () => window.print());` so a function reference is passed correctly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a608674ec832d90eab591cdea9d14)