### PR TITLE
Fix RFQ quotation line grouping mutation

### DIFF
--- a/app/Http/Controllers/Purchases/PurchasesRFQController.php
+++ b/app/Http/Controllers/Purchases/PurchasesRFQController.php
@@ -109,7 +109,9 @@ class PurchasesRFQController extends Controller
                     ]);
                 }
 
-                $lineGroups[$key]['lines'][$quotation->id] = $line;
+                $lineGroup = $lineGroups->get($key);
+                $lineGroup['lines'][$quotation->id] = $line;
+                $lineGroups->put($key, $lineGroup);
             }
         }
 


### PR DESCRIPTION
### Motivation
- Avoid the "Indirect modification of overloaded element of Illuminate\Support\Collection has no effect" warning when building line groups for RFQ comparison by making collection mutations explicit.

### Description
- Replace direct array-style mutation on a `Collection` entry with an explicit `get`/modify/`put` sequence in `app/Http/Controllers/Purchases/PurchasesRFQController.php` so quotation lines are added to the correct group.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf17a8ffc832d81e211af2555f1e3)