### PR TITLE
Add bulk invoice generation for pending delivery lines (one invoice per order)

### DIFF
--- a/app/Livewire/InvoicesRequest.php
+++ b/app/Livewire/InvoicesRequest.php
@@ -131,6 +131,56 @@ class InvoicesRequest extends Component
         }
     }
 
+    public function generateInvoicesForCompany()
+    {
+        $this->validate([
+            'companies_id' => 'required',
+            'companies_addresses_id' => 'required',
+            'companies_contacts_id' => 'required',
+            'user_id' => 'required',
+        ]);
+
+        $deliveryLines = $this->InvoiceDataService->getInvoiceRequestsLines(
+            (int) $this->companies_id,
+            $this->deliveryDateStart,
+            $this->deliveryDateEnd,
+            $this->sortField,
+            $this->sortAsc
+        );
+
+        if ($deliveryLines->isEmpty()) {
+            session()->flash('error', 'No lines to invoice');
+            return;
+        }
+
+        $deliveryLines
+            ->groupBy(fn($line) => $line->orderLine->orders_id)
+            ->each(function ($lines) {
+                $this->ordre = 10;
+                $invoiceCreated = $this->createInvoiceForCompany();
+
+                foreach ($lines as $deliveryLine) {
+                    $this->invoiceLineService->createInvoiceLine(
+                        $invoiceCreated,
+                        $deliveryLine->order_line_id,
+                        $deliveryLine->id,
+                        $this->ordre,
+                        $deliveryLine->qty,
+                        $deliveryLine->OrderLine->accounting_vats_id
+                    );
+
+                    $this->updateDeliveryLineStatus($deliveryLine);
+                    $this->updateOrderLineInfo($deliveryLine);
+                    $this->ordre += 10;
+                }
+            });
+
+        $this->refreshInvoiceDefaults();
+        $this->data = [];
+
+        session()->flash('success', 'Invoices created');
+    }
+
     private function hasDeliveryLines()
     {
         foreach ($this->data as $item) {
@@ -144,6 +194,30 @@ class InvoicesRequest extends Component
     private function createInvoice()
     {
         return $this->invoiceService->createInvoice($this->code, $this->label, $this->companies_id, $this->companies_addresses_id, $this->companies_contacts_id, $this->user_id);
+    }
+
+    private function createInvoiceForCompany()
+    {
+        $lastInvoice = Invoices::latest()->first();
+        $invoiceId = $lastInvoice ? $lastInvoice->id : 0;
+        $code = $this->documentCodeGenerator->generateDocumentCode('invoice', $invoiceId);
+
+        return $this->invoiceService->createInvoice(
+            $code,
+            $code,
+            $this->companies_id,
+            $this->companies_addresses_id,
+            $this->companies_contacts_id,
+            $this->user_id
+        );
+    }
+
+    private function refreshInvoiceDefaults()
+    {
+        $this->LastInvoice = Invoices::latest()->first();
+        $invoiceId = $this->LastInvoice ? $this->LastInvoice->id : 0;
+        $this->code = $this->documentCodeGenerator->generateDocumentCode('invoice', $invoiceId);
+        $this->label = $this->code;
     }
 
     private function createInvoiceNoteLines($invoiceCreated)

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -777,6 +777,7 @@ return [
     'invoices_export_trans_key'                => 'تصدير أسطر الفاتورة',
     'others_trans_key'                         => 'أخرى',
     'new_invoice_trans_key'                    => 'فاتورة جديدة',
+    'generate_pending_invoices_trans_key'      => 'إنشاء الفواتير المعلقة',
     'number_of_invoice_trans_key'              => 'إجمالي عدد الفواتير',
     'amount_of_invoice_trans_key'              => 'إجمالي مبلغ الفواتير',
     'payments_received_of_invoice_trans_key'   => 'إجمالي المبالغ المستلمة',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -917,6 +917,7 @@ return [
     'invoices_export_trans_key'                => 'Invoice lines export',
     'others_trans_key'                         => 'Others',
     'new_invoice_trans_key'                    => 'New invoice',
+    'generate_pending_invoices_trans_key'      => 'Generate pending invoices',
     'number_of_invoice_trans_key'              => 'Total number of invoices',
     'amount_of_invoice_trans_key'              => 'Total amount of invoices',
     'payments_received_of_invoice_trans_key'   => 'Total amount of payments received',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -777,6 +777,7 @@ return [
     'invoices_export_trans_key'                => 'Exportar líneas de factura',
     'others_trans_key'                         => 'Otros',
     'new_invoice_trans_key'                    => 'Nueva factura',
+    'generate_pending_invoices_trans_key'      => 'Generar facturas pendientes',
     'number_of_invoice_trans_key'              => 'Número total de facturas',
     'amount_of_invoice_trans_key'              => 'Cantidad total de facturas',
     'payments_received_of_invoice_trans_key'   => 'Total de pagos recibidos',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -917,6 +917,7 @@ return [
     'invoices_export_trans_key'                => 'Exporter ligne de facture',
     'others_trans_key'                         => 'Autres',
     'new_invoice_trans_key'                    => 'Nouvelle facture',
+    'generate_pending_invoices_trans_key'      => 'Générer les factures en attente',
     'number_of_invoice_trans_key'              => 'Nombre total de factures',
     'amount_of_invoice_trans_key'              => 'Montant total des factures',
     'payments_received_of_invoice_trans_key'   => 'Montant total des paiements reçus',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -90,6 +90,7 @@ return [
     'invoices_request_trans_key'               => 'Yêu cầu hóa đơn',
     'invoices_list_trans_key'                  => 'Danh sách hóa đơn',
     'others_trans_key'                         => 'Khác',
+    'generate_pending_invoices_trans_key'      => 'Tạo hóa đơn đang chờ',
 
     //PRODUCT
     'product_trans_key'                        => 'Sản phẩm',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -905,6 +905,7 @@ return [
     'invoices_export_trans_key'                => '导出发票行',
     'others_trans_key'                         => '其他',
     'new_invoice_trans_key'                    => '新建发票',
+    'generate_pending_invoices_trans_key'      => '生成待处理发票',
     'number_of_invoice_trans_key'              => '发票总数',
     'amount_of_invoice_trans_key'              => '发票总金额',
     'payments_received_of_invoice_trans_key'   => '已收款总额',

--- a/resources/views/livewire/invoices-request.blade.php
+++ b/resources/views/livewire/invoices-request.blade.php
@@ -113,6 +113,11 @@
                         <div class="input-group">
                             <button type="Submit" wire:click.prevent="storeInvoice()" class="btn btn-success">{{ __('general_content.new_invoice_trans_key') }}</button>
                         </div>
+                        @if($companies_id)
+                            <div class="input-group mt-2">
+                                <button type="button" wire:click.prevent="generateInvoicesForCompany()" class="btn btn-primary">{{ __('general_content.generate_pending_invoices_trans_key') }}</button>
+                            </div>
+                        @endif
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Provide a way to create invoices in bulk for pending delivery lines when a company is selected, generating one invoice per distinct order.
- Allow operators to trigger generation from the `/invoices/request` page via a contextual button when a company is chosen.
- Ensure invoice lines are created and delivery/order statuses are updated automatically.
- Add localized label for the new action across supported locales.

### Description
- Added `generateInvoicesForCompany()` to `app/Livewire/InvoicesRequest.php` which groups pending `DeliveryLines` by order (`orderLine->orders_id`) and creates one invoice per order, creating invoice lines via `InvoiceLineService` and updating statuses.
- Added helpers `createInvoiceForCompany()` and `refreshInvoiceDefaults()` to generate per-order invoice codes using `DocumentCodeGenerator` and to reset the invoice defaults after generation.
- Updated `resources/views/livewire/invoices-request.blade.php` to show a `Generate pending invoices` button (calling `generateInvoicesForCompany()`) only when a company is selected (`$companies_id`).
- Added translations for the new button label `generate_pending_invoices_trans_key` in multiple `resources/lang/*/general_content.php` files (`en`, `fr`, `es`, `ar`, `zh-CN`, `vi`).

### Testing
- No automated unit tests were executed as part of this change.
- An attempt to start the dev server with `php artisan serve --host 0.0.0.0 --port 8000` failed because `vendor/autoload.php` was missing, so runtime smoke verification was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a68c80a18832d874920b5af3bc0e1)