### PR TITLE
Guard null order line relations in purchase quotation PDF

### DIFF
--- a/resources/views/print/pdf-purchases-quotation.blade.php
+++ b/resources/views/print/pdf-purchases-quotation.blade.php
@@ -112,8 +112,8 @@
                 <tbody>
                     @forelse($Document->Lines as $DocumentLine)
                     <tr>
-                        <td>{{ $DocumentLine->tasks->OrderLines->order->code }}</td>
-                        <td>#{{ $DocumentLine->tasks->id }}  {{ $DocumentLine->tasks->label }}</td>
+                        <td>{{ data_get($DocumentLine, 'tasks.OrderLines.order.code', '-') }}</td>
+                        <td>#{{ data_get($DocumentLine, 'tasks.id', '-') }}  {{ data_get($DocumentLine, 'tasks.label', '') }}</td>
                         <td>{{ $DocumentLine->qty_to_order }}</td>
                         <td>.............{{ $Factory->curency }}</td>
                         <td>.............{{ $Factory->curency }}</td>


### PR DESCRIPTION
### Motivation
- Prevent PHP errors when rendering purchase quotation PDFs if a line's `tasks` or its related `OrderLines`/`order` is null.

### Description
- Use `data_get` with fallbacks in `resources/views/print/pdf-purchases-quotation.blade.php` to safely access `tasks.OrderLines.order.code`, `tasks.id`, and `tasks.label` when rendering document lines.

### Testing
- No automated tests were run; this is a view-only safe-access fix and should be covered by existing rendering tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c08f9f57c832d947ce59ef5b17044)