### PR TITLE
Add total order weight to order info

### DIFF
--- a/app/Models/Workflow/Orders.php
+++ b/app/Models/Workflow/Orders.php
@@ -252,6 +252,15 @@ class Orders extends Model
         return round($SumPercent/$TotalCountLines,2);
     }
 
+    public function getTotalWeightAttribute()
+    {
+        return $this->OrderLines->sum(function ($orderLine) {
+            $weight = optional($orderLine->OrderLineDetails)->weight ?? 0;
+
+            return (float) $weight * (float) $orderLine->qty;
+        });
+    }
+
     // Relationship with the Rating associated with the Purchases
     public function Rating()
     {

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -521,6 +521,7 @@ return [
     'finishing_trans_key'                   => 'التشطيب',
     'thickness_trans_key'                   => 'السمك',
     'weight_trans_key'                      => 'الوزن',
+    'total_weight_trans_key'                => 'إجمالي الوزن',
     'bend_count_trans_key'                  => 'عدد الثنيات',
     'x_size_trans_key'                      => 'الحجم X',
     'y_size_trans_key'                      => 'الحجم Y',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -593,6 +593,7 @@ return [
     'thickness_trans_key'                      => 'Thickness',
     'weight_trans_key'                         => 'Net weight',
     'gross_weight_trans_key'                   => 'Gross weight',
+    'total_weight_trans_key'                   => 'Total weight',
     'bend_count_trans_key'                     => 'Bend count',
     'x_size_trans_key'                         => 'X size',
     'y_size_trans_key'                         => 'Y size',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -521,6 +521,7 @@ return [
     'finishing_trans_key'                      => 'Acabado',
     'thickness_trans_key'                      => 'Espesor',
     'weight_trans_key'                         => 'Peso',
+    'total_weight_trans_key'                   => 'Peso total',
     'bend_count_trans_key'                     => 'Cantidad de dobleces',
     'x_size_trans_key'                         => 'Tamaño X',
     'y_size_trans_key'                         => 'Tamaño Y',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -593,6 +593,7 @@ return [
     'finishing_trans_key'                      => 'Finition',
     'weight_trans_key'                         => 'Poids net',
     'gross_weight_trans_key'                   => 'Poids brut',
+    'total_weight_trans_key'                   => 'Poids total',
     'bend_count_trans_key'                     => 'Nombre de plis',
     'x_size_trans_key'                         => 'Taille X',
     'y_size_trans_key'                         => 'Taille Y',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -583,6 +583,7 @@ return [
     'finishing_trans_key'                      => '表面处理',
     'weight_trans_key'                         => '净重',
     'gross_weight_trans_key'                   => '毛重',
+    'total_weight_trans_key'                   => '总重量',
     'bend_count_trans_key'                     => '折弯次数',
     'x_size_trans_key'                         => 'X 尺寸',
     'y_size_trans_key'                         => 'Y 尺寸',

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -50,6 +50,7 @@
                     <input type="hidden" name="type" value="{{ $Order->type }}">
                     <p><label for="code" class="text-success">{{ __('general_content.external_id_trans_key') }}</label>  {{  $Order->code }}</p>
                     <p><label for="date" class="text-success">{{ __('general_content.date_trans_key') }}</label>  {{  $Order->GetshortCreatedAttribute() }}</p>
+                    <p><label class="text-success">{{ __('general_content.total_weight_trans_key') }}</label>  {{ number_format($Order->total_weight, 3, '.', ' ') }}</p>
                   </div>
                   <div class="form-group col-md-6">
                     @include('include.form.form-input-label',['label' =>__('general_content.name_order_trans_key'), 'Value' =>  $Order->label])


### PR DESCRIPTION
### Motivation

- Show the total weight on the order detail page as the sum of each order line detail weight multiplied by its quantity to help with packing/shipping and reporting.
- Keep the computation robust when some lines have no `OrderLineDetails`.

### Description

- Add `getTotalWeightAttribute()` to `app/Models/Workflow/Orders.php` to compute `sum(orderLine.OrderLineDetails.weight * orderLine.qty)` using `optional(...)` to handle missing details.
- Display the computed value in the order informations card in `resources/views/workflow/orders-show.blade.php` using `number_format($Order->total_weight, 3, '.', ' ')`.
- Add `total_weight_trans_key` translation entries in `resources/lang/{en,fr,es,ar,zh-CN}/general_content.php` and use that label in the view.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe61a9b6c832d81a6699380ecf882)