### PR TITLE
Fix task quantity fallback for quote lines

### DIFF
--- a/app/Models/Planning/Task.php
+++ b/app/Models/Planning/Task.php
@@ -293,19 +293,29 @@ class Task extends Model
     }
 
     /**
-     * Get the quantity of the order line.
+     * Get the quantity used for time and cost calculations.
      *
-     * This method retrieves the order line associated with the task and returns its quantity.
-     * If the order line or its quantity is not found, it returns 0.
+     * This method retrieves the order line quantity when available. If the task
+     * is tied to a quote line (before an order exists), it falls back to the
+     * quote line quantity or the task's own quantity.
      *
-     * @return int The quantity of the order line.
+     * @return int The quantity of the related line or task.
      */
     public function GetOrderQtyLine()
     {
-        $OrderLine = OrderLines::find($this->order_lines_id);
-        if(empty($OrderLine->qty)) $LineQty = 0;
-        else $LineQty = $OrderLine->qty;
-        return $LineQty;
+        if (!empty($this->order_lines_id)) {
+            $OrderLine = OrderLines::find($this->order_lines_id);
+            return $OrderLine->qty ?? 0;
+        }
+
+        if (!empty($this->quote_lines_id)) {
+            $QuoteLine = QuoteLines::find($this->quote_lines_id);
+            if (!empty($QuoteLine->qty)) {
+                return $QuoteLine->qty;
+            }
+        }
+
+        return $this->qty ?? 0;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- The simulation aggregated task hours using `Task::TotalTime()` which relies on `ProductTime()` that previously only used the order-line quantity, causing tasks attached to quote lines to resolve product time to 0 when `order_lines_id` was null. 
- This underestimated required hours for quotes and could mark infeasible quotes as feasible, so a fallback to the quote line quantity (or the task quantity) was needed.

### Description
- Updated `Task::GetOrderQtyLine()` in `app/Models/Planning/Task.php` to first return the order line quantity when `order_lines_id` is present, then fall back to the quote line quantity via `quote_lines_id`, and finally to the task's own `qty` when neither line is available.
- Clarified the method PHPDoc to explain the new lookup order and intent.
- No other behavior of `ProductTime()` or `TotalTime()` was changed; they now correctly calculate using the improved quantity lookup.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff6a506a4832d8b7b50ea51b5dc42)