### PR TITLE
Add delivery lead-time simulation to quote view

### DIFF
--- a/app/Http/Controllers/Workflow/QuotesController.php
+++ b/app/Http/Controllers/Workflow/QuotesController.php
@@ -6,6 +6,9 @@ use Carbon\Carbon;
 use Illuminate\Support\Number;
 use Illuminate\Support\Facades\Log;
 use App\Models\Workflow\Quotes;
+use App\Models\Planning\Task;
+use App\Models\Methods\MethodsServices;
+use App\Models\Times\TimesBanckHoliday;
 use App\Services\QuoteKPIService;
 use App\Traits\NextPreviousTrait;
 use App\Services\SelectDataService;
@@ -13,6 +16,7 @@ use App\Http\Controllers\Controller;
 use App\Services\CustomFieldService;
 use App\Services\QuoteCalculatorService;
 use App\Models\Workflow\QuoteProjectEstimate;
+use Illuminate\Http\Request;
 use App\Http\Requests\Workflow\UpdateQuoteRequest;
 use App\Http\Requests\Workflow\ProjectEstimateRequest;
 use Spatie\Activitylog\Models\Activity;
@@ -213,4 +217,214 @@ class QuotesController extends Controller
     return redirect()->route('quotes.show', ['id' => $quoteId])
         ->with('success', __('Estimation de projet enregistrée avec succès.'));
 }
+
+    public function simulateDelivery(Request $request, Quotes $id)
+    {
+        $validated = $request->validate([
+            'requested_delivery_date' => 'required|date',
+        ]);
+
+        $requestedDate = Carbon::parse($validated['requested_delivery_date'])->startOfDay();
+        $startDate = Carbon::now()->startOfDay();
+
+        if ($requestedDate->lt($startDate)) {
+            return redirect()
+                ->route('quotes.show', ['id' => $id->id])
+                ->with('error', __('general_content.simulation_invalid_date_trans_key'));
+        }
+
+        $quoteLineIds = $id->QuoteLines()->pluck('id');
+
+        if ($quoteLineIds->isEmpty()) {
+            return redirect()
+                ->route('quotes.show', ['id' => $id->id])
+                ->with('error', __('general_content.simulation_no_tasks_trans_key'));
+        }
+
+        $quoteTasks = Task::query()
+            ->whereIn('quote_lines_id', $quoteLineIds)
+            ->where(function ($query) {
+                return $query->where('tasks.type', 1)
+                    ->orWhere('tasks.type', 7);
+            })
+            ->get();
+
+        if ($quoteTasks->isEmpty()) {
+            return redirect()
+                ->route('quotes.show', ['id' => $id->id])
+                ->with('error', __('general_content.simulation_no_tasks_trans_key'));
+        }
+
+        $requiredByService = $quoteTasks
+            ->filter(fn (Task $task) => !is_null($task->methods_services_id))
+            ->groupBy('methods_services_id')
+            ->map(fn ($tasks) => round($tasks->sum(fn (Task $task) => $task->TotalTime()), 2))
+            ->toArray();
+
+        if ($requiredByService === []) {
+            return redirect()
+                ->route('quotes.show', ['id' => $id->id])
+                ->with('error', __('general_content.simulation_no_tasks_trans_key'));
+        }
+
+        $maxSearchDays = 365;
+        $simulationEndDate = $startDate->copy()->addDays($maxSearchDays);
+        if ($requestedDate->gt($simulationEndDate)) {
+            $simulationEndDate = $requestedDate->copy();
+        }
+
+        $loadTasks = Task::query()
+            ->whereNotNull('order_lines_id')
+            ->whereBetween('end_date', [$startDate->toDateString(), $simulationEndDate->toDateString()])
+            ->where(function ($query) {
+                return $query->where('tasks.type', 1)
+                    ->orWhere('tasks.type', 7);
+            })
+            ->get();
+
+        $loadByServiceDay = [];
+        foreach ($loadTasks as $task) {
+            if (is_null($task->methods_services_id) || is_null($task->end_date)) {
+                continue;
+            }
+            $day = Carbon::parse($task->end_date)->toDateString();
+            $serviceId = $task->methods_services_id;
+            $loadByServiceDay[$serviceId][$day] = ($loadByServiceDay[$serviceId][$day] ?? 0) + $task->TotalTime();
+        }
+
+        $capacityPerDay = 16;
+        $remainingAfterRequested = $this->simulateRemainingHours(
+            $requiredByService,
+            $startDate,
+            $requestedDate,
+            $capacityPerDay,
+            $loadByServiceDay
+        );
+
+        $isPossible = $this->allServicesSatisfied($remainingAfterRequested);
+        $earliestDate = $this->calculateEarliestCompletionDate(
+            $requiredByService,
+            $startDate,
+            $simulationEndDate,
+            $capacityPerDay,
+            $loadByServiceDay
+        );
+
+        $missingByService = [];
+        if (!$isPossible) {
+            foreach ($remainingAfterRequested as $serviceId => $remainingHours) {
+                if ($remainingHours > 0) {
+                    $missingByService[$serviceId] = round($remainingHours, 2);
+                }
+            }
+        }
+
+        $serviceLabels = MethodsServices::query()
+            ->whereIn('id', array_keys($requiredByService))
+            ->pluck('label', 'id')
+            ->toArray();
+
+        return redirect()
+            ->route('quotes.show', ['id' => $id->id])
+            ->with('delivery_simulation', [
+                'requested_date' => $requestedDate->toDateString(),
+                'is_possible' => $isPossible,
+                'earliest_date' => $earliestDate?->toDateString(),
+                'required_by_service' => $requiredByService,
+                'missing_by_service' => $missingByService,
+                'service_labels' => $serviceLabels,
+                'capacity_per_day' => $capacityPerDay,
+            ]);
+    }
+
+    private function simulateRemainingHours(
+        array $requiredByService,
+        Carbon $startDate,
+        Carbon $endDate,
+        int $capacityPerDay,
+        array $loadByServiceDay
+    ): array {
+        $remaining = $requiredByService;
+        $cursor = $startDate->copy();
+
+        while ($cursor->lte($endDate)) {
+            if (!$this->isWorkingDay($cursor)) {
+                $cursor->addDay();
+                continue;
+            }
+
+            $dayKey = $cursor->toDateString();
+            foreach ($remaining as $serviceId => $hours) {
+                if ($hours <= 0) {
+                    continue;
+                }
+                $loaded = $loadByServiceDay[$serviceId][$dayKey] ?? 0;
+                $available = $capacityPerDay - $loaded;
+                if ($available <= 0) {
+                    continue;
+                }
+                $remaining[$serviceId] = round($hours - min($available, $hours), 2);
+            }
+
+            $cursor->addDay();
+        }
+
+        return $remaining;
+    }
+
+    private function calculateEarliestCompletionDate(
+        array $requiredByService,
+        Carbon $startDate,
+        Carbon $endDate,
+        int $capacityPerDay,
+        array $loadByServiceDay
+    ): ?Carbon {
+        $remaining = $requiredByService;
+        $cursor = $startDate->copy();
+
+        while ($cursor->lte($endDate)) {
+            if ($this->isWorkingDay($cursor)) {
+                $dayKey = $cursor->toDateString();
+                foreach ($remaining as $serviceId => $hours) {
+                    if ($hours <= 0) {
+                        continue;
+                    }
+                    $loaded = $loadByServiceDay[$serviceId][$dayKey] ?? 0;
+                    $available = $capacityPerDay - $loaded;
+                    if ($available <= 0) {
+                        continue;
+                    }
+                    $remaining[$serviceId] = round($hours - min($available, $hours), 2);
+                }
+
+                if ($this->allServicesSatisfied($remaining)) {
+                    return $cursor->copy();
+                }
+            }
+
+            $cursor->addDay();
+        }
+
+        return null;
+    }
+
+    private function allServicesSatisfied(array $remainingByService): bool
+    {
+        foreach ($remainingByService as $hours) {
+            if ($hours > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isWorkingDay(Carbon $date): bool
+    {
+        if ($date->isWeekend()) {
+            return false;
+        }
+
+        return !TimesBanckHoliday::isBankHoliday($date);
+    }
 }

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -607,6 +607,7 @@ return [
     'section_size_trans_key'                   => 'Section size',
 
     'delivery_note_number_trans_key'           => 'Delivery note number',
+    'delivery_simulation_trans_key'            => 'Delivery lead-time simulation',
     'customer_reference_trans_key'             => 'Customer reference',
     
     'absence_type_day_trans_key'               => 'Absence type day',
@@ -833,6 +834,19 @@ return [
     'days_late_trans_key'                      => ':days days late',
     'to_deliver_today_trans_key'               => 'To be delivered today',
     'delivery_in_days_trans_key'               => 'Delivery in :days days',
+    'requested_delivery_date_trans_key'        => 'Requested delivery date',
+    'run_simulation_trans_key'                 => 'Run simulation',
+    'simulation_possible_trans_key'            => 'Feasible with current load',
+    'simulation_not_possible_trans_key'        => 'Not feasible with current load',
+    'earliest_possible_date_trans_key'         => 'Earliest possible date',
+    'simulation_missing_capacity_trans_key'    => 'Missing capacity (hours)',
+    'simulation_no_tasks_trans_key'            => 'No quote tasks available to run the simulation.',
+    'simulation_invalid_date_trans_key'        => 'The requested date must be today or later.',
+    'simulation_results_trans_key'             => 'Simulation result',
+    'simulation_required_hours_trans_key'      => 'Theoretical time (hours)',
+    'simulation_service_trans_key'             => 'Service',
+    'simulation_remaining_hours_trans_key'     => 'Missing hours',
+    'simulation_capacity_per_day_trans_key'    => 'Daily capacity used',
     
     'info_statu_trans_key'                     => 'The document status does not allow adding / modifying / deleting lines.',
     

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -607,6 +607,7 @@ return [
     'section_size_trans_key'                   => 'Taille des sections',
 
     'delivery_note_number_trans_key'           => 'Nom du bon de livraison',
+    'delivery_simulation_trans_key'            => 'Simulation de délai de livraison',
     'customer_reference_trans_key'             => 'Référence client',
 
     'absence_type_day_trans_key'               => 'Type de jour d\'absence',
@@ -833,6 +834,19 @@ return [
     'days_late_trans_key'                      => ':days jr de retard',
     'to_deliver_today_trans_key'               => 'À livrer aujourd’hui',
     'delivery_in_days_trans_key'               => 'Livraison dans :days jr',
+    'requested_delivery_date_trans_key'        => 'Date de livraison souhaitée',
+    'run_simulation_trans_key'                 => 'Lancer la simulation',
+    'simulation_possible_trans_key'            => 'Faisable avec la charge actuelle',
+    'simulation_not_possible_trans_key'        => 'Non faisable avec la charge actuelle',
+    'earliest_possible_date_trans_key'         => 'Date au plus tôt',
+    'simulation_missing_capacity_trans_key'    => 'Manque de capacité (heures)',
+    'simulation_no_tasks_trans_key'            => 'Aucune tâche de devis pour lancer la simulation.',
+    'simulation_invalid_date_trans_key'        => 'La date souhaitée doit être supérieure ou égale à aujourd\'hui.',
+    'simulation_results_trans_key'             => 'Résultat de la simulation',
+    'simulation_required_hours_trans_key'      => 'Temps théorique (heures)',
+    'simulation_service_trans_key'             => 'Service',
+    'simulation_remaining_hours_trans_key'     => 'Heures manquantes',
+    'simulation_capacity_per_day_trans_key'    => 'Capacité journalière utilisée',
     
     'info_statu_trans_key'                     => 'Le statut du document ne permet pas d\'ajouter/modifier/supprimer des lignes.',
 

--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -192,6 +192,70 @@
               @include('include.sub-total-price')
             </x-adminlte-card>
 
+            <x-adminlte-card title="{{ __('general_content.delivery_simulation_trans_key') }}" theme="info" collapsible maximizable>
+              <form action="{{ route('quotes.delivery.simulation', ['id' => $Quote->id]) }}" method="POST">
+                @csrf
+                <div class="form-group">
+                  <label for="requested_delivery_date">{{ __('general_content.requested_delivery_date_trans_key') }}</label>
+                  <input type="date" class="form-control" id="requested_delivery_date" name="requested_delivery_date" value="{{ old('requested_delivery_date') }}" required>
+                </div>
+                <button type="submit" class="btn btn-primary btn-sm">
+                  <i class="fas fa-play-circle"></i> {{ __('general_content.run_simulation_trans_key') }}
+                </button>
+              </form>
+
+              @if(session('delivery_simulation'))
+                @php($simulation = session('delivery_simulation'))
+                <div class="mt-3">
+                  <h6 class="text-muted mb-2">{{ __('general_content.simulation_results_trans_key') }}</h6>
+                  @if($simulation['is_possible'])
+                    <span class="badge badge-success">{{ __('general_content.simulation_possible_trans_key') }}</span>
+                  @else
+                    <span class="badge badge-danger">{{ __('general_content.simulation_not_possible_trans_key') }}</span>
+                  @endif
+
+                  <p class="mt-2 mb-1">
+                    <strong>{{ __('general_content.requested_delivery_date_trans_key') }}:</strong>
+                    {{ $simulation['requested_date'] }}
+                  </p>
+
+                  @if(!empty($simulation['earliest_date']))
+                    <p class="mb-2">
+                      <strong>{{ __('general_content.earliest_possible_date_trans_key') }}:</strong>
+                      {{ $simulation['earliest_date'] }}
+                    </p>
+                  @endif
+
+                  <p class="text-muted mb-2">
+                    {{ __('general_content.simulation_capacity_per_day_trans_key') }} ({{ $simulation['capacity_per_day'] }} h)
+                  </p>
+
+                  <table class="table table-sm table-striped mb-0">
+                    <thead>
+                      <tr>
+                        <th>{{ __('general_content.simulation_service_trans_key') }}</th>
+                        <th class="text-right">{{ __('general_content.simulation_required_hours_trans_key') }}</th>
+                        @if(!$simulation['is_possible'])
+                          <th class="text-right">{{ __('general_content.simulation_remaining_hours_trans_key') }}</th>
+                        @endif
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @foreach($simulation['required_by_service'] as $serviceId => $requiredHours)
+                        <tr>
+                          <td>{{ $simulation['service_labels'][$serviceId] ?? $serviceId }}</td>
+                          <td class="text-right">{{ $requiredHours }}</td>
+                          @if(!$simulation['is_possible'])
+                            <td class="text-right">{{ $simulation['missing_by_service'][$serviceId] ?? 0 }}</td>
+                          @endif
+                        </tr>
+                      @endforeach
+                    </tbody>
+                  </table>
+                </div>
+              @endif
+            </x-adminlte-card>
+
             @if($Quote->opportunities_id)
               <x-adminlte-card title="{{ __('general_content.historical_trans_key') }}" theme="info"  collapsible="collapsed" maximizable>
                 <div class="text-muted">

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,6 +148,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/{idQuote}/edit-detail-lines/{id}', 'App\Http\Controllers\Workflow\QuoteLinesController@update')->name('quotes.update.detail.line');
         Route::post('/{idQuote}/edit-detail-lines/{id}/image', 'App\Http\Controllers\Workflow\QuoteLinesController@StoreImage')->name('quotes.update.detail.picture');
         Route::post('/{idQuote}/lines/import', 'App\Http\Controllers\Workflow\QuoteLinesController@import')->name('quotes.lines.import');
+        Route::post('/{id}/delivery-simulation', 'App\Http\Controllers\Workflow\QuotesController@simulateDelivery')->name('quotes.delivery.simulation');
         //Project estimate
         Route::post('project-estimate/save/{id}', 'App\Http\Controllers\Workflow\QuotesController@saveProjectEstimate')->name('quotes.project.estimates');
         //import


### PR DESCRIPTION
### Motivation
- Provide a way on the quote page to enter a requested delivery date, simulate whether current production load can meet it, and propose an earliest feasible date or remaining capacity per service.

### Description
- Added a POST route `quotes.delivery.simulation` and a new `simulateDelivery` action in `QuotesController` that validates the requested date, aggregates quote tasks by service and required hours, and compares them to scheduled/order load to determine feasibility.
- Implemented simulation helpers in the controller to walk working days (skipping weekends and bank holidays) and compute remaining hours per service and the earliest completion date given a fixed daily capacity (16h); the simulation looks at existing order tasks (by `order_lines_id`) to compute daily load.
- Added a UI card on the quote page (`resources/views/workflow/quotes-show.blade.php`) with a date input and run button that posts to the new route and displays simulation results, required hours per service, and missing/earliest date information.
- Added English and French translation keys and labels for the new UI/messages and updated necessary imports/usages in the controller and routes (`routes/web.php`, `resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`, `app/Http/Controllers/Workflow/QuotesController.php`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff0d0075c832dae8f962bedffefc3)