### PR TITLE
Remove duplicate company API routes to fix route name collision

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -32,8 +32,6 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 // new route :
 Route::get('/gantt/order/{order_lines_id}', 'App\Http\Controllers\Planning\GanttController@getTasksByOrderLine');
 
-Route::apiResource('company',CompanyController::class);
-Route::post('/company', 'App\Http\Controllers\Api\CompanyController@store');
 Route::apiResource('companies', CompanyController::class);
 
 Route::apiResource('quote',QuoteController::class);


### PR DESCRIPTION
### Motivation
- Fix a route serialization crash caused by duplicated API routes registering the same route name (`companies.index`) which caused a crash loop during `docker compose up --build`.

### Description
- Remove the redundant singular API routes from `routes/api.php` by deleting `Route::apiResource('company', CompanyController::class)` and the duplicate `Route::post('/company', ...)` so only `Route::apiResource('companies', CompanyController::class)` remains.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709107a964832d9657c03793944a00)