### PR TITLE
Link assets to methods resources (FK, model, controller and views)

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -4,24 +4,29 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Assets\Asset;
+use App\Services\SelectDataService;
 use Illuminate\Support\Facades\Redirect;
 
 class AssetController extends Controller
 {
-    public function __construct()
+    protected SelectDataService $SelectDataService;
+
+    public function __construct(SelectDataService $SelectDataService)
     {
         $this->middleware(['auth', 'check.factory', 'permission:asset_manager']);
+        $this->SelectDataService = $SelectDataService;
     }
 
     public function index()
     {
-        $assets = Asset::orderBy('id')->paginate(10);
+        $assets = Asset::with('methodsRessource')->orderBy('id')->paginate(10);
         return view('assets.assets-index', compact('assets'));
     }
 
     public function create()
     {
-        return view('assets.assets-create');
+        $ressourcesSelect = $this->SelectDataService->getRessources();
+        return view('assets.assets-create', compact('ressourcesSelect'));
     }
 
     public function store(Request $request)
@@ -29,6 +34,7 @@ class AssetController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'category' => 'nullable|string',
+            'methods_ressource_id' => 'nullable|exists:methods_ressources,id',
             'acquisition_value' => 'required|numeric',
             'acquisition_date' => 'required|date',
             'depreciation_duration' => 'required|integer',
@@ -39,14 +45,15 @@ class AssetController extends Controller
 
     public function show($id)
     {
-        $asset = Asset::with(['accountingEntries', 'workOrders'])->findOrFail($id);
+        $asset = Asset::with(['accountingEntries', 'workOrders', 'methodsRessource'])->findOrFail($id);
         return view('assets.assets-show', compact('asset'));
     }
 
     public function edit($id)
     {
         $asset = Asset::findOrFail($id);
-        return view('assets.assets-edit', compact('asset'));
+        $ressourcesSelect = $this->SelectDataService->getRessources();
+        return view('assets.assets-edit', compact('asset', 'ressourcesSelect'));
     }
 
     public function update(Request $request, $id)
@@ -55,6 +62,7 @@ class AssetController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'category' => 'nullable|string',
+            'methods_ressource_id' => 'nullable|exists:methods_ressources,id',
             'acquisition_value' => 'required|numeric',
             'acquisition_date' => 'required|date',
             'depreciation_duration' => 'required|integer',

--- a/app/Models/Assets/Asset.php
+++ b/app/Models/Assets/Asset.php
@@ -4,14 +4,17 @@ namespace App\Models\Assets;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use App\Models\Accounting\AccountingEntry;
 use App\Models\Maintenance\WorkOrder;
+use App\Models\Methods\MethodsRessources;
 
 class Asset extends Model
 {
     protected $fillable = [
         'name',
         'category',
+        'methods_ressource_id',
         'acquisition_value',
         'acquisition_date',
         'depreciation_duration',
@@ -31,5 +34,10 @@ class Asset extends Model
     public function workOrders(): HasMany
     {
         return $this->hasMany(WorkOrder::class);
+    }
+
+    public function methodsRessource(): BelongsTo
+    {
+        return $this->belongsTo(MethodsRessources::class, 'methods_ressource_id');
     }
 }

--- a/database/migrations/2025_03_11_000004_add_methods_ressource_id_to_assets_table.php
+++ b/database/migrations/2025_03_11_000004_add_methods_ressource_id_to_assets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->foreignId('methods_ressource_id')
+                ->nullable()
+                ->after('category')
+                ->constrained('methods_ressources')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropForeign(['methods_ressource_id']);
+            $table->dropColumn('methods_ressource_id');
+        });
+    }
+};

--- a/resources/views/assets/assets-create.blade.php
+++ b/resources/views/assets/assets-create.blade.php
@@ -19,6 +19,17 @@
                 <input type="text" class="form-control" name="category" id="category" value="{{ old('category') }}">
             </div>
             <div class="form-group">
+                <label for="methods_ressource_id">{{ __('general_content.ressource_trans_key') }}</label>
+                <select class="form-control" name="methods_ressource_id" id="methods_ressource_id">
+                    <option value="">{{ __('general_content.select_ressource_trans_key') }}</option>
+                    @foreach($ressourcesSelect as $ressource)
+                        <option value="{{ $ressource->id }}" {{ old('methods_ressource_id') == $ressource->id ? 'selected' : '' }}>
+                            {{ $ressource->label }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
                 <label for="acquisition_value">Acquisition value</label>
                 <input type="number" step="0.01" class="form-control" name="acquisition_value" id="acquisition_value" value="{{ old('acquisition_value') }}">
             </div>

--- a/resources/views/assets/assets-edit.blade.php
+++ b/resources/views/assets/assets-edit.blade.php
@@ -19,6 +19,17 @@
                 <input type="text" class="form-control" name="category" id="category" value="{{ old('category', $asset->category) }}">
             </div>
             <div class="form-group">
+                <label for="methods_ressource_id">{{ __('general_content.ressource_trans_key') }}</label>
+                <select class="form-control" name="methods_ressource_id" id="methods_ressource_id">
+                    <option value="">{{ __('general_content.select_ressource_trans_key') }}</option>
+                    @foreach($ressourcesSelect as $ressource)
+                        <option value="{{ $ressource->id }}" {{ old('methods_ressource_id', $asset->methods_ressource_id) == $ressource->id ? 'selected' : '' }}>
+                            {{ $ressource->label }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
                 <label for="acquisition_value">Acquisition value</label>
                 <input type="number" step="0.01" class="form-control" name="acquisition_value" id="acquisition_value" value="{{ old('acquisition_value', $asset->acquisition_value) }}">
             </div>

--- a/resources/views/assets/assets-show.blade.php
+++ b/resources/views/assets/assets-show.blade.php
@@ -13,6 +13,8 @@
                 <dl>
                     <dt>Category</dt>
                     <dd>{{ $asset->category }}</dd>
+                    <dt>{{ __('general_content.ressource_trans_key') }}</dt>
+                    <dd>{{ $asset->methodsRessource?->label ?? __('general_content.no_data_trans_key') }}</dd>
                     <dt>Acquisition value</dt>
                     <dd>{{ $asset->acquisition_value }}</dd>
                     <dt>Acquisition date</dt>

--- a/resources/views/assets/partials/assets-list.blade.php
+++ b/resources/views/assets/partials/assets-list.blade.php
@@ -5,6 +5,7 @@
                 <tr>
                     <th>{{ __('general_content.name_trans_key') }}</th>
                     <th>Category</th>
+                    <th>{{ __('general_content.ressource_trans_key') }}</th>
                     <th>Acquisition value</th>
                     <th>Acquisition date</th>
                     <th>Depreciation duration (months)</th>
@@ -16,6 +17,7 @@
                     <tr>
                         <td><a href="{{ route('assets.show', $asset->id) }}">{{ $asset->name }}</a></td>
                         <td>{{ $asset->category }}</td>
+                        <td>{{ $asset->methodsRessource?->label ?? __('general_content.no_data_trans_key') }}</td>
                         <td>{{ $asset->acquisition_value }}</td>
                         <td>{{ $asset->acquisition_date->format('Y-m-d') }}</td>
                         <td>{{ $asset->depreciation_duration }}</td>
@@ -27,7 +29,7 @@
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="6">{{ __('general_content.no_data_trans_key') }}</td>
+                        <td colspan="7">{{ __('general_content.no_data_trans_key') }}</td>
                     </tr>
                 @endforelse
             </tbody>


### PR DESCRIPTION
### Motivation

- Allow linking an Asset to a Methods Resource so assets can be associated with existing method resources and used in UIs and relations.

### Description

- Add nullable `methods_ressource_id` foreign key migration and wire a `methodsRessource()` `BelongsTo` relationship on `Asset` (`database/migrations/2025_03_11_000004_add_methods_ressource_id_to_assets_table.php`, `app/Models/Assets/Asset.php`).
- Inject `SelectDataService` into `AssetController`, validate and persist `methods_ressource_id`, eager-load the relation in list/detail views, and pass resource options to create/edit views (`app/Http/Controllers/AssetController.php`).
- Update asset views to allow selecting a Methods Resource on create/edit and to display the linked resource in the list and detail pages (`resources/views/assets/assets-create.blade.php`, `resources/views/assets/assets-edit.blade.php`, `resources/views/assets/assets-show.blade.php`, `resources/views/assets/partials/assets-list.blade.php`).

### Testing

- No automated tests were executed against these changes.
- An attempt to start the app with `php artisan serve` failed due to missing vendor files (`vendor/autoload.php`), so runtime verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971333156b8832db8e5f576a4581e11)