### PR TITLE
Add RFQ links to quotation compare view

### DIFF
--- a/resources/views/purchases/purchases-quotation-compare.blade.php
+++ b/resources/views/purchases/purchases-quotation-compare.blade.php
@@ -21,8 +21,14 @@
             <th>{{ __('general_content.qty_trans_key') }}</th>
             @foreach($quotations as $quotation)
               <th>
-                {{ $quotation->companie?->label ?? $quotation->code }}
-                <div class="text-muted">{{ $quotation->code }}</div>
+                <a href="{{ route('purchases.quotations.show', ['id' => $quotation->id]) }}">
+                  {{ $quotation->companie?->label ?? $quotation->code }}
+                </a>
+                <div class="text-muted">
+                  <a href="{{ route('purchases.quotations.show', ['id' => $quotation->id]) }}">
+                    {{ $quotation->code }}
+                  </a>
+                </div>
               </th>
             @endforeach
           </tr>


### PR DESCRIPTION
### Motivation
- Allow users to navigate from the RFQ comparison table directly to each RFQ detail page for faster inspection.

### Description
- Update `resources/views/purchases/purchases-quotation-compare.blade.php` to wrap the supplier label and quotation code with links to the RFQ detail route `route('purchases.quotations.show', ['id' => $quotation->id])`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf8996f64832da1ddf139c4cae874)