### PR TITLE
Add monthly receipt statistics to purchases receipt dashboard

### DIFF
--- a/app/Http/Controllers/Purchases/PurchasesReceiptController.php
+++ b/app/Http/Controllers/Purchases/PurchasesReceiptController.php
@@ -166,6 +166,7 @@ class PurchasesReceiptController extends Controller
     public function receipt()
     {
         $data['PurchaseReciepCountDataRate'] = $this->purchaseKPIService->getPurchaseReciepCountDataRate();
+        $data['purchaseReceiptMonthlyRecap'] = $this->purchaseKPIService->getPurchaseReceiptMonthlyRecap();
         return view('purchases/purchases-receipt')->with('data',$data);
     }
 

--- a/app/Services/PurchaseKPIService.php
+++ b/app/Services/PurchaseKPIService.php
@@ -304,6 +304,30 @@ class PurchaseKPIService
     }
 
     /**
+     * Get the monthly recap of purchase receipts for the current year.
+     *
+     * This function retrieves the count of purchase receipts per month
+     * for the current year.
+     *
+     * @return \Illuminate\Support\Collection A collection of objects where each object contains:
+     * - month: The month of the purchase receipt.
+     * - receiptCount: The total number of receipts for that month.
+     */
+    public function getPurchaseReceiptMonthlyRecap()
+    {
+        $currentYear = Carbon::now()->format('Y');
+
+        return DB::table('purchase_receipts')
+            ->selectRaw('
+                MONTH(purchase_receipts.created_at) AS month,
+                COUNT(*) AS receiptCount
+            ')
+            ->whereYear('purchase_receipts.created_at', $currentYear)
+            ->groupByRaw('MONTH(purchase_receipts.created_at)')
+            ->get();
+    }
+
+    /**
      * Retrieve the purchase invoice data rate.
      *
      * This function queries the 'purchase_invoices' table and returns the count of purchase invoices

--- a/resources/views/purchases/purchases-receipt.blade.php
+++ b/resources/views/purchases/purchases-receipt.blade.php
@@ -17,7 +17,7 @@
       <canvas id="donutChart" width="400" height="400"></canvas>
     </x-adminlte-card>
     <x-adminlte-card title="{{ __('general_content.statistiques_trans_key') }}" theme="warning" icon="fas fa-chart-bar text-white" collapsible removable maximizable>
-      <canvas id="donutChart" width="400" height="400"></canvas>
+      <canvas id="barChart" style="min-height: 250px; height: 250px; max-height: 250px; max-width: 100%;"></canvas>
     </x-adminlte-card>
   </div>
   <div class="col-md-9">
@@ -74,6 +74,52 @@
         options: donutOptions
       })
   
-  
+    //-------------
+    //- BAR CHART -
+    //-------------
+    var barChartCanvas = $('#barChart').get(0).getContext('2d')
+    var barChartData =  {
+      labels  : ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August','September','October','September','December ' ],
+      datasets: [
+        {
+          label               : 'Total receipts',
+          backgroundColor     : 'rgba(60,141,188,0.9)',
+          borderColor         : 'rgba(60,141,188,0.8)',
+          pointRadius          : false,
+          pointColor          : '#3b8bba',
+          pointStrokeColor    : 'rgba(60,141,188,1)',
+          pointHighlightFill  : '#fff',
+          pointHighlightStroke: 'rgba(60,141,188,1)',
+          data                : [
+                              @php ($j = 1)
+                              @for($iM =1;$iM<=12;$iM++)
+                                @foreach ($data['purchaseReceiptMonthlyRecap'] as $key => $item)
+                                @php ($j = 1)
+                                  @if($iM  == $item->month) 
+                                  "{{ $item->receiptCount }}",
+                                    @php ($j = 2)
+                                    @break
+                                  @endif
+                                @endforeach
+                                @if($j == 1) 
+                                  0,
+                                  @php ($j = 1)
+                                @endif
+                              @endfor ]
+        },
+      ]
+    }
+
+    var barChartOptions = {
+      responsive              : true,
+      maintainAspectRatio     : false,
+      datasetFill             : false
+    }
+
+    new Chart(barChartCanvas, {
+      type: 'bar',
+      data: barChartData,
+      options: barChartOptions
+    })
     </script>
 @stop


### PR DESCRIPTION
### Motivation
- Provide monthly statistics for purchase receipts on the `/purchases/receipt` dashboard so users can see receipt volume trends in addition to status counts.
- Surface a monthly recap alongside the existing status pie chart to improve visibility of receipt activity over the year.

### Description
- Add `getPurchaseReceiptMonthlyRecap()` to `app/Services/PurchaseKPIService.php` to return monthly counts of `purchase_receipts` for the current year.
- Expose the monthly recap data in the receipt controller by populating `$data['purchaseReceiptMonthlyRecap']` in `app/Http/Controllers/Purchases/PurchasesReceiptController.php`.
- Replace the second donut canvas with a `barChart` canvas and render a Chart.js bar chart in `resources/views/purchases/purchases-receipt.blade.php` that maps months to the recap `receiptCount` values.

### Testing
- No unit or integration test suite was run against the changes.
- An attempt to start the application with `php artisan serve --host 0.0.0.0 --port 8000` was performed and failed due to a missing `vendor/autoload.php`, so runtime verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0ad619a0832d8624d0e8ecbc4de6)