### PR TITLE
Eager-load OrderLineDetails in OrdersController@show

### DIFF
--- a/app/Http/Controllers/Workflow/OrdersController.php
+++ b/app/Http/Controllers/Workflow/OrdersController.php
@@ -92,7 +92,7 @@ class OrdersController extends Controller
     {
         $factory = app('Factory');
 
-        $id->load(['OrderSite.OrderSiteImplantations']);
+        $id->load(['OrderSite.OrderSiteImplantations', 'OrderLines.OrderLineDetails']);
 
         // Retrieve necessary data for dropdowns
         $CompanieSelect = $this->SelectDataService->getCompanies();


### PR DESCRIPTION
### Motivation
- Prevent N+1 queries when rendering order totals (for example `getTotalWeightAttribute` accesses `$orderLine->OrderLineDetails`) by ensuring line details are loaded with the order.

### Description
- Add `OrderLines.OrderLineDetails` to the `$id->load()` call in `app/Http/Controllers/Workflow/OrdersController.php` within `show` so order lines' details are eager-loaded.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff6bff86c832da865327c9405e342)