### PR TITLE
Guard null quote code in quote lines view

### DIFF
--- a/resources/views/livewire/quotes-lines-index.blade.php
+++ b/resources/views/livewire/quotes-lines-index.blade.php
@@ -36,7 +36,7 @@
                         @forelse ($QuoteLineslist as $QuoteLine)
                         <tr>
                             <td>
-                                <x-QuoteButton id="{{ $QuoteLine->quotes_id }}" code="{{ $QuoteLine->quote['code'] }}"  />
+                                <x-QuoteButton id="{{ $QuoteLine->quotes_id }}" code="{{ data_get($QuoteLine, 'quote.code') }}"  />
                             </td>
                             <td>{{ $QuoteLine->ordre }}</td>
                             <td>{{ $QuoteLine->code }}</td>


### PR DESCRIPTION
### Motivation
- Prevent a "Trying to access array offset on value of type null" error when rendering the quote code for a quote line by safely handling a missing `quote` relationship.

### Description
- Replace the direct array access `{{ $QuoteLine->quote['code'] }}` with the safe accessor `{{ data_get($QuoteLine, 'quote.code') }}` in `resources/views/livewire/quotes-lines-index.blade.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff5b4d910832db71c82c2ac6bac57)