### PR TITLE
Scope task date calculation to current order

### DIFF
--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Workflow;
 
 use Illuminate\Support\Number;
 use App\Models\Workflow\Orders;
+use App\Jobs\CalculateTaskDates;
 use App\Services\OrderKPIService;
 use App\Traits\NextPreviousTrait;
 use App\Models\Admin\Factory;
@@ -15,6 +16,7 @@ use App\Services\OrderInvoiceDataService;
 use App\Services\OrderBusinessBalanceService;
 use App\Models\Workflow\OrderLines;
 use App\Http\Requests\Workflow\UpdateOrderRequest;
+use Illuminate\Support\Facades\Cache;
 use Spatie\Activitylog\Models\Activity;
 
 class OrdersController extends Controller
@@ -248,5 +250,15 @@ class OrdersController extends Controller
 
         // Redirect with success message
         return redirect()->route('orders.show', ['id' => $order->id])->with('success', 'Successfully updated Order');
+    }
+
+    public function calculateTaskDates(Orders $order)
+    {
+        Cache::forget(CalculateTaskDates::cacheKeyForOrder($order->id));
+        CalculateTaskDates::dispatchAfterResponse($order->id);
+
+        return redirect()
+            ->route('orders.show', ['id' => $order->id])
+            ->with('success', 'Task date calculation queued for this order.');
     }
 }

--- a/app/Jobs/CalculateTaskDates.php
+++ b/app/Jobs/CalculateTaskDates.php
@@ -19,6 +19,25 @@ class CalculateTaskDates implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public const CACHE_KEY = 'task_calculation_dates_progress';
+    public const ORDER_CACHE_KEY_PREFIX = 'task_calculation_dates_progress_order_';
+
+    private ?int $orderId;
+    private string $cacheKey;
+
+    public function __construct(?int $orderId = null)
+    {
+        $this->orderId = $orderId;
+        $this->cacheKey = self::cacheKeyForOrder($orderId);
+    }
+
+    public static function cacheKeyForOrder(?int $orderId = null): string
+    {
+        if ($orderId === null) {
+            return self::CACHE_KEY;
+        }
+
+        return self::ORDER_CACHE_KEY_PREFIX . $orderId;
+    }
 
     /**
      * Execute the job.
@@ -33,12 +52,16 @@ class CalculateTaskDates implements ShouldQueue
                                                 return $query->where('tasks.type', 1)
                                                             ->orWhere('tasks.type', 7);
                                             })
-                                            ->orderBy('ordre');
+                                    ->orderBy('ordre');
                                     }])
                                     ->join('orders', 'order_lines.orders_id', '=', 'orders.id')
                                     ->where('order_lines.tasks_status', '!=', 4)
                                     ->orderBy('order_lines.internal_delay')
                                     ->select('order_lines.*');
+
+        if ($this->orderId !== null) {
+            $orderLines->where('order_lines.orders_id', $this->orderId);
+        }
 
         $countLines = (clone $orderLines)->count();
 
@@ -88,7 +111,7 @@ class CalculateTaskDates implements ShouldQueue
 
     private function initializeProgress(): void
     {
-        Cache::put(self::CACHE_KEY, [
+        Cache::put($this->cacheKey, [
             'status' => 'running',
             'progress' => 0,
             'count' => 0,
@@ -97,7 +120,7 @@ class CalculateTaskDates implements ShouldQueue
 
     private function updateProgress(int $processed, int $total): void
     {
-        Cache::put(self::CACHE_KEY, [
+        Cache::put($this->cacheKey, [
             'status' => 'running',
             'progress' => round(($processed / $total) * 100, 2),
             'count' => $processed,
@@ -106,9 +129,9 @@ class CalculateTaskDates implements ShouldQueue
 
     private function markFinished(): void
     {
-        $state = Cache::get(self::CACHE_KEY, []);
+        $state = Cache::get($this->cacheKey, []);
 
-        Cache::put(self::CACHE_KEY, [
+        Cache::put($this->cacheKey, [
             'status' => 'finished',
             'progress' => $state['progress'] ?? 100,
             'count' => $state['count'] ?? 0,

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -291,6 +291,17 @@
                         <a href="{{ route('print.manufacturing.instruction', ['Document' => $Order->id])}}" rel="noopener" target="_blank" class="btn btn-info btn-sm"><i class="fas fa-print"></i>Print</a>
                       </td>
                     </tr>
+                    <tr>
+                      <td style="width:50%">{{ __('general_content.calculate_date_task_trans_key') }}</td>
+                      <td>
+                        <form method="POST" action="{{ route('orders.calculate.task.dates', ['order' => $Order->id]) }}">
+                          @csrf
+                          <button class="btn btn-success btn-sm" type="submit">
+                            <i class="fas fa-calendar-check"></i> {{ __('general_content.calculate_task_trans_key') }}
+                          </button>
+                        </form>
+                      </td>
+                    </tr>
                     @if($Order->statu != 1 && $nest2prodUrl !== '')
                     <tr>
                       <td style="width:50%">Nest2Prod</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -162,6 +162,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/lines', 'App\Http\Controllers\Workflow\OrderLinesController@index')->name('orders-lines'); 
         Route::post('/edit/{id}', 'App\Http\Controllers\Workflow\OrdersController@update')->name('orders.update');
         Route::get('/{id}', 'App\Http\Controllers\Workflow\OrdersController@show')->name('orders.show');
+        Route::post('/{order}/calculate-task-dates', 'App\Http\Controllers\Workflow\OrdersController@calculateTaskDates')->name('orders.calculate.task.dates');
         //order line
         Route::post('/{idOrder}/edit-detail-lines/{id}', 'App\Http\Controllers\Workflow\OrderLinesController@update')->name('orders.update.detail.line');
         Route::post('/{idOrder}/edit-detail-lines/{id}/image', 'App\Http\Controllers\Workflow\OrderLinesController@StoreImage')->name('orders.update.detail.picture');


### PR DESCRIPTION
### Motivation

- Provide the ability to recalculate task start/end dates only for the tasks that belong to a single order and trigger that calculation from the order sheet.
- Track progress per-order so the UI can show progress for a single-order recalculation independently from global runs.

### Description

- Update `CalculateTaskDates` to accept an optional order ID, add per-order cache keys, and filter the `OrderLines` query when an order ID is provided so only lines for that order are processed.
- Add `CalculateTaskDates::cacheKeyForOrder()` and use a per-job cache key (`task_calculation_dates_progress_order_{id}`) for progress storage.
- Add `OrdersController::calculateTaskDates()` which clears the order-specific progress cache and dispatches `CalculateTaskDates` for the given order ID.
- Add a POST route `orders/{order}/calculate-task-dates` and a button/form in the order show view to queue the order-scoped recalculation from the UI.

### Testing

- No automated test suite was executed as part of this change.
- An attempt to start the application with `php artisan serve` failed due to a missing `vendor/autoload.php`, so runtime verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fed9e3bb8832da9337f3ded49a0f9)