### PR TITLE
Fix asset pagination for links

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -15,7 +15,7 @@ class AssetController extends Controller
 
     public function index()
     {
-        $assets = Asset::all();
+        $assets = Asset::orderBy('id')->paginate(10);
         return view('assets.assets-index', compact('assets'));
     }
 


### PR DESCRIPTION
### Motivation
- The assets list view calls `->links()` but the controller returned an `Eloquent\Collection` from `Asset::all()`, causing a "Method Illuminate\Database\Eloquent\Collection::links does not exist." error.

### Description
- Replace `Asset::all()` with `Asset::orderBy('id')->paginate(10)` in `app/Http/Controllers/AssetController.php` so the view receives a paginator that supports `->links()`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f3d77280832d891855ce97035eeb)