### PR TITLE
Add RFQ grouping cues to purchase quotations list

### DIFF
--- a/app/Livewire/PurchasesQuotationIndex.php
+++ b/app/Livewire/PurchasesQuotationIndex.php
@@ -83,7 +83,8 @@ class PurchasesQuotationIndex extends Component
 
     private function getPurchasesQuotations()
     {
-        return PurchasesQuotation::withCount('PurchaseQuotationLines')
+        return PurchasesQuotation::with(['companie', 'rfqGroup'])
+                                ->withCount('PurchaseQuotationLines')
                                 ->where('label', 'like', '%' . $this->search . '%')
                                 ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
                                 ->paginate(15);

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -855,6 +855,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'طلب شراء',
     'requests_for_quotation_list_trans_key'    => 'طلبات السعر',
+    'rfq_group_trans_key'                      => 'مجموعة طلبات الأسعار',
     'compare_rfq_trans_key'                    => 'مقارنة الموردين',
     'name_quote_request_trans_key'             => 'اسم طلب العرض',
     

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1007,6 +1007,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'Purchase request',
     'requests_for_quotation_list_trans_key'    => 'Requests for quotation',
+    'rfq_group_trans_key'                      => 'RFQ group',
     'name_quote_request_trans_key'             => 'Name of quotation request',
     'compare_rfq_trans_key'                    => 'Compare suppliers',
     

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -856,6 +856,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'Solicitud de compra',
     'requests_for_quotation_list_trans_key'    => 'Solicitudes de cotización',
+    'rfq_group_trans_key'                      => 'Grupo RFQ',
     'compare_rfq_trans_key'                    => 'Comparar proveedores',
     'name_quote_request_trans_key'             => 'Nombre de la solicitud de cotización',
 

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1007,6 +1007,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => 'Demande d\'achat',
     'requests_for_quotation_list_trans_key'    => 'Demande de devis',
+    'rfq_group_trans_key'                      => 'Groupe RFQ',
     'compare_rfq_trans_key'                    => 'Comparer les fournisseurs',
     'name_quote_request_trans_key'             => 'Nom de la demande d\'achat',
 

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -112,6 +112,7 @@ return [
     'purchase_trans_key'                       => 'Mua hàng',
     'purchase_request_trans_key'               => 'Đề xuất mua hàng',
     'requests_for_quotation_list_trans_key'    => 'Danh mục báo giá đề xuất',
+    'rfq_group_trans_key'                      => 'Nhóm RFQ',
     'lead_time_trans_key'                      => 'Thời gian giao hàng',
     'score_trans_key'                          => 'Điểm số',
     'compare_rfq_trans_key'                    => 'So sánh nhà cung cấp',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -995,6 +995,7 @@ return [
     //PURCHASE REQUEST
     'purchase_request_trans_key'               => '采购申请',
     'requests_for_quotation_list_trans_key'    => '询价单',
+    'rfq_group_trans_key'                      => '询价组',
     'compare_rfq_trans_key'                    => '对比供应商',
     'name_quote_request_trans_key'             => '采购申请名称',
 

--- a/resources/views/livewire/purchases-quotation-index.blade.php
+++ b/resources/views/livewire/purchases-quotation-index.blade.php
@@ -14,6 +14,7 @@
                         <th>
                             <a class="btn btn-secondary" wire:click.prevent="sortBy('label')" role="button" href="#">{{__('general_content.label_trans_key') }} @include('include.sort-icon', ['field' => 'label'])</a>
                         </th>
+                        <th>{{ __('general_content.rfq_group_trans_key') }}</th>
                         <th>
                             <a class="btn btn-secondary" wire:click.prevent="sortBy('companies_id')"   role="button" href="#">{{__('general_content.id_trans_key') }} @include('include.sort-icon', ['field' => 'companies_id'])</a>
                         </th>
@@ -26,10 +27,35 @@
                     </tr>
                 </thead>
                 <tbody>
+                    @php
+                        $previousGroup = null;
+                    @endphp
                     @forelse ($PurchasesQuotationList as $PurchaseQuotation)
-                    <tr>
+                    @php
+                        $currentGroup = $PurchaseQuotation->rfq_group_id;
+                    @endphp
+                    @if ($currentGroup && $currentGroup !== $previousGroup)
+                        <tr class="table-active">
+                            <td colspan="8">
+                                <strong>{{ __('general_content.rfq_group_trans_key') }}:</strong>
+                                {{ $PurchaseQuotation->rfqGroup?->label ?? $PurchaseQuotation->rfqGroup?->code }}
+                                @if($PurchaseQuotation->rfqGroup?->code)
+                                    <span class="text-muted">({{ $PurchaseQuotation->rfqGroup->code }})</span>
+                                @endif
+                            </td>
+                        </tr>
+                    @endif
+                    <tr @if($currentGroup) style="border-left: 4px solid #6c757d;" @endif>
                         <td>{{ $PurchaseQuotation->code }}</td>
                         <td>{{ $PurchaseQuotation->label }}</td>
+                        <td>
+                            @if($PurchaseQuotation->rfqGroup)
+                                <span class="badge badge-light">{{ $PurchaseQuotation->rfqGroup->code }}</span>
+                                <div class="text-muted small">{{ $PurchaseQuotation->rfqGroup->label }}</div>
+                            @else
+                                <span class="text-muted">—</span>
+                            @endif
+                        </td>
                         <td>
                             <x-CompanieButton id="{{ $PurchaseQuotation->companies_id }}" label="{{ $PurchaseQuotation->companie['label'] }}"  />
                         </td>
@@ -50,14 +76,18 @@
                             @endif
                         </td>
                     </tr>
+                    @php
+                        $previousGroup = $currentGroup;
+                    @endphp
                     @empty
-                        <x-EmptyDataLine col="7" text="{{ __('general_content.no_data_trans_key') }}"  />
+                        <x-EmptyDataLine col="8" text="{{ __('general_content.no_data_trans_key') }}"  />
                     @endforelse
                 </tbody>
                 <tfoot>
                     <tr>
                         <th>{{__('general_content.id_trans_key') }}</th>
                         <th>{{__('general_content.label_trans_key') }}</th>
+                        <th>{{ __('general_content.rfq_group_trans_key') }}</th>
                         <th>{{__('general_content.customer_trans_key') }}</th>
                         <th>{{__('general_content.lines_count_trans_key') }}</th>
                         <th>{{__('general_content.status_trans_key') }}</th>


### PR DESCRIPTION
### Motivation
- Improve scannability of the quotations list so grouped RFQ (request-for-quotation) entries are visually obvious when visiting `/purchases/quotation`.

### Description
- Eager-load related `rfqGroup` and `companie` relationships in `getPurchasesQuotations()` by using `with(['companie','rfqGroup'])` to avoid N+1 queries. 
- Add an RFQ group column and visual separators in the listing view by updating `resources/views/livewire/purchases-quotation-index.blade.php` to render a group header row when the `rfq_group_id` changes and a left-border cue on grouped rows. 
- Display RFQ code and label (badge + muted label) per row and show a group header with label and code where a new group starts. 
- Add `rfq_group_trans_key` translation entries across supported locales (`en`, `fr`, `es`, `ar`, `vi`, `zh-CN`).

### Testing
- No automated test suite was executed against these changes. 
- Attempted to run `php artisan serve` to smoke-test the app, but it failed in the environment due to a missing `vendor/autoload.php` (composer dependencies not installed), so no runtime verification could be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf4f324d4832d96c67306de7edb94)