### PR TITLE
Fix Livewire invoice export selection binding

### DIFF
--- a/app/Livewire/InvoiceExportLines.php
+++ b/app/Livewire/InvoiceExportLines.php
@@ -15,11 +15,11 @@ class InvoiceExportLines extends Component
     public $data = [];
 
     //export
-    public Collection $selectedInvoiceLine;
+    public array $selectedInvoiceLine = [];
 
     public function mount() 
     {
-        $this->selectedInvoiceLine = collect();
+        $this->selectedInvoiceLine = [];
     }
 
     public function render()
@@ -34,7 +34,9 @@ class InvoiceExportLines extends Component
 
     private function getSelectedInvoiceLine()
     {
-        return $this->selectedInvoiceLine->filter(fn($p) => $p)->keys();
+        return collect($this->selectedInvoiceLine)
+            ->filter(fn($p) => $p)
+            ->keys();
     }
 
     public function export($ext)


### PR DESCRIPTION
### Motivation
- Resolve Livewire checkbox binding / "Indirect modification of overloaded element" issues by avoiding mutation of an `Illuminate\Support\Collection` when checkboxes are bound to a component property.

### Description
- Change the export selection state from `Collection` to array by making `public array $selectedInvoiceLine = []`, initializing it in `mount()` and adapting `getSelectedInvoiceLine()` to `collect($this->selectedInvoiceLine)->filter(...)->keys()` so selection logic continues to work.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bef698910832db196ae4805d13389)