### PR TITLE
Add purchase quotation statistics to RFQ dashboard

### DIFF
--- a/app/Http/Controllers/Purchases/PurchasesRFQController.php
+++ b/app/Http/Controllers/Purchases/PurchasesRFQController.php
@@ -10,8 +10,10 @@ use App\Services\PurchaseKPIService;
 use App\Services\PurchaseQuotationService;
 use App\Services\PurchaseOrderService;
 use App\Models\Purchases\PurchasesQuotation;
+use App\Models\Purchases\PurchaseQuotationLines;
 use App\Models\Purchases\PurchaseRfqGroup;
 use App\Http\Requests\Purchases\UpdatePurchaseQuotationRequest;
+use Illuminate\Support\Number;
 use Illuminate\Support\Facades\DB;
 
 class PurchasesRFQController extends Controller
@@ -63,9 +65,22 @@ class PurchasesRFQController extends Controller
      */
     public function quotation()
     {    
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
         $data['purchasesQuotationDataRate'] = $this->purchaseKPIService->getPurchaseQuotationDataRate();
+        $totalPurchaseQuotationCount = PurchasesQuotation::count();
+        $totalPurchaseQuotationLineCount = PurchaseQuotationLines::count();
+        $totalPurchaseQuotationAmount = Number::currency(
+            PurchaseQuotationLines::sum('total_price'),
+            $currency,
+            config('app.locale')
+        );
                                                             
-        return view('purchases/purchases-quotation')->with('data',$data);
+        return view('purchases/purchases-quotation', [
+            'totalPurchaseQuotationCount' => $totalPurchaseQuotationCount,
+            'totalPurchaseQuotationLineCount' => $totalPurchaseQuotationLineCount,
+            'totalPurchaseQuotationAmount' => $totalPurchaseQuotationAmount,
+        ])->with('data', $data);
     }
 
     /**

--- a/resources/views/purchases/purchases-quotation.blade.php
+++ b/resources/views/purchases/purchases-quotation.blade.php
@@ -17,7 +17,21 @@
       <canvas id="donutChart" width="400" height="400"></canvas>
     </x-adminlte-card>
     <x-adminlte-card title="{{ __('general_content.statistiques_trans_key') }}" theme="warning" icon="fas fa-chart-bar text-white" collapsible removable maximizable>
-      <canvas id="donutChart" width="400" height="400"></canvas>
+      <x-adminlte-small-box
+        title="{{ __('general_content.purchase_quotation_trans_key') }}"
+        text="{{ $totalPurchaseQuotationCount }}"
+        icon="fas fa-file-signature text-white"
+        theme="info"/>
+      <x-adminlte-small-box
+        title="{{ __('general_content.lines_count_trans_key') }}"
+        text="{{ $totalPurchaseQuotationLineCount }}"
+        icon="fas fa-stream text-white"
+        theme="purple"/>
+      <x-adminlte-small-box
+        title="{{ __('general_content.total_price_trans_key') }}"
+        text="{{ $totalPurchaseQuotationAmount }}"
+        icon="fas fa-coins text-white"
+        theme="success"/>
     </x-adminlte-card>
   </div>
   <div class="col-md-9">


### PR DESCRIPTION
### Motivation
- Provide quick summary metrics on the purchase quotation (RFQ) page so users can see totals and amounts at a glance instead of only the status donut chart.

### Description
- Compute totals in the controller by adding `PurchaseQuotationLines` and `Number` imports and calculating `PurchasesQuotation::count()`, `PurchaseQuotationLines::count()` and the summed `total_price` formatted via `Number::currency()` in `PurchasesRFQController::quotation`.
- Pass the computed values to the view and render a new statistics card with three `x-adminlte-small-box` tiles showing the quotations count, lines count and total amount in `resources/views/purchases/purchases-quotation.blade.php` under the existing donut chart.
- Keep existing donut chart logic intact and only add the summary tiles to the right of it.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0602ac3c832db0489a91ebfbf574)