### PR TITLE
Add duplicate action for purchase quotations (RFQ)

### DIFF
--- a/app/Http/Controllers/Purchases/PurchasesRFQController.php
+++ b/app/Http/Controllers/Purchases/PurchasesRFQController.php
@@ -7,10 +7,12 @@ use App\Services\SelectDataService;
 use App\Http\Controllers\Controller;
 use App\Services\CustomFieldService;
 use App\Services\PurchaseKPIService;
+use App\Services\PurchaseQuotationService;
 use App\Services\PurchaseOrderService;
 use App\Models\Purchases\PurchasesQuotation;
 use App\Models\Purchases\PurchaseRfqGroup;
 use App\Http\Requests\Purchases\UpdatePurchaseQuotationRequest;
+use Illuminate\Support\Facades\DB;
 
 class PurchasesRFQController extends Controller
 {
@@ -19,6 +21,7 @@ class PurchasesRFQController extends Controller
     protected $SelectDataService;
     protected $purchaseKPIService;
     protected $customFieldService;
+    protected $purchaseQuotationService;
     protected $purchaseOrderService;
 
     /**
@@ -33,11 +36,13 @@ class PurchasesRFQController extends Controller
             SelectDataService $SelectDataService, 
             PurchaseKPIService $purchaseKPIService,
             CustomFieldService $customFieldService,
+            PurchaseQuotationService $purchaseQuotationService,
             PurchaseOrderService $purchaseOrderService,
         ){
         $this->SelectDataService = $SelectDataService;
         $this->purchaseKPIService = $purchaseKPIService;
         $this->customFieldService = $customFieldService;
+        $this->purchaseQuotationService = $purchaseQuotationService;
         $this->purchaseOrderService = $purchaseOrderService;
     }
     
@@ -125,6 +130,45 @@ class PurchasesRFQController extends Controller
             'lineGroups' => $lineGroups->values(),
             'supplierTotals' => $supplierTotals,
         ]);
+    }
+
+    /**
+     * Duplicate a purchase quotation with its lines.
+     *
+     * @param PurchasesQuotation $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function duplicateQuotation(PurchasesQuotation $id)
+    {
+        $id->load('PurchaseQuotationLines');
+        $newCode = $this->purchaseQuotationService->generatePurchasesQuotationCode();
+        $newLabel = $id->label . ' #duplicate' . $id->id;
+
+        $newQuotation = DB::transaction(function () use ($id, $newCode, $newLabel) {
+            $newQuotation = $this->purchaseQuotationService->createPurchasesQuotation(
+                $id->companies_id,
+                $newCode,
+                $newLabel,
+                $id->companies_contacts_id,
+                $id->companies_addresses_id,
+                $id->rfq_group_id
+            );
+            $newQuotation->delay = $id->delay;
+            $newQuotation->statu = $id->statu;
+            $newQuotation->comment = $id->comment;
+            $newQuotation->save();
+
+            foreach ($id->PurchaseQuotationLines as $line) {
+                $newLine = $line->replicate();
+                $newLine->purchases_quotation_id = $newQuotation->id;
+                $newLine->save();
+            }
+
+            return $newQuotation;
+        });
+
+        return redirect()->route('purchases.quotations.show', ['id' =>  $newQuotation->id])
+            ->with('success', 'Successfully duplicated purchase quotation');
     }
 
     /**

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -806,6 +806,7 @@ return [
     'quantite_eco_max_trans_key'               => 'الحد الأقصى لكمية مستدامة',
     'quantite_max_trans_key'                   => 'الحد الأقصى للكمية',
     'duplicate_product_trans_key'              => 'نسخ المنتج',
+    'duplicate_purchase_quotation_trans_key'   => 'نسخ طلب عرض السعر',
     'other_information_trans_key'              => 'معلومات أخرى',
     'index_trans_key'                          => 'الفهرس',
     'new_product_trans_key'                    => 'منتج جديد',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -953,6 +953,7 @@ return [
     'quantite_eco_max_trans_key'               => 'Qty eco max',
     'quantite_max_trans_key'                   => 'Qty max',
     'duplicate_product_trans_key'              => 'Duplicate product',
+    'duplicate_purchase_quotation_trans_key'   => 'Duplicate purchase quotation',
     'other_information_trans_key'              => 'Other information',
     'index_trans_key'                          => 'Index',
     'new_product_trans_key'                    => 'New product',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -806,6 +806,7 @@ return [
     'quantite_eco_max_trans_key'               => 'Cantidad eco máxima',
     'quantite_max_trans_key'                   => 'Cantidad máxima',
     'duplicate_product_trans_key'              => 'Duplicar producto',
+    'duplicate_purchase_quotation_trans_key'   => 'Duplicar solicitud de cotización',
     'other_information_trans_key'              => 'Otra información',
     'index_trans_key'                          => 'Índice',
     'new_product_trans_key'                    => 'Nuevo producto',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -953,6 +953,7 @@ return [
     'quantite_eco_max_trans_key'               => 'Quantité eco max',
     'quantite_max_trans_key'                   => 'Quantité max',
     'duplicate_product_trans_key'              => 'Dupliqué produit',
+    'duplicate_purchase_quotation_trans_key'   => 'Dupliquer la demande de devis',
     'other_information_trans_key'              => 'Autre information',
     'index_trans_key'                          => 'Ind',
     'new_product_trans_key'                    => 'Nouveau produit',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -190,6 +190,7 @@ return [
     'custom_fields_options_help_trans_key'     => 'Được hiển thị như các giá trị có thể chọn trong danh sách.',
     'custom_fields_select_placeholder_trans_key' => 'Chọn một tùy chọn',
     'select_user_trans_key'                    => 'Chọn người dùng',
+    'duplicate_purchase_quotation_trans_key'   => 'Nhân bản yêu cầu báo giá',
 
     //REVIEW & CHANGE
     'review_change_tracking_trans_key'         => 'Theo dõi xem xét và thay đổi',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -941,6 +941,7 @@ return [
     'quantite_eco_max_trans_key'               => '经济最大量',
     'quantite_max_trans_key'                   => '最大量',
     'duplicate_product_trans_key'              => '复制产品',
+    'duplicate_purchase_quotation_trans_key'   => '复制采购询价单',
     'other_information_trans_key'              => '其他信息',
     'index_trans_key'                          => '索引',
     'new_product_trans_key'                    => '新建产品',

--- a/resources/views/purchases/purchases-quotation-show.blade.php
+++ b/resources/views/purchases/purchases-quotation-show.blade.php
@@ -112,6 +112,14 @@
                     </td>
                   </tr>
                   @endif
+                  <tr>
+                    <td style="width:50%">{{ __('general_content.duplicate_purchase_quotation_trans_key') }}</td>
+                    <td>
+                      <a class="btn btn-outline-secondary btn-sm" href="{{ route('purchases.quotations.duplicate', ['id' => $PurchaseQuotation->id]) }}">
+                        <i class="fas fa-copy"></i> {{ __('general_content.duplicate_purchase_quotation_trans_key') }}
+                      </a>
+                    </td>
+                  </tr>
                 </table>
               </div>
             </x-adminlte-card>

--- a/routes/web.php
+++ b/routes/web.php
@@ -223,6 +223,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         
         Route::post('/edit/{id}', 'App\Http\Controllers\Purchases\PurchasesController@updatePurchase')->middleware(['auth'])->name('purchase.update');
         Route::post('/quotation/edit/{id}', 'App\Http\Controllers\Purchases\PurchasesRFQController@updatePurchaseQuotation')->middleware(['auth'])->name('quotation.update');
+        Route::get('/quotation/{id}/duplicate', 'App\Http\Controllers\Purchases\PurchasesRFQController@duplicateQuotation')->middleware(['auth'])->name('purchases.quotations.duplicate');
         Route::post('/receipt/edit/{id}', 'App\Http\Controllers\Purchases\PurchasesReceiptController@updatePurchaseReceipt')->middleware(['auth'])->name('receipt.update');
         Route::post('/receipt/control/{id}', 'App\Http\Controllers\Purchases\PurchasesReceiptController@updateReceiptControl')->middleware(['auth'])->name('purchase.receipts.reception_control');
         Route::post('/receipt/line/{purchaseReceiptLine}/inspection', 'App\Http\Controllers\Purchases\PurchasesReceiptController@updateLineInspection')->middleware(['auth'])->name('purchase.receipts.lines.update');


### PR DESCRIPTION
### Motivation
- Provide a quick way to clone an existing purchase quotation (RFQ) including its lines while keeping it associated with the same RFQ group so users can create a new supplier quotation from an existing one.

### Description
- Added `duplicateQuotation` to `PurchasesRFQController` which creates a new `PurchasesQuotation`, preserves `rfq_group_id`, copies metadata and replicates all `PurchaseQuotationLines` inside a DB transaction using `PurchaseQuotationService` and `DB::transaction`.
- Registered a new route `purchases.quotations.duplicate` at `GET /purchases/quotation/{id}/duplicate` that points to `PurchasesRFQController@duplicateQuotation`.
- Exposed a duplicate button in the quotation view at `resources/views/purchases/purchases-quotation-show.blade.php` that links to the new route and added translation keys `duplicate_purchase_quotation_trans_key` to multiple locale files.

### Testing
- No automated tests were executed for this change.
- An attempt to run the application with `php artisan serve` failed due to missing dependencies (`vendor/autoload.php` not found), so manual web testing was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bfb64f144832da4c6ec320ca6943e)