### PR TITLE
Add select-all toggle to delivery request lines

### DIFF
--- a/app/Livewire/DeliverysRequest.php
+++ b/app/Livewire/DeliverysRequest.php
@@ -55,6 +55,7 @@ class DeliverysRequest extends Component
     public $CompanieSelect = [];
     public $data = [];
     public $qty = [];
+    public $selectAll = false;
 
     private $ordre = 10;
 
@@ -86,6 +87,25 @@ class DeliverysRequest extends Component
         $deliveryId = $this->LastDelivery ? $this->LastDelivery->id : 0;
         $this->code = $this->documentCodeGenerator->generateDocumentCode('delivery', $deliveryId);
         $this->label = $this->code;
+    }
+
+    public function updatedCompaniesId()
+    {
+        $this->selectAll = false;
+        $this->data = [];
+    }
+
+    public function updatedSelectAll($value)
+    {
+        $lines = $this->DeliveryDataService->getDeliveryRequestsLines(
+            $this->companies_id,
+            $this->sortField,
+            $this->sortAsc
+        );
+
+        foreach ($lines as $line) {
+            $this->data[$line->id]['order_line_id'] = $value ? $line->id : false;
+        }
     }
 
     public function render()

--- a/resources/views/livewire/deliverys-request.blade.php
+++ b/resources/views/livewire/deliverys-request.blade.php
@@ -128,7 +128,17 @@
                         <th>{{ __('general_content.discount_trans_key') }}</th>
                         <th>{{ __('general_content.vat_trans_key') }}</th>
                         <th>{{ __('general_content.delivery_date_trans_key') }}</th>
-                        <th>{{__('general_content.action_trans_key') }}</th>
+                        <th>
+                            {{__('general_content.action_trans_key') }}
+                            @if($companies_id)
+                                <div class="custom-control custom-checkbox mt-2">
+                                    <input class="custom-control-input" id="selectAllLines" type="checkbox" wire:model.live="selectAll">
+                                    <label class="custom-control-label" for="selectAllLines">
+                                        {{ $selectAll ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
+                                    </label>
+                                </div>
+                            @endif
+                        </th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
### Motivation
- Provide a way to quickly select/deselect all order lines on the delivery request page when a customer is chosen.  

### Description
- Added a Livewire boolean state `selectAll` to `app/Livewire/DeliverysRequest.php`.  
- Added `updatedCompaniesId()` to reset `selectAll` and `data` when the customer changes and `updatedSelectAll($value)` to fetch the current request lines via `DeliveryDataService->getDeliveryRequestsLines` and set each line's `data[<id>]['order_line_id']` to either the line id or `false`.  
- Added a header checkbox to `resources/views/livewire/deliverys-request.blade.php` that is shown only when a company is selected and toggles between `select_all_lines_trans_key` and `deselect_all_lines_trans_key`.  
- Changes affect `app/Livewire/DeliverysRequest.php` and `resources/views/livewire/deliverys-request.blade.php` and wire the UI toggle to Livewire state.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a60074ef8832db420a795660c56da)