### PR TITLE
Add compare link for RFQ group headers

### DIFF
--- a/resources/views/livewire/purchases-quotation-index.blade.php
+++ b/resources/views/livewire/purchases-quotation-index.blade.php
@@ -37,11 +37,20 @@
                     @if ($currentGroup && $currentGroup !== $previousGroup)
                         <tr class="table-active">
                             <td colspan="8">
-                                <strong>{{ __('general_content.rfq_group_trans_key') }}:</strong>
-                                {{ $PurchaseQuotation->rfqGroup?->label ?? $PurchaseQuotation->rfqGroup?->code }}
-                                @if($PurchaseQuotation->rfqGroup?->code)
-                                    <span class="text-muted">({{ $PurchaseQuotation->rfqGroup->code }})</span>
-                                @endif
+                                <div class="d-flex align-items-center justify-content-between flex-wrap">
+                                    <div>
+                                        <strong>{{ __('general_content.rfq_group_trans_key') }}:</strong>
+                                        {{ $PurchaseQuotation->rfqGroup?->label ?? $PurchaseQuotation->rfqGroup?->code }}
+                                        @if($PurchaseQuotation->rfqGroup?->code)
+                                            <span class="text-muted">({{ $PurchaseQuotation->rfqGroup->code }})</span>
+                                        @endif
+                                    </div>
+                                    @if($PurchaseQuotation->rfq_group_id)
+                                        <a class="btn btn-outline-primary btn-sm" href="{{ route('purchases.quotations.compare', ['group' => $PurchaseQuotation->rfq_group_id]) }}">
+                                            <i class="fas fa-balance-scale"></i> {{ __('general_content.compare_rfq_trans_key') }}
+                                        </a>
+                                    @endif
+                                </div>
                             </td>
                         </tr>
                     @endif


### PR DESCRIPTION
### Motivation
- Provide a direct "Compare" link for RFQ groups in the purchase quotations list so users can jump to the group comparison page (`/purchases/quotations/compare`) from the group header.

### Description
- Updated `resources/views/livewire/purchases-quotation-index.blade.php` to wrap the RFQ group header in a flex container and add a compare button aligned to the right. 
- The new button links to the route `purchases.quotations.compare` with the `group` parameter set to `rfq_group_id` and uses the `compare_rfq_trans_key` translation and a FontAwesome icon. 
- The compare link is rendered conditionally only when `rfq_group_id` is present, preserving the existing group label/code display.

### Testing
- Attempted to run the application with `php artisan serve --host=0.0.0.0 --port=8000`, but it failed due to missing dependencies: `vendor/autoload.php` was not found, so runtime verification could not be performed. 
- No automated test suites were executed in this environment due to the missing vendor dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf8e03dc4832dba76004b6d6df9d9)