### PR TITLE
Add RFQ grouping and supplier comparison (multi‑supplier RFQ)

### DIFF
--- a/app/Http/Controllers/Purchases/PurchasesRFQController.php
+++ b/app/Http/Controllers/Purchases/PurchasesRFQController.php
@@ -9,6 +9,7 @@ use App\Services\CustomFieldService;
 use App\Services\PurchaseKPIService;
 use App\Services\PurchaseOrderService;
 use App\Models\Purchases\PurchasesQuotation;
+use App\Models\Purchases\PurchaseRfqGroup;
 use App\Http\Requests\Purchases\UpdatePurchaseQuotationRequest;
 
 class PurchasesRFQController extends Controller
@@ -82,6 +83,45 @@ class PurchasesRFQController extends Controller
             'ContactSelect' => $ContactSelect,
             'previousUrl' =>  $previousUrl,
             'nextUrl' =>  $nextUrl,
+        ]);
+    }
+
+    /**
+     * Display a comparison table for a RFQ group.
+     *
+     * @param PurchaseRfqGroup $group
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function compareQuotationGroup(PurchaseRfqGroup $group)
+    {
+        $group->load(['purchaseQuotations.companie', 'purchaseQuotations.PurchaseQuotationLines']);
+        $quotations = $group->purchaseQuotations;
+
+        $lineGroups = collect();
+        foreach ($quotations as $quotation) {
+            foreach ($quotation->PurchaseQuotationLines as $line) {
+                $key = $line->product_id ? 'product-' . $line->product_id : 'line-' . $line->id;
+                if (!$lineGroups->has($key)) {
+                    $lineGroups->put($key, [
+                        'label' => $line->label ?? $line->code ?? __('general_content.line_trans_key'),
+                        'qty' => $line->qty_to_order,
+                        'lines' => [],
+                    ]);
+                }
+
+                $lineGroups[$key]['lines'][$quotation->id] = $line;
+            }
+        }
+
+        $supplierTotals = $quotations->mapWithKeys(function ($quotation) {
+            return [$quotation->id => $quotation->PurchaseQuotationLines->sum('total_price')];
+        });
+
+        return view('purchases/purchases-quotation-compare', [
+            'rfqGroup' => $group,
+            'quotations' => $quotations,
+            'lineGroups' => $lineGroups->values(),
+            'supplierTotals' => $supplierTotals,
         ]);
     }
 

--- a/app/Livewire/PurchasesRequest.php
+++ b/app/Livewire/PurchasesRequest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\App;
 use Carbon\Carbon;
 use App\Services\PurchaseOrderService;
 use App\Services\PurchaseQuotationService;
+use App\Models\Purchases\PurchasesQuotation;
 use App\Models\Companies\CompaniesContacts;
 use App\Models\Companies\CompaniesAddresses;
 
@@ -20,6 +21,7 @@ class PurchasesRequest extends Component
 {
     // Properties for managing state
     public $companies_id = '';
+    public $selected_companies = [];
     public $sortField = 'tasks.id'; // default sorting field
     public $sortAsc = true; // default sort direction
     
@@ -60,9 +62,9 @@ class PurchasesRequest extends Component
         }
         elseif($this->document_type == 'PQ'){
             return [
-                'code' =>'required|unique:purchases_quotations',
+                'code' =>'required|unique:purchase_rfq_groups,code',
                 'label' =>'required',
-                'companies_id'=>'required',
+                'selected_companies' => 'required|array|min:1',
             ];
         }
     }
@@ -151,22 +153,21 @@ class PurchasesRequest extends Component
         $taskIds = collect($this->data)->pluck('task_id')->filter()->count();
 
         // Get default settings for the purchase order or quotation
-        $defaultSettings = [
-            'AccountingVat' => $this->purchaseOrderService->getAccountingVat(),
-            'defaultAddress' => CompaniesAddresses::getDefault(['companies_id' => $this->companies_id]),
-            'defaultContact' => CompaniesContacts::getDefault(['companies_id' => $this->companies_id]),
-        ];
-
-        // Check if all default settings are available
-        foreach ($defaultSettings as $key => $setting) {
-            if (is_null($setting)) {
-                return redirect()->back()->with('error', 'No default settings for ' . str_replace('_', ' ', $key));
-            }
-            $defaultSettings[$key] = $setting->id;
-        }
-
         // Create puchase order
         if($this->document_type == 'PU'){
+            $defaultSettings = [
+                'AccountingVat' => $this->purchaseOrderService->getAccountingVat(),
+                'defaultAddress' => CompaniesAddresses::getDefault(['companies_id' => $this->companies_id]),
+                'defaultContact' => CompaniesContacts::getDefault(['companies_id' => $this->companies_id]),
+            ];
+
+            // Check if all default settings are available
+            foreach ($defaultSettings as $key => $setting) {
+                if (is_null($setting)) {
+                    return redirect()->back()->with('error', 'No default settings for ' . str_replace('_', ' ', $key));
+                }
+                $defaultSettings[$key] = $setting->id;
+            }
 
             // Get the status update for the purchase order
             $statusUpdate = $this->purchaseOrderService->getStatusUpdate();
@@ -208,27 +209,58 @@ class PurchasesRequest extends Component
                 return redirect()->back()->with('error', 'No status "RFQ in progress" or "Started" in kanban for defining progress');
             }
 
-            // Create the purchase quotation
-            $PurchaseQuotationCreated = $this->purchaseQuotationService->createPurchasesQuotation($this->companies_id, 
-                                                                                                $this->code , 
-                                                                                                $this->label , 
-                                                                                                $defaultSettings['defaultAddress'],
-                                                                                                $defaultSettings['defaultContact']);
+            $rfqGroup = $this->purchaseQuotationService->createRfqGroup($this->code, $this->label);
+            $selectedCompanies = collect($this->selected_companies)->filter()->unique()->values();
 
-            if (!$PurchaseQuotationCreated) {
-                return redirect()->back()->withErrors(['msg' => 'Something went wrong (like no default settings for address, contact or accounting vat)']);
-            }
+            foreach ($selectedCompanies as $companyId) {
+                $company = Companies::find($companyId);
 
-            if ($taskIds > 0) {
-                // Process the purchase request lines
-                $this->purchaseQuotationService->processPurchaseRequestLines(
-                    $this->data,
-                    $PurchaseQuotationCreated,
-                    $statusUpdate->id
+                if (!$company) {
+                    return redirect()->back()->withErrors(['msg' => 'Supplier not found']);
+                }
+
+                $defaultSettings = [
+                    'AccountingVat' => $this->purchaseOrderService->getAccountingVat(),
+                    'defaultAddress' => CompaniesAddresses::getDefault(['companies_id' => $companyId]),
+                    'defaultContact' => CompaniesContacts::getDefault(['companies_id' => $companyId]),
+                ];
+
+                foreach ($defaultSettings as $key => $setting) {
+                    if (is_null($setting)) {
+                        return redirect()->back()->with('error', 'No default settings for ' . str_replace('_', ' ', $key));
+                    }
+                    $defaultSettings[$key] = $setting->id;
+                }
+
+                $quotationCode = $this->purchaseQuotationService->generateGroupedQuotationCode($this->code, $company);
+                $quotationLabel = $this->label . ' - ' . $company->label;
+
+                $PurchaseQuotationCreated = $this->purchaseQuotationService->createPurchasesQuotation(
+                    $companyId,
+                    $quotationCode,
+                    $quotationLabel,
+                    $defaultSettings['defaultAddress'],
+                    $defaultSettings['defaultContact'],
+                    $rfqGroup->id
                 );
+
+                if (!$PurchaseQuotationCreated) {
+                    return redirect()->back()->withErrors(['msg' => 'Something went wrong (like no default settings for address, contact or accounting vat)']);
+                }
+
+                if ($taskIds > 0) {
+                    $this->purchaseQuotationService->processPurchaseRequestLines(
+                        $this->data,
+                        $PurchaseQuotationCreated,
+                        $statusUpdate->id
+                    );
+                }
             }
-                
-            return redirect()->route('purchases.quotations.show', ['id' => $PurchaseQuotationCreated->id])->with('success', 'Successfully created new purchase quotation');
+
+            $firstQuotation = PurchasesQuotation::where('rfq_group_id', $rfqGroup->id)->orderBy('id')->first();
+
+            return redirect()->route('purchases.quotations.show', ['id' => $firstQuotation->id])
+                ->with('success', 'Successfully created new purchase quotation');
         }
         else{
             return redirect()->back()->with('error', 'no document type');

--- a/app/Models/Purchases/PurchaseQuotationLines.php
+++ b/app/Models/Purchases/PurchaseQuotationLines.php
@@ -22,6 +22,10 @@ class PurchaseQuotationLines extends Model
         'qty_to_order',
         'unit_price',
         'total_price',
+        'lead_time_days',
+        'conditions',
+        'supplier_score',
+        'supplier_comment',
         'qty_accepted',
         'canceled_qty',
     ];

--- a/app/Models/Purchases/PurchaseRfqGroup.php
+++ b/app/Models/Purchases/PurchaseRfqGroup.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Purchases;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Purchases\PurchasesQuotation;
+
+class PurchaseRfqGroup extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'code',
+        'label',
+        'description',
+        'user_id',
+    ];
+
+    public function purchaseQuotations()
+    {
+        return $this->hasMany(PurchasesQuotation::class, 'rfq_group_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/Purchases/PurchasesQuotation.php
+++ b/app/Models/Purchases/PurchasesQuotation.php
@@ -12,6 +12,7 @@ use App\Models\Companies\CompaniesContacts;
 use Spatie\Activitylog\Traits\LogsActivity;
 use App\Models\Companies\CompaniesAddresses;
 use App\Models\Purchases\PurchaseQuotationLines;
+use App\Models\Purchases\PurchaseRfqGroup;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class PurchasesQuotation extends Model
@@ -24,6 +25,7 @@ class PurchasesQuotation extends Model
                             'companies_id', 
                             'companies_contacts_id',   
                             'companies_addresses_id',  
+                            'rfq_group_id',
                             'statu',  
                             'user_id',
                             'comment',
@@ -67,6 +69,11 @@ class PurchasesQuotation extends Model
     public function PurchaseQuotationLines()
     {
         return $this->hasMany(PurchaseQuotationLines::class)->orderBy('ordre');
+    }
+
+    public function rfqGroup()
+    {
+        return $this->belongsTo(PurchaseRfqGroup::class, 'rfq_group_id');
     }
 
     /**

--- a/app/Services/PurchaseQuotationService.php
+++ b/app/Services/PurchaseQuotationService.php
@@ -4,10 +4,12 @@ namespace App\Services;
 
 use App\Models\Planning\Task;
 use App\Models\Planning\Status;
+use App\Models\Companies\Companies;
 use Illuminate\Support\Facades\Auth;
 use App\Services\DocumentCodeGenerator;
 use App\Models\Purchases\PurchasesQuotation;
 use App\Models\Purchases\PurchaseQuotationLines;
+use App\Models\Purchases\PurchaseRfqGroup;
 
 class PurchaseQuotationService
 {
@@ -27,9 +29,10 @@ class PurchaseQuotationService
      * @param string $purchaseQuotationLabel The label for the purchase quotation.
      * @param int $defaultContact The ID of the default contact for the purchase quotation.
      * @param int $defaultAddress The ID of the default address for the purchase quotation.
+     * @param int|null $rfqGroupId The ID of the RFQ group.
      * @return \App\Models\Purchases\PurchasesQuotation The created purchase quotation.
      */
-    public function createPurchasesQuotation($purchaseQuotationData, $purchaseQuotationCode, $purchaseQuotationLabel, $defaultContact, $defaultAddress)
+    public function createPurchasesQuotation($purchaseQuotationData, $purchaseQuotationCode, $purchaseQuotationLabel, $defaultContact, $defaultAddress, $rfqGroupId = null)
     {
         return PurchasesQuotation::create([
             'code' => $purchaseQuotationCode,
@@ -37,8 +40,46 @@ class PurchaseQuotationService
             'companies_id' => $purchaseQuotationData,
             'companies_contacts_id' => $defaultContact,
             'companies_addresses_id' => $defaultAddress,
+            'rfq_group_id' => $rfqGroupId,
             'user_id' => Auth::id(),
         ]);
+    }
+
+    /**
+     * Create a new RFQ group.
+     *
+     * @param string $code
+     * @param string $label
+     * @param string|null $description
+     * @return \App\Models\Purchases\PurchaseRfqGroup
+     */
+    public function createRfqGroup($code, $label, $description = null)
+    {
+        return PurchaseRfqGroup::create([
+            'code' => $code,
+            'label' => $label,
+            'description' => $description,
+            'user_id' => Auth::id(),
+        ]);
+    }
+
+    /**
+     * Generate a unique quotation code for a supplier in a RFQ group.
+     *
+     * @param string $baseCode
+     * @param \App\Models\Companies\Companies $company
+     * @return string
+     */
+    public function generateGroupedQuotationCode($baseCode, Companies $company)
+    {
+        $suffix = $company->code ?: $company->id;
+        $code = $baseCode . '-' . $suffix;
+
+        if (PurchasesQuotation::where('code', $code)->exists()) {
+            $code = $baseCode . '-' . $company->id . '-' . now()->format('His');
+        }
+
+        return $code;
     }
 
     /**
@@ -56,6 +97,8 @@ class PurchaseQuotationService
         return PurchaseQuotationLines::create([
             'purchases_quotation_id' => $purchaseQuotation->id,
             'tasks_id' => $task->id,
+            'code' => $task->Component?->code ?? $task->code,
+            'product_id' => $task->component_id,
             'label' => $task->label,
             'ordre' => $ordre, 
             //'supplier_ref' => , can be null

--- a/database/migrations/2025_03_01_000001_create_purchase_rfq_groups_table.php
+++ b/database/migrations/2025_03_01_000001_create_purchase_rfq_groups_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('purchase_rfq_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('label');
+            $table->text('description')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_rfq_groups');
+    }
+};

--- a/database/migrations/2025_03_01_000002_add_rfq_group_id_to_purchases_quotations_table.php
+++ b/database/migrations/2025_03_01_000002_add_rfq_group_id_to_purchases_quotations_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('purchases_quotations', function (Blueprint $table) {
+            $table->unsignedBigInteger('rfq_group_id')->nullable()->after('companies_addresses_id');
+            $table->index('rfq_group_id', 'purchases_quotations_rfq_group_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('purchases_quotations', function (Blueprint $table) {
+            $table->dropIndex('purchases_quotations_rfq_group_id_index');
+            $table->dropColumn('rfq_group_id');
+        });
+    }
+};

--- a/database/migrations/2025_03_01_000003_add_supplier_response_fields_to_purchase_quotation_lines_table.php
+++ b/database/migrations/2025_03_01_000003_add_supplier_response_fields_to_purchase_quotation_lines_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('purchase_quotation_lines', function (Blueprint $table) {
+            $table->unsignedInteger('lead_time_days')->nullable()->after('total_price');
+            $table->text('conditions')->nullable()->after('lead_time_days');
+            $table->decimal('supplier_score', 8, 2)->nullable()->after('conditions');
+            $table->text('supplier_comment')->nullable()->after('supplier_score');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('purchase_quotation_lines', function (Blueprint $table) {
+            $table->dropColumn(['lead_time_days', 'conditions', 'supplier_score', 'supplier_comment']);
+        });
+    }
+};

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -294,6 +294,8 @@ return [
     'purchase_quotation_trans_key'             => 'عرض الشراء',
     'purchase_quotation_info_trans_key'        => 'معلومات عرض الشراء',
     'purchase_quotation_lines_trans_key'       => 'أسطر عرض الشراء',
+    'lead_time_trans_key'                      => 'المهلة',
+    'score_trans_key'                          => 'الدرجة',
 
     'purchase_info_trans_key'                  => 'معلومات الشراء',
     'purchase_lines_trans_key'                 => 'أسطر الشراء',
@@ -398,6 +400,7 @@ return [
     'select_user_trans_key'                 => 'اختر مستخدم',
     'select_user_management_trans_key'      => 'اختر إدارة المستخدمين',
     'select_company_trans_key'              => 'اختر جهة ثالثة',
+    'select_suppliers_trans_key'            => 'اختر الموردين',
     'select_address_trans_key'              => 'اختر العنوان',
     'select_contact_trans_key'              => 'اختر جهة اتصال',
     'select_payement_condition_trans_key'   => 'اختر شرط الدفع',
@@ -852,6 +855,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'طلب شراء',
     'requests_for_quotation_list_trans_key'    => 'طلبات السعر',
+    'compare_rfq_trans_key'                    => 'مقارنة الموردين',
     'name_quote_request_trans_key'             => 'اسم طلب العرض',
     
     'purchase_list_trans_key'      => 'قائمة الشراء',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -343,6 +343,8 @@ return [
     'purchase_quotation_trans_key'             => 'Purchase quotation',
     'purchase_quotation_info_trans_key'        => 'Purchase quotation info',
     'purchase_quotation_lines_trans_key'       => 'Purchase quotation lines',
+    'lead_time_trans_key'                      => 'Lead time',
+    'score_trans_key'                          => 'Score',
 
     'purchase_info_trans_key'                  => 'Purchase info',
     'purchase_lines_trans_key'                 => 'Purchase lines',
@@ -456,6 +458,7 @@ return [
     'select_user_trans_key'                    => 'Select user',
     'select_user_management_trans_key'         => 'Select user management',
     'select_company_trans_key'                 => 'Select third party',
+    'select_suppliers_trans_key'               => 'Select suppliers',
     'select_address_trans_key'                 => 'Select address',
     'select_contact_trans_key'                 => 'Select contact',
     'select_payement_condition_trans_key'      => 'Select payement condition',
@@ -1005,6 +1008,7 @@ return [
     'purchase_request_trans_key'               => 'Purchase request',
     'requests_for_quotation_list_trans_key'    => 'Requests for quotation',
     'name_quote_request_trans_key'             => 'Name of quotation request',
+    'compare_rfq_trans_key'                    => 'Compare suppliers',
     
     'purchase_list_trans_key'                  => 'Purchase list',
     'waiting_to_receipt_trans_key'             => 'Waiting to receipt',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -291,6 +291,8 @@ return [
     'purchase_quotation_trans_key'             => 'Cotización de compra',
     'purchase_quotation_info_trans_key'        => 'Información de cotización de compra',
     'purchase_quotation_lines_trans_key'       => 'Líneas de cotización de compra',
+    'lead_time_trans_key'                      => 'Plazo',
+    'score_trans_key'                          => 'Puntuación',
 
     'purchase_info_trans_key'                  => 'Información de compra',
     'purchase_lines_trans_key'                 => 'Líneas de compra',
@@ -396,6 +398,7 @@ return [
     'select_user_trans_key'                    => 'Seleccionar usuario',
     'select_user_management_trans_key'         => 'Seleccionar gestión de usuarios',
     'select_company_trans_key'                 => 'Seleccionar tercero',
+    'select_suppliers_trans_key'               => 'Seleccionar proveedores',
     'select_address_trans_key'                 => 'Seleccionar dirección',
     'select_contact_trans_key'                 => 'Seleccionar contacto',
     'select_payement_condition_trans_key'      => 'Seleccionar condición de pago',
@@ -853,6 +856,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'Solicitud de compra',
     'requests_for_quotation_list_trans_key'    => 'Solicitudes de cotización',
+    'compare_rfq_trans_key'                    => 'Comparar proveedores',
     'name_quote_request_trans_key'             => 'Nombre de la solicitud de cotización',
 
     'purchase_list_trans_key'                  => 'Lista de compras',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -343,6 +343,8 @@ return [
     'purchase_quotation_trans_key'             => 'Demande d\'achat',
     'purchase_quotation_info_trans_key'        => 'Info Devis d\'achat',
     'purchase_quotation_lines_trans_key'       => 'Ligne devis d\'achat',
+    'lead_time_trans_key'                      => 'Délai',
+    'score_trans_key'                          => 'Score',
 
     'purchase_info_trans_key'                  => 'Achat info',
     'purchase_lines_trans_key'                 => 'Ligne achat',
@@ -456,6 +458,7 @@ return [
     'select_user_trans_key'                    => 'Sélectionner un utilisateur',
     'select_user_management_trans_key'         => 'Selectionner l\'utilisateur',
     'select_company_trans_key'                 => 'Selectionner tiers',
+    'select_suppliers_trans_key'               => 'Sélectionner des fournisseurs',
     'select_address_trans_key'                 => 'Selectionner adresse',
     'select_contact_trans_key'                 => 'Selectionner contact',
     'select_payement_condition_trans_key'      => 'Selectionner condition de paiement',
@@ -1004,6 +1007,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'Demande d\'achat',
     'requests_for_quotation_list_trans_key'    => 'Demande de devis',
+    'compare_rfq_trans_key'                    => 'Comparer les fournisseurs',
     'name_quote_request_trans_key'             => 'Nom de la demande d\'achat',
 
     'purchase_list_trans_key'                  => 'Liste commande d\'achat',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -112,6 +112,9 @@ return [
     'purchase_trans_key'                       => 'Mua hàng',
     'purchase_request_trans_key'               => 'Đề xuất mua hàng',
     'requests_for_quotation_list_trans_key'    => 'Danh mục báo giá đề xuất',
+    'lead_time_trans_key'                      => 'Thời gian giao hàng',
+    'score_trans_key'                          => 'Điểm số',
+    'compare_rfq_trans_key'                    => 'So sánh nhà cung cấp',
     'purchase_list_trans_key'                  => 'Danh sách mua hàng',
     'waiting_to_receipt_trans_key'             => 'Chờ đơn nhận',
     'po_receipt_trans_key'                     => 'Đơn nhận PO',
@@ -197,4 +200,5 @@ return [
     'change_reason_trans_key'                  => 'Lý do thay đổi',
     'change_approved_at_trans_key'             => 'Thời gian phê duyệt thay đổi',
     'changes_trans_key'                        => 'Thay đổi',
+    'select_suppliers_trans_key'               => 'Chọn nhà cung cấp',
 ];

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -334,6 +334,8 @@ return [
     'purchase_quotation_trans_key'             => '采购询价',
     'purchase_quotation_info_trans_key'        => '采购报价信息',
     'purchase_quotation_lines_trans_key'       => '采购报价行',
+    'lead_time_trans_key'                      => '交期',
+    'score_trans_key'                          => '评分',
 
     'purchase_info_trans_key'                  => '采购信息',
     'purchase_lines_trans_key'                 => '采购行',
@@ -446,6 +448,7 @@ return [
     'select_user_trans_key'                    => '选择用户',
     'select_user_management_trans_key'         => '选择用户',
     'select_company_trans_key'                 => '选择第三方',
+    'select_suppliers_trans_key'               => '选择供应商',
     'select_address_trans_key'                 => '选择地址',
     'select_contact_trans_key'                 => '选择联系人',
     'select_payement_condition_trans_key'      => '选择付款条件',
@@ -992,6 +995,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => '采购申请',
     'requests_for_quotation_list_trans_key'    => '询价单',
+    'compare_rfq_trans_key'                    => '对比供应商',
     'name_quote_request_trans_key'             => '采购申请名称',
 
     'purchase_list_trans_key'                  => '采购订单列表',

--- a/resources/views/livewire/purchases-request.blade.php
+++ b/resources/views/livewire/purchases-request.blade.php
@@ -36,6 +36,24 @@
                         </div>
                         @error('companies_id') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
+                    @if($document_type == 'PQ')
+                    <div class="form-group col-md-3">
+                        <label for="selected_companies">{{ __('general_content.select_suppliers_trans_key') }}</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fas fa-industry"></i></span>
+                            </div>
+                            <select class="form-control" wire:model.live="selected_companies" name="selected_companies[]" id="selected_companies" multiple>
+                                @forelse ($CompanieSelect as $item)
+                                    <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
+                                @empty
+                                    <option value="">{{ __('general_content.no_select_company_trans_key') }}</option>
+                                @endforelse
+                            </select>
+                        </div>
+                        @error('selected_companies') <span class="text-danger">{{ $message }}<br/></span>@enderror
+                    </div>
+                    @endif
                     <div class="form-group col-md-3">
                         <label for="code">{{ __('general_content.external_id_trans_key') }}</label>
                         <div class="input-group">

--- a/resources/views/purchases/purchases-quotation-compare.blade.php
+++ b/resources/views/purchases/purchases-quotation-compare.blade.php
@@ -1,0 +1,87 @@
+@extends('adminlte::page')
+
+@section('title', __('general_content.compare_rfq_trans_key'))
+
+@section('content_header')
+  <link rel="stylesheet" href="{{ asset('css/custom.css') }}">
+  <h1>{{ __('general_content.compare_rfq_trans_key') }} : {{ $rfqGroup->code }}</h1>
+@stop
+
+@section('content')
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">{{ $rfqGroup->label }}</h3>
+  </div>
+  <div class="card-body">
+    <div class="table-responsive p-0">
+      <table class="table table-hover table-bordered">
+        <thead>
+          <tr>
+            <th>{{ __('general_content.line_trans_key') }}</th>
+            <th>{{ __('general_content.qty_trans_key') }}</th>
+            @foreach($quotations as $quotation)
+              <th>
+                {{ $quotation->companie?->label ?? $quotation->code }}
+                <div class="text-muted">{{ $quotation->code }}</div>
+              </th>
+            @endforeach
+          </tr>
+        </thead>
+        <tbody>
+          @forelse($lineGroups as $lineGroup)
+            @php
+              $lineEntries = collect($lineGroup['lines']);
+              $bestPrice = $lineEntries->whereNotNull('unit_price')->min('unit_price');
+            @endphp
+            <tr>
+              <td>{{ $lineGroup['label'] }}</td>
+              <td>{{ number_format($lineGroup['qty'], 3, '.', ' ') }}</td>
+              @foreach($quotations as $quotation)
+                @php
+                  $line = $lineGroup['lines'][$quotation->id] ?? null;
+                  $isBestPrice = $line && $bestPrice !== null && $line->unit_price == $bestPrice;
+                @endphp
+                <td @if($isBestPrice) class="table-success" @endif>
+                  @if($line)
+                    <div><strong>{{ $line->formatted_selling_price }}</strong></div>
+                    <div class="text-muted">{{ __('general_content.total_price_trans_key') }}: {{ $line->formatted_total_price }}</div>
+                    @if($line->lead_time_days)
+                      <div>{{ __('general_content.lead_time_trans_key') }}: {{ $line->lead_time_days }} d</div>
+                    @endif
+                    @if($line->conditions)
+                      <div>{{ $line->conditions }}</div>
+                    @endif
+                    @if($line->supplier_score)
+                      <div>{{ __('general_content.score_trans_key') }}: {{ $line->supplier_score }}</div>
+                    @endif
+                    @if($line->supplier_comment)
+                      <div class="text-muted">{{ $line->supplier_comment }}</div>
+                    @endif
+                  @else
+                    <span class="text-muted">-</span>
+                  @endif
+                </td>
+              @endforeach
+            </tr>
+          @empty
+            <tr>
+              <td colspan="{{ 2 + $quotations->count() }}">
+                {{ __('general_content.no_data_trans_key') }}
+              </td>
+            </tr>
+          @endforelse
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>{{ __('general_content.total_price_trans_key') }}</th>
+            <th></th>
+            @foreach($quotations as $quotation)
+              <th>{{ number_format($supplierTotals[$quotation->id] ?? 0, 2, '.', ' ') }}</th>
+            @endforeach
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</div>
+@stop

--- a/resources/views/purchases/purchases-quotation-show.blade.php
+++ b/resources/views/purchases/purchases-quotation-show.blade.php
@@ -102,6 +102,16 @@
                     <td><x-ButtonTextEmail route="{{ route('email.create', ['type' => 'purchase-quotation', 'id' => $PurchaseQuotation->id]) }}" /></td>
                   </tr>
                   @endif
+                  @if($PurchaseQuotation->rfq_group_id)
+                  <tr>
+                    <td style="width:50%">{{ __('general_content.compare_rfq_trans_key') }}</td>
+                    <td>
+                      <a class="btn btn-outline-primary btn-sm" href="{{ route('purchases.quotations.compare', ['group' => $PurchaseQuotation->rfq_group_id]) }}">
+                        <i class="fas fa-balance-scale"></i> {{ __('general_content.compare_rfq_trans_key') }}
+                      </a>
+                    </td>
+                  </tr>
+                  @endif
                 </table>
               </div>
             </x-adminlte-card>

--- a/routes/web.php
+++ b/routes/web.php
@@ -231,6 +231,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
 
         Route::get('/{id}', 'App\Http\Controllers\Purchases\PurchasesController@showPurchase')->middleware(['auth'])->name('purchases.show');
         Route::get('/quotation/{id}', 'App\Http\Controllers\Purchases\PurchasesRFQController@showQuotation')->middleware(['auth'])->name('purchases.quotations.show');
+        Route::get('/quotation/group/{group}/compare', 'App\Http\Controllers\Purchases\PurchasesRFQController@compareQuotationGroup')->middleware(['auth'])->name('purchases.quotations.compare');
         Route::get('/receipt/{id}', 'App\Http\Controllers\Purchases\PurchasesReceiptController@showReceipt')->middleware(['auth'])->name('purchase.receipts.show');
         Route::get('/invoice/{id}', 'App\Http\Controllers\Purchases\PurchasesInvoiceController@showInvoice')->middleware(['auth'])->name('purchase.invoices.show');
     });


### PR DESCRIPTION
### Motivation

- Introduce a two-level RFQ model (master RFQ + per-supplier quotations) to allow creating one request that targets multiple suppliers and to enable automatic comparison of supplier responses. 
- Persist basic supplier response fields (lead time, conditions, score, comment) per quotation line to support line-by-line comparison and ranking.

### Description

- Add a new model and migration `purchase_rfq_groups` and link it to `purchases_quotations` via a nullable `rfq_group_id` column using migration `2025_03_01_000001_create_purchase_rfq_groups_table.php` and `2025_03_01_000002_add_rfq_group_id_to_purchases_quotations_table.php` and model `app/Models/Purchases/PurchaseRfqGroup.php`.
- Add supplier-response columns to quotation lines with migration `2025_03_01_000003_add_supplier_response_fields_to_purchase_quotation_lines_table.php` and extend `app/Models/Purchases/PurchaseQuotationLines.php` fillable fields with `lead_time_days`, `conditions`, `supplier_score`, and `supplier_comment`.
- Extend `PurchaseQuotationService` with `createRfqGroup`, `generateGroupedQuotationCode`, and an updated `createPurchasesQuotation` signature to support creating grouped per-supplier quotations and to include `code`/`product_id` when creating lines (`app/Services/PurchaseQuotationService.php`).
- Update the RFQ creation flow in the Livewire component `app/Livewire/PurchasesRequest.php` and the UI `resources/views/livewire/purchases-request.blade.php` to allow selecting multiple suppliers, create an RFQ group, and generate one supplier-specific quotation per selected supplier (with per-supplier defaults and codes).
- Add a comparison endpoint and view: controller method `PurchasesRFQController::compareQuotationGroup`, a route `purchases.quotations.compare` (`/purchases/quotation/group/{group}/compare`), the comparison view `resources/views/purchases/purchases-quotation-compare.blade.php`, and a link from the quotation details view to open the comparison table (`resources/views/purchases/purchases-quotation-show.blade.php`).
- Add/update translations for new UI strings `compare_rfq_trans_key`, `select_suppliers_trans_key`, `lead_time_trans_key`, and `score_trans_key` across language files.

### Testing

- A Playwright script visited `http://localhost:8000` and saved a screenshot artifact `artifacts/rfq-compare.png`, which completed successfully. 
- No unit or feature tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be9d0e348832db07773b4a538b419)