### PR TITLE
Add formatted unit price accessor on PurchaseQuotationLines

### DIFF
--- a/app/Models/Purchases/PurchaseQuotationLines.php
+++ b/app/Models/Purchases/PurchaseQuotationLines.php
@@ -54,11 +54,21 @@ class PurchaseQuotationLines extends Model
      *
      * @return string The formatted unit price.
      */
-    public function getFormattedSellingPriceAttribute()
+    public function getFormattedUnitPriceAttribute()
     {
         $factory = app('Factory'); 
         $currency = $factory->curency ?? 'EUR';
         return Number::currency($this->unit_price, $currency, config('app.locale'));
+    }
+
+    /**
+     * Get the formatted selling price attribute.
+     *
+     * @return string The formatted selling price.
+     */
+    public function getFormattedSellingPriceAttribute()
+    {
+        return $this->formatted_unit_price;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Provide a dedicated formatted unit price accessor for `PurchaseQuotationLines` and preserve the existing selling price accessor as a compatibility proxy.

### Description
- Implement `getFormattedUnitPriceAttribute()` to format `unit_price` as a currency and add `getFormattedSellingPriceAttribute()` which returns `formatted_unit_price`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf5d7ac58832da6ac1ec43813f1a4)