### PR TITLE
Add pending orders KPI to company dashboard

### DIFF
--- a/app/Http/Controllers/Companies/CompaniesController.php
+++ b/app/Http/Controllers/Companies/CompaniesController.php
@@ -86,6 +86,7 @@ class CompaniesController extends Controller
         $userSelect = $this->SelectDataService->getUsers();
         list($previousUrl, $nextUrl) = $this->getNextPrevious(new Companies(), $id->id);
         $remainingInvoiceOrder =  $this->orderKPIService->getOrderMonthlyRemainingToInvoice($id->id);
+        $pendingOrdersCount = $this->orderKPIService->getPendingOrdersCountForCompany($id->id);
         $paidInvoices = $this->invoiceKPIService->getPaidInvoicesCount($id->id);
         $unpaidInvoices = $this->invoiceKPIService->getUnpaidInvoicesCount($id->id);
         $serviceRate = $this->orderKPIService->getServiceRate($id->id);
@@ -145,6 +146,7 @@ class CompaniesController extends Controller
                                                         'previousUrl',
                                                         'nextUrl',
                                                         'remainingInvoiceOrder',
+                                                        'pendingOrdersCount',
                                                         'customerProcessingCost',
                                                         'paidInvoices',
                                                         'unpaidInvoices',

--- a/app/Services/OrderKPIService.php
+++ b/app/Services/OrderKPIService.php
@@ -416,6 +416,28 @@ class OrderKPIService
     }
 
     /**
+    * Get the number of pending orders for a specific company for the current year.
+    *
+    * An order is pending if it has at least one order line that is not fully delivered.
+    *
+    * @param int $companyId
+    * @return int The number of pending orders for the company.
+    */
+    public function getPendingOrdersCountForCompany(int $companyId)
+    {
+        $cacheKey = 'pending_orders_count_' . now()->year . '_company_' . $companyId;
+
+        return Cache::remember($cacheKey, now()->addMinutes(10), function () use ($companyId) {
+            return Orders::where('companies_id', $companyId)
+                ->whereYear('created_at', now()->year)
+                ->whereHas('orderLines', function ($query) {
+                    $query->whereIn('delivery_status', [1, 2]);
+                })
+                ->count();
+        });
+    }
+
+    /**
     * Calculate the Service Rate.
     *
     * The Service Rate is calculated by dividing the number of requests (order lines)

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -644,6 +644,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'إجمالي التسليم للشهر',
     'remaining_month_trans_key'                => 'الإجمالي المتبقي للتسليم',
     'remaining_invoice_month_trans_key'        => 'الإجمالي المتبقي للفوترة',
+    'pending_orders_trans_key'                => 'الطلبات قيد التنفيذ',
     'forecast_next_three_months_trans_key'     => 'توقعات الأشهر الثلاثة القادمة',
 
     

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -728,6 +728,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'Total Delivered for the month',
     'remaining_month_trans_key'                => 'Total remaining to deliver',
     'remaining_invoice_month_trans_key'        => 'Total remaining to invoice',
+    'pending_orders_trans_key'                => 'Orders in progress',
     'forecast_next_three_months_trans_key'     => 'Forecast for the next 3 months',
     'service_rate_trans_key'                   => 'Service rate',
     'average_order_processing_time_trans_key'  => 'Average order processing time',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -644,6 +644,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'Total entregado en el mes',
     'remaining_month_trans_key'                => 'Total restante por entregar',
     'remaining_invoice_month_trans_key'        => 'Total restante por facturar',
+    'pending_orders_trans_key'                => 'Pedidos en curso',
     'forecast_next_three_months_trans_key'     => 'Pronóstico para los próximos 3 meses',
 
         

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -728,6 +728,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'Total livré du mois',
     'remaining_month_trans_key'                => 'Total restant à livrer',
     'remaining_invoice_month_trans_key'        => 'Total restant à facturer',
+    'pending_orders_trans_key'                => 'Commandes en cours',
     'forecast_next_three_months_trans_key'     => 'Prévision pour les 3 prochains mois',
     'service_rate_trans_key'                   => 'Taux de service',
     'average_order_processing_time_trans_key'  => 'Temps moyen de traitement',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -56,6 +56,7 @@ return [
     'delivered_month_in_progress_trans_key'    => 'Số đơn đã giao trong tháng',
     'remaining_month_trans_key'                => 'Số đơn phải giao',
     'remaining_invoice_month_trans_key'        => 'Tổng còn lại cần xuất hóa đơn',
+    'pending_orders_trans_key'                => 'Đơn hàng đang xử lý',
     'forecast_next_three_months_trans_key'     => 'Dự báo cho 3 tháng tới',
     
 

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -717,6 +717,7 @@ return [
     'delivered_month_in_progress_trans_key'    => '本月已交付总计',
     'remaining_month_trans_key'                => '本月剩余交付',
     'remaining_invoice_month_trans_key'        => '本月剩余开票',
+    'pending_orders_trans_key'                => '进行中的订单',
     'forecast_next_three_months_trans_key'     => '未来3个月预测',
     'service_rate_trans_key'                   => '服务率',
     'average_order_processing_time_trans_key'  => '平均处理时间',

--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -47,6 +47,13 @@
           </div>
 
           <div class="col-lg-3 col-md-3">
+            <x-adminlte-small-box title="{{ $pendingOrdersCount }}"
+              text="{{ __('general_content.pending_orders_trans_key') }}"
+              icon="icon fas fa-box-open"
+              theme="warning" />
+          </div>
+
+          <div class="col-lg-3 col-md-3">
             <x-adminlte-small-box title="{{ $customerProcessingCost }}"
               text="{{ __('general_content.customer_processing_cost_trans_key') }}"
               icon="icon fas fa-info"


### PR DESCRIPTION
### Motivation
- Provide a company-specific KPI on the company detail page to show how many orders are currently in progress (pending delivery) for that customer.

### Description
- Added `getPendingOrdersCountForCompany(int $companyId)` to `app/Services/OrderKPIService.php` which caches and returns the count of orders for a company that have at least one order line with `delivery_status` in `[1,2]`.
- Wired the new KPI into the company controller by calling `getPendingOrdersCountForCompany` in `app/Http/Controllers/Companies/CompaniesController.php` and passing `pendingOrdersCount` to the view.
- Displayed the KPI on the company dashboard by adding a small box in `resources/views/companies/companies-show.blade.php` that renders `pendingOrdersCount` with the `pending_orders_trans_key` label.
- Added `pending_orders_trans_key` translations in the supported locale files in `resources/lang/*/general_content.php`.

### Testing
- No automated tests were executed for this change.
- An attempt to run the app with `php artisan serve` failed because `vendor/autoload.php` was missing, so runtime verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff986d078832d986fa9467bd71dcb)