### PR TITLE
Gate Assets submenu with new `asset-menu` permission and seed it

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -39,7 +39,7 @@ class AssetController extends Controller
 
     public function show($id)
     {
-        $asset = Asset::with('accountingEntries')->findOrFail($id);
+        $asset = Asset::with(['accountingEntries', 'workOrders'])->findOrFail($id);
         return view('assets.assets-show', compact('asset'));
     }
 

--- a/app/Http/Controllers/Maintenance/WorkOrderController.php
+++ b/app/Http/Controllers/Maintenance/WorkOrderController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\Maintenance;
+
+use App\Http\Controllers\Controller;
+use App\Models\Assets\Asset;
+use App\Models\Maintenance\WorkOrder;
+use App\Models\Times\TimesMachineEvent;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class WorkOrderController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'check.factory', 'permission:asset_manager']);
+    }
+
+    public function index()
+    {
+        $workOrders = WorkOrder::with(['asset', 'machineEvent', 'creator'])
+            ->orderByDesc('requested_at')
+            ->paginate(15);
+
+        return view('gmao.work-orders-index', [
+            'workOrders' => $workOrders,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        return view('gmao.work-orders-create', [
+            'assets' => Asset::orderBy('name')->get(),
+            'machineEvents' => TimesMachineEvent::orderBy('ordre')->get(),
+            'priorities' => $this->priorityOptions(),
+            'statuses' => $this->statusOptions(),
+            'selectedAssetId' => $request->get('asset_id'),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $this->validatedData($request);
+        $data['created_by'] = Auth::id();
+
+        $workOrder = WorkOrder::create($data);
+
+        return redirect()->route('gmao.work-orders.show', $workOrder->id);
+    }
+
+    public function show($id)
+    {
+        $workOrder = WorkOrder::with(['asset', 'machineEvent', 'creator'])->findOrFail($id);
+
+        return view('gmao.work-orders-show', [
+            'workOrder' => $workOrder,
+        ]);
+    }
+
+    public function edit($id)
+    {
+        $workOrder = WorkOrder::findOrFail($id);
+
+        return view('gmao.work-orders-edit', [
+            'workOrder' => $workOrder,
+            'assets' => Asset::orderBy('name')->get(),
+            'machineEvents' => TimesMachineEvent::orderBy('ordre')->get(),
+            'priorities' => $this->priorityOptions(),
+            'statuses' => $this->statusOptions(),
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $workOrder = WorkOrder::findOrFail($id);
+        $data = $this->validatedData($request);
+
+        $workOrder->update($data);
+
+        return redirect()->route('gmao.work-orders.show', $workOrder->id);
+    }
+
+    public function destroy($id)
+    {
+        $workOrder = WorkOrder::findOrFail($id);
+        $workOrder->delete();
+
+        return redirect()->route('gmao.work-orders.index');
+    }
+
+    private function priorityOptions(): array
+    {
+        return [
+            'low' => 'Low',
+            'medium' => 'Medium',
+            'high' => 'High',
+            'critical' => 'Critical',
+        ];
+    }
+
+    private function statusOptions(): array
+    {
+        return [
+            'requested' => 'Requested',
+            'scheduled' => 'Scheduled',
+            'in_progress' => 'In progress',
+            'completed' => 'Completed',
+            'canceled' => 'Canceled',
+        ];
+    }
+
+    private function validatedData(Request $request): array
+    {
+        return $request->validate([
+            'asset_id' => 'required|exists:assets,id',
+            'times_machine_event_id' => 'nullable|exists:times_machine_events,id',
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'priority' => 'required|in:low,medium,high,critical',
+            'status' => 'required|in:requested,scheduled,in_progress,completed,canceled',
+            'requested_at' => 'required|date',
+            'scheduled_at' => 'nullable|date',
+            'completed_at' => 'nullable|date',
+        ]);
+    }
+}

--- a/app/Models/Assets/Asset.php
+++ b/app/Models/Assets/Asset.php
@@ -5,6 +5,7 @@ namespace App\Models\Assets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\Accounting\AccountingEntry;
+use App\Models\Maintenance\WorkOrder;
 
 class Asset extends Model
 {
@@ -25,5 +26,10 @@ class Asset extends Model
     public function accountingEntries(): HasMany
     {
         return $this->hasMany(AccountingEntry::class);
+    }
+
+    public function workOrders(): HasMany
+    {
+        return $this->hasMany(WorkOrder::class);
     }
 }

--- a/app/Models/Maintenance/WorkOrder.php
+++ b/app/Models/Maintenance/WorkOrder.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class WorkOrder extends Model
 {
+    protected $table = 'maintenance_work_orders';
+
     protected $fillable = [
         'asset_id',
         'times_machine_event_id',

--- a/app/Models/Maintenance/WorkOrder.php
+++ b/app/Models/Maintenance/WorkOrder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models\Maintenance;
+
+use App\Models\Assets\Asset;
+use App\Models\Times\TimesMachineEvent;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WorkOrder extends Model
+{
+    protected $fillable = [
+        'asset_id',
+        'times_machine_event_id',
+        'title',
+        'description',
+        'priority',
+        'status',
+        'requested_at',
+        'scheduled_at',
+        'completed_at',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'requested_at' => 'date',
+        'scheduled_at' => 'date',
+        'completed_at' => 'date',
+    ];
+
+    public function asset(): BelongsTo
+    {
+        return $this->belongsTo(Asset::class);
+    }
+
+    public function machineEvent(): BelongsTo
+    {
+        return $this->belongsTo(TimesMachineEvent::class, 'times_machine_event_id');
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -617,6 +617,24 @@ return [
             'can'  => ['accounting-menu'],
         ],
         [
+            'text' => 'GMAO',
+            'icon' => 'fas fa-tools',
+            'can'  => ['asset_manager'],
+            'submenu' => [
+                [
+                    'text' => 'assets_trans_key',
+                    'url'  => 'assets',
+                    'icon_color' => 'info',
+                    'can'  => ['asset-menu'],
+                ],
+                [
+                    'text' => 'Work orders',
+                    'url'  => 'gmao/work-orders',
+                    'icon_color' => 'primary',
+                ],
+            ],
+        ],
+        [
             'text' => 'human_resources_trans_key',
             'icon' => 'fas fa-users',
             'url'  => '',

--- a/database/migrations/2025_03_11_000003_create_maintenance_work_orders_table.php
+++ b/database/migrations/2025_03_11_000003_create_maintenance_work_orders_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('maintenance_work_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_id')->constrained('assets')->cascadeOnDelete();
+            $table->foreignId('times_machine_event_id')->nullable()->constrained('times_machine_events')->nullOnDelete();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('priority')->default('medium');
+            $table->string('status')->default('requested');
+            $table->date('requested_at');
+            $table->date('scheduled_at')->nullable();
+            $table->date('completed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_work_orders');
+    }
+};

--- a/database/seeders/PermissionTableSeeder.php
+++ b/database/seeders/PermissionTableSeeder.php
@@ -34,6 +34,7 @@ class PermissionTableSeeder  extends Seeder
                         'osh-menu',
                         'your-company-menu',
                         'asset_manager',
+                        'asset-menu',
                         ];
     
                         foreach ($permissions as $permission) {

--- a/resources/views/assets/assets-show.blade.php
+++ b/resources/views/assets/assets-show.blade.php
@@ -34,5 +34,17 @@
                 <li>{{ $entry->entry_label }} - {{ $entry->debit_amount }} / {{ $entry->credit_amount }}</li>
             @endforeach
         </ul>
+        <h2>Maintenance work orders</h2>
+        <ul>
+            @forelse($asset->workOrders as $workOrder)
+                <li>
+                    <a href="{{ route('gmao.work-orders.show', $workOrder->id) }}">#{{ $workOrder->id }} - {{ $workOrder->title }}</a>
+                    ({{ ucfirst(str_replace('_', ' ', $workOrder->status)) }})
+                </li>
+            @empty
+                <li>{{ __('general_content.no_data_trans_key') }}</li>
+            @endforelse
+        </ul>
+        <a href="{{ route('gmao.work-orders.create', ['asset_id' => $asset->id]) }}" class="btn btn-primary">New work order</a>
     </x-adminlte-card>
 @stop

--- a/resources/views/gmao/work-orders-create.blade.php
+++ b/resources/views/gmao/work-orders-create.blade.php
@@ -1,0 +1,73 @@
+@extends('adminlte::page')
+
+@section('title', 'New Work Order')
+
+@section('content_header')
+    <h1>New Work Order</h1>
+@stop
+
+@section('content')
+    <form method="POST" action="{{ route('gmao.work-orders.store') }}">
+        @csrf
+        <x-adminlte-card title="Work Order" theme="secondary" maximizable>
+            <div class="form-group">
+                <label for="asset_id">Asset</label>
+                <select class="form-control" name="asset_id" id="asset_id">
+                    <option value="">Select an asset</option>
+                    @foreach($assets as $asset)
+                        <option value="{{ $asset->id }}" @selected(old('asset_id', $selectedAssetId) == $asset->id)>{{ $asset->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="times_machine_event_id">Machine event</label>
+                <select class="form-control" name="times_machine_event_id" id="times_machine_event_id">
+                    <option value="">Not specified</option>
+                    @foreach($machineEvents as $machineEvent)
+                        <option value="{{ $machineEvent->id }}" @selected(old('times_machine_event_id') == $machineEvent->id)>{{ $machineEvent->label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="title">Title</label>
+                <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}">
+            </div>
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea class="form-control" name="description" id="description" rows="4">{{ old('description') }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="priority">Priority</label>
+                <select class="form-control" name="priority" id="priority">
+                    @foreach($priorities as $value => $label)
+                        <option value="{{ $value }}" @selected(old('priority', 'medium') == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="status">Status</label>
+                <select class="form-control" name="status" id="status">
+                    @foreach($statuses as $value => $label)
+                        <option value="{{ $value }}" @selected(old('status', 'requested') == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="requested_at">Requested at</label>
+                <input type="date" class="form-control" name="requested_at" id="requested_at" value="{{ old('requested_at', now()->format('Y-m-d')) }}">
+            </div>
+            <div class="form-group">
+                <label for="scheduled_at">Scheduled at</label>
+                <input type="date" class="form-control" name="scheduled_at" id="scheduled_at" value="{{ old('scheduled_at') }}">
+            </div>
+            <div class="form-group">
+                <label for="completed_at">Completed at</label>
+                <input type="date" class="form-control" name="completed_at" id="completed_at" value="{{ old('completed_at') }}">
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="Save" theme="success" icon="fas fa-lg fa-save" />
+                <a href="{{ route('gmao.work-orders.index') }}" class="btn btn-secondary float-right">Back</a>
+            </x-slot>
+        </x-adminlte-card>
+    </form>
+@stop

--- a/resources/views/gmao/work-orders-edit.blade.php
+++ b/resources/views/gmao/work-orders-edit.blade.php
@@ -1,0 +1,74 @@
+@extends('adminlte::page')
+
+@section('title', 'Edit Work Order')
+
+@section('content_header')
+    <h1>Edit Work Order</h1>
+@stop
+
+@section('content')
+    <form method="POST" action="{{ route('gmao.work-orders.update', $workOrder->id) }}">
+        @csrf
+        @method('PUT')
+        <x-adminlte-card title="Work Order" theme="secondary" maximizable>
+            <div class="form-group">
+                <label for="asset_id">Asset</label>
+                <select class="form-control" name="asset_id" id="asset_id">
+                    <option value="">Select an asset</option>
+                    @foreach($assets as $asset)
+                        <option value="{{ $asset->id }}" @selected(old('asset_id', $workOrder->asset_id) == $asset->id)>{{ $asset->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="times_machine_event_id">Machine event</label>
+                <select class="form-control" name="times_machine_event_id" id="times_machine_event_id">
+                    <option value="">Not specified</option>
+                    @foreach($machineEvents as $machineEvent)
+                        <option value="{{ $machineEvent->id }}" @selected(old('times_machine_event_id', $workOrder->times_machine_event_id) == $machineEvent->id)>{{ $machineEvent->label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="title">Title</label>
+                <input type="text" class="form-control" name="title" id="title" value="{{ old('title', $workOrder->title) }}">
+            </div>
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea class="form-control" name="description" id="description" rows="4">{{ old('description', $workOrder->description) }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="priority">Priority</label>
+                <select class="form-control" name="priority" id="priority">
+                    @foreach($priorities as $value => $label)
+                        <option value="{{ $value }}" @selected(old('priority', $workOrder->priority) == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="status">Status</label>
+                <select class="form-control" name="status" id="status">
+                    @foreach($statuses as $value => $label)
+                        <option value="{{ $value }}" @selected(old('status', $workOrder->status) == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="requested_at">Requested at</label>
+                <input type="date" class="form-control" name="requested_at" id="requested_at" value="{{ old('requested_at', optional($workOrder->requested_at)->format('Y-m-d')) }}">
+            </div>
+            <div class="form-group">
+                <label for="scheduled_at">Scheduled at</label>
+                <input type="date" class="form-control" name="scheduled_at" id="scheduled_at" value="{{ old('scheduled_at', optional($workOrder->scheduled_at)->format('Y-m-d')) }}">
+            </div>
+            <div class="form-group">
+                <label for="completed_at">Completed at</label>
+                <input type="date" class="form-control" name="completed_at" id="completed_at" value="{{ old('completed_at', optional($workOrder->completed_at)->format('Y-m-d')) }}">
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="Save" theme="success" icon="fas fa-lg fa-save" />
+                <a href="{{ route('gmao.work-orders.show', $workOrder->id) }}" class="btn btn-secondary float-right">Back</a>
+            </x-slot>
+        </x-adminlte-card>
+    </form>
+@stop

--- a/resources/views/gmao/work-orders-index.blade.php
+++ b/resources/views/gmao/work-orders-index.blade.php
@@ -1,0 +1,52 @@
+@extends('adminlte::page')
+
+@section('title', 'GMAO - Work Orders')
+
+@section('content_header')
+    <h1>GMAO - Work Orders</h1>
+@stop
+
+@section('content')
+    <x-adminlte-card title="Work Orders" theme="primary" maximizable>
+        <div class="card-body table-responsive p-0">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Asset</th>
+                        <th>Title</th>
+                        <th>Priority</th>
+                        <th>Status</th>
+                        <th>Requested at</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($workOrders as $workOrder)
+                        <tr>
+                            <td>{{ $workOrder->id }}</td>
+                            <td>{{ $workOrder->asset?->name }}</td>
+                            <td><a href="{{ route('gmao.work-orders.show', $workOrder->id) }}">{{ $workOrder->title }}</a></td>
+                            <td>{{ ucfirst(str_replace('_', ' ', $workOrder->priority)) }}</td>
+                            <td>{{ ucfirst(str_replace('_', ' ', $workOrder->status)) }}</td>
+                            <td>{{ optional($workOrder->requested_at)->format('Y-m-d') }}</td>
+                            <td class="text-right">
+                                <a href="{{ route('gmao.work-orders.edit', $workOrder->id) }}" class="btn btn-xs btn-default text-primary mx-1 shadow" title="Edit">
+                                    <i class="fa fa-lg fa-fw fa-pen"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7">{{ __('general_content.no_data_trans_key') }}</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            <a href="{{ route('gmao.work-orders.create') }}" class="btn btn-primary">New Work Order</a>
+            {{ $workOrders->links() }}
+        </div>
+    </x-adminlte-card>
+@stop

--- a/resources/views/gmao/work-orders-show.blade.php
+++ b/resources/views/gmao/work-orders-show.blade.php
@@ -1,0 +1,49 @@
+@extends('adminlte::page')
+
+@section('title', 'Work Order #' . $workOrder->id)
+
+@section('content_header')
+    <h1>Work Order #{{ $workOrder->id }}</h1>
+@stop
+
+@section('content')
+    <x-adminlte-card title="Work Order Details" theme="primary" maximizable>
+        <div class="row">
+            <div class="col-md-6">
+                <dl>
+                    <dt>Asset</dt>
+                    <dd>{{ $workOrder->asset?->name }}</dd>
+                    <dt>Title</dt>
+                    <dd>{{ $workOrder->title }}</dd>
+                    <dt>Description</dt>
+                    <dd>{{ $workOrder->description }}</dd>
+                    <dt>Machine event</dt>
+                    <dd>{{ $workOrder->machineEvent?->label ?? 'Not specified' }}</dd>
+                    <dt>Priority</dt>
+                    <dd>{{ ucfirst(str_replace('_', ' ', $workOrder->priority)) }}</dd>
+                    <dt>Status</dt>
+                    <dd>{{ ucfirst(str_replace('_', ' ', $workOrder->status)) }}</dd>
+                </dl>
+            </div>
+            <div class="col-md-6">
+                <dl>
+                    <dt>Requested at</dt>
+                    <dd>{{ optional($workOrder->requested_at)->format('Y-m-d') }}</dd>
+                    <dt>Scheduled at</dt>
+                    <dd>{{ optional($workOrder->scheduled_at)->format('Y-m-d') }}</dd>
+                    <dt>Completed at</dt>
+                    <dd>{{ optional($workOrder->completed_at)->format('Y-m-d') }}</dd>
+                    <dt>Created by</dt>
+                    <dd>{{ $workOrder->creator?->name ?? 'N/A' }}</dd>
+                </dl>
+            </div>
+        </div>
+        <a href="{{ route('gmao.work-orders.edit', $workOrder->id) }}" class="btn btn-info">Edit</a>
+        <a href="{{ route('gmao.work-orders.index') }}" class="btn btn-secondary">Back</a>
+        <form method="POST" action="{{ route('gmao.work-orders.destroy', $workOrder->id) }}" class="d-inline">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    </x-adminlte-card>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -301,6 +301,16 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::delete('/{id}', 'App\\Http\\Controllers\\AssetController@destroy')->name('assets.destroy');
     });
 
+    Route::group(['prefix' => 'gmao', 'middleware' => ['auth', 'check.factory']], function () {
+        Route::get('/work-orders', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@index')->name('gmao.work-orders.index');
+        Route::get('/work-orders/create', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@create')->name('gmao.work-orders.create');
+        Route::post('/work-orders', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@store')->name('gmao.work-orders.store');
+        Route::get('/work-orders/{id}', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@show')->name('gmao.work-orders.show');
+        Route::get('/work-orders/{id}/edit', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@edit')->name('gmao.work-orders.edit');
+        Route::put('/work-orders/{id}', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@update')->name('gmao.work-orders.update');
+        Route::delete('/work-orders/{id}', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@destroy')->name('gmao.work-orders.destroy');
+    });
+
     Route::group(['prefix' => 'times', 'middleware' => ['auth', 'check.factory']], function () {
         // Index route
         Route::get('/', 'App\Http\Controllers\Times\TimesController@index')->name('times');


### PR DESCRIPTION
### Motivation
- Allow separate permission control for the GMAO "Assets" submenu so visibility can be granted to users with the new `asset-menu` permission distinct from the `asset_manager` role.

### Description
- Added `'can' => ['asset-menu']` to the Assets submenu entry in `config/adminlte.php` to gate the menu item by permission.
- Seeded the `asset-menu` permission in `database/seeders/PermissionTableSeeder.php` so the permission exists for assignment.

### Testing
- No automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970e56f1d80832d90fa338b4ac86220)