### PR TITLE
docs: document custom Artisan commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ Run specific tests:
 php artisan test --filter TestName
 ```
 
+## 🛠️ Custom Artisan Commands (Commandes Artisan spécifiques)
+
+These commands are defined in this repository and complement the default Laravel tooling.
+
+| Command | Description | Example |
+| --- | --- | --- |
+| `php artisan wem:diagnostics` | Check common local setup requirements (PHP version, extensions, app key, cache/storage permissions, Redis, DB, broadcasting). | `php artisan wem:diagnostics` |
+| `php artisan wem:n2p:push-order {orderId} {--sync}` | Push a specific order to Nest2Prod (sync option bypasses the queue). | `php artisan wem:n2p:push-order 123 --sync` |
+| `php artisan quality:dispatch-calibration-alerts` | Notify responsible users when quality control device calibration is due or overdue. | `php artisan quality:dispatch-calibration-alerts` |
+| `php artisan emails:send-auto-reports` | Send scheduled automatic email reports based on user preferences. | `php artisan emails:send-auto-reports` |
+| `php artisan ldap:import-users` | Import LDAP users into the Laravel database. | `php artisan ldap:import-users` |
+
 ## 🤝 Contributing
 
 We welcome contributions! Whether you're fixing bugs, adding features, or improving documentation, your help is appreciated.


### PR DESCRIPTION
### Motivation
- Add concise documentation of repository-specific Artisan commands to the README so contributors can discover and run `wem:diagnostics`, `wem:n2p:push-order`, `quality:dispatch-calibration-alerts`, `emails:send-auto-reports`, and `ldap:import-users`.

### Description
- Added a new "🛠️ Custom Artisan Commands (Commandes Artisan spécifiques)" section to `README.md` with a table that documents `php artisan wem:diagnostics`, `php artisan wem:n2p:push-order {orderId} {--sync}`, `php artisan quality:dispatch-calibration-alerts`, `php artisan emails:send-auto-reports`, and `php artisan ldap:import-users` including short descriptions and usage examples.

### Testing
- Documentation-only change; no automated tests were run and the change is limited to `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cff5ba68c832d856e17a7cbe8c6c6)