### PR TITLE
Add maintenance plans and expand work orders for GMAO

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -39,7 +39,7 @@ class AssetController extends Controller
 
     public function show($id)
     {
-        $asset = Asset::with(['accountingEntries', 'workOrders'])->findOrFail($id);
+        $asset = Asset::with(['accountingEntries', 'workOrders', 'maintenancePlans'])->findOrFail($id);
         return view('assets.assets-show', compact('asset'));
     }
 

--- a/app/Http/Controllers/Maintenance/MaintenancePlanController.php
+++ b/app/Http/Controllers/Maintenance/MaintenancePlanController.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Http\Controllers\Maintenance;
+
+use App\Http\Controllers\Controller;
+use App\Models\Assets\Asset;
+use App\Models\Maintenance\MaintenancePlan;
+use App\Models\Maintenance\WorkOrder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class MaintenancePlanController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'check.factory', 'permission:asset_manager']);
+    }
+
+    public function index()
+    {
+        $plans = MaintenancePlan::with('asset')
+            ->orderByDesc('created_at')
+            ->paginate(15);
+
+        return view('gmao.maintenance-plans-index', [
+            'plans' => $plans,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        return view('gmao.maintenance-plans-create', [
+            'assets' => Asset::orderBy('name')->get(),
+            'triggerTypes' => $this->triggerTypeOptions(),
+            'selectedAssetId' => $request->get('asset_id'),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $plan = MaintenancePlan::create($this->validatedData($request));
+
+        return redirect()->route('gmao.maintenance-plans.show', $plan->id);
+    }
+
+    public function show($id)
+    {
+        $plan = MaintenancePlan::with('asset')->findOrFail($id);
+
+        return view('gmao.maintenance-plans-show', [
+            'plan' => $plan,
+        ]);
+    }
+
+    public function edit($id)
+    {
+        $plan = MaintenancePlan::findOrFail($id);
+
+        return view('gmao.maintenance-plans-edit', [
+            'plan' => $plan,
+            'assets' => Asset::orderBy('name')->get(),
+            'triggerTypes' => $this->triggerTypeOptions(),
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $plan = MaintenancePlan::findOrFail($id);
+        $plan->update($this->validatedData($request));
+
+        return redirect()->route('gmao.maintenance-plans.show', $plan->id);
+    }
+
+    public function destroy($id)
+    {
+        $plan = MaintenancePlan::findOrFail($id);
+        $plan->delete();
+
+        return redirect()->route('gmao.maintenance-plans.index');
+    }
+
+    public function generateWorkOrder($id)
+    {
+        $plan = MaintenancePlan::with('asset')->findOrFail($id);
+
+        $workOrder = WorkOrder::create([
+            'asset_id' => $plan->asset_id,
+            'title' => $plan->title,
+            'description' => $plan->description,
+            'actions_performed' => $plan->actions,
+            'parts_consumed' => $plan->required_parts,
+            'priority' => 'medium',
+            'work_type' => 'preventive',
+            'status' => 'planned',
+            'requested_at' => now()->toDateString(),
+            'scheduled_at' => $plan->fixed_date?->toDateString(),
+            'estimated_duration_minutes' => $plan->estimated_duration_minutes,
+            'created_by' => Auth::id(),
+        ]);
+
+        return redirect()->route('gmao.work-orders.show', $workOrder->id);
+    }
+
+    private function triggerTypeOptions(): array
+    {
+        return [
+            'time' => 'Time-based',
+            'machine_hours' => 'Machine hours',
+            'cycles' => 'Cycles / pieces',
+            'fixed_date' => 'Fixed date',
+        ];
+    }
+
+    private function validatedData(Request $request): array
+    {
+        return $request->validate([
+            'asset_id' => 'required|exists:assets,id',
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'trigger_type' => 'required|in:time,machine_hours,cycles,fixed_date',
+            'trigger_value' => 'nullable|string|max:255',
+            'fixed_date' => 'nullable|date',
+            'estimated_duration_minutes' => 'nullable|integer|min:0',
+            'required_skill' => 'nullable|string|max:255',
+            'actions' => 'nullable|string',
+            'required_parts' => 'nullable|string',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Maintenance/WorkOrderController.php
+++ b/app/Http/Controllers/Maintenance/WorkOrderController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Assets\Asset;
 use App\Models\Maintenance\WorkOrder;
 use App\Models\Times\TimesMachineEvent;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -18,7 +19,7 @@ class WorkOrderController extends Controller
 
     public function index()
     {
-        $workOrders = WorkOrder::with(['asset', 'machineEvent', 'creator'])
+        $workOrders = WorkOrder::with(['asset', 'machineEvent', 'creator', 'technician'])
             ->orderByDesc('requested_at')
             ->paginate(15);
 
@@ -34,6 +35,8 @@ class WorkOrderController extends Controller
             'machineEvents' => TimesMachineEvent::orderBy('ordre')->get(),
             'priorities' => $this->priorityOptions(),
             'statuses' => $this->statusOptions(),
+            'workTypes' => $this->workTypeOptions(),
+            'technicians' => User::orderBy('name')->get(),
             'selectedAssetId' => $request->get('asset_id'),
         ]);
     }
@@ -50,7 +53,7 @@ class WorkOrderController extends Controller
 
     public function show($id)
     {
-        $workOrder = WorkOrder::with(['asset', 'machineEvent', 'creator'])->findOrFail($id);
+        $workOrder = WorkOrder::with(['asset', 'machineEvent', 'creator', 'technician'])->findOrFail($id);
 
         return view('gmao.work-orders-show', [
             'workOrder' => $workOrder,
@@ -67,6 +70,8 @@ class WorkOrderController extends Controller
             'machineEvents' => TimesMachineEvent::orderBy('ordre')->get(),
             'priorities' => $this->priorityOptions(),
             'statuses' => $this->statusOptions(),
+            'workTypes' => $this->workTypeOptions(),
+            'technicians' => User::orderBy('name')->get(),
         ]);
     }
 
@@ -101,11 +106,21 @@ class WorkOrderController extends Controller
     private function statusOptions(): array
     {
         return [
-            'requested' => 'Requested',
-            'scheduled' => 'Scheduled',
+            'draft' => 'Draft',
+            'planned' => 'Planned',
             'in_progress' => 'In progress',
             'completed' => 'Completed',
-            'canceled' => 'Canceled',
+            'closed' => 'Closed',
+        ];
+    }
+
+    private function workTypeOptions(): array
+    {
+        return [
+            'preventive' => 'Preventive',
+            'corrective' => 'Corrective',
+            'improvement' => 'Improvement',
+            'safety' => 'Safety',
         ];
     }
 
@@ -116,11 +131,24 @@ class WorkOrderController extends Controller
             'times_machine_event_id' => 'nullable|exists:times_machine_events,id',
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'actions_performed' => 'nullable|string',
+            'parts_consumed' => 'nullable|string',
+            'comments' => 'nullable|string',
             'priority' => 'required|in:low,medium,high,critical',
-            'status' => 'required|in:requested,scheduled,in_progress,completed,canceled',
+            'work_type' => 'required|in:preventive,corrective,improvement,safety',
+            'status' => 'required|in:draft,planned,in_progress,completed,closed',
             'requested_at' => 'required|date',
             'scheduled_at' => 'nullable|date',
             'completed_at' => 'nullable|date',
+            'started_at' => 'nullable|date',
+            'finished_at' => 'nullable|date',
+            'estimated_duration_minutes' => 'nullable|integer|min:0',
+            'actual_duration_minutes' => 'nullable|integer|min:0',
+            'assigned_to' => 'nullable|exists:users,id',
+            'failure_type' => 'nullable|string|max:255',
+            'severity' => 'nullable|string|max:255',
+            'machine_stopped' => 'nullable|boolean',
+            'failure_started_at' => 'nullable|date',
         ]);
     }
 }

--- a/app/Models/Assets/Asset.php
+++ b/app/Models/Assets/Asset.php
@@ -5,6 +5,7 @@ namespace App\Models\Assets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\Accounting\AccountingEntry;
+use App\Models\Maintenance\MaintenancePlan;
 use App\Models\Maintenance\WorkOrder;
 
 class Asset extends Model
@@ -31,5 +32,10 @@ class Asset extends Model
     public function workOrders(): HasMany
     {
         return $this->hasMany(WorkOrder::class);
+    }
+
+    public function maintenancePlans(): HasMany
+    {
+        return $this->hasMany(MaintenancePlan::class);
     }
 }

--- a/app/Models/Maintenance/MaintenancePlan.php
+++ b/app/Models/Maintenance/MaintenancePlan.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models\Maintenance;
+
+use App\Models\Assets\Asset;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class MaintenancePlan extends Model
+{
+    protected $table = 'maintenance_plans';
+
+    protected $fillable = [
+        'asset_id',
+        'title',
+        'description',
+        'trigger_type',
+        'trigger_value',
+        'fixed_date',
+        'estimated_duration_minutes',
+        'required_skill',
+        'actions',
+        'required_parts',
+    ];
+
+    protected $casts = [
+        'fixed_date' => 'date',
+    ];
+
+    public function asset(): BelongsTo
+    {
+        return $this->belongsTo(Asset::class);
+    }
+}

--- a/app/Models/Maintenance/WorkOrder.php
+++ b/app/Models/Maintenance/WorkOrder.php
@@ -17,18 +17,35 @@ class WorkOrder extends Model
         'times_machine_event_id',
         'title',
         'description',
+        'actions_performed',
+        'parts_consumed',
+        'comments',
         'priority',
+        'work_type',
         'status',
         'requested_at',
         'scheduled_at',
+        'started_at',
+        'finished_at',
         'completed_at',
+        'estimated_duration_minutes',
+        'actual_duration_minutes',
+        'assigned_to',
+        'failure_type',
+        'severity',
+        'machine_stopped',
+        'failure_started_at',
         'created_by',
     ];
 
     protected $casts = [
         'requested_at' => 'date',
         'scheduled_at' => 'date',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
         'completed_at' => 'date',
+        'failure_started_at' => 'datetime',
+        'machine_stopped' => 'boolean',
     ];
 
     public function asset(): BelongsTo
@@ -44,5 +61,10 @@ class WorkOrder extends Model
     public function creator(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function technician(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_to');
     }
 }

--- a/database/migrations/2025_03_12_000002_update_maintenance_work_orders_table.php
+++ b/database/migrations/2025_03_12_000002_update_maintenance_work_orders_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('maintenance_work_orders', function (Blueprint $table) {
+            $table->string('work_type')->default('preventive')->after('priority');
+            $table->foreignId('assigned_to')->nullable()->after('work_type')->constrained('users')->nullOnDelete();
+            $table->dateTime('started_at')->nullable()->after('scheduled_at');
+            $table->dateTime('finished_at')->nullable()->after('started_at');
+            $table->unsignedInteger('estimated_duration_minutes')->nullable()->after('finished_at');
+            $table->unsignedInteger('actual_duration_minutes')->nullable()->after('estimated_duration_minutes');
+            $table->text('actions_performed')->nullable()->after('description');
+            $table->text('parts_consumed')->nullable()->after('actions_performed');
+            $table->text('comments')->nullable()->after('parts_consumed');
+            $table->string('failure_type')->nullable()->after('comments');
+            $table->string('severity')->nullable()->after('failure_type');
+            $table->boolean('machine_stopped')->default(false)->after('severity');
+            $table->dateTime('failure_started_at')->nullable()->after('machine_stopped');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('maintenance_work_orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('assigned_to');
+            $table->dropColumn([
+                'work_type',
+                'started_at',
+                'finished_at',
+                'estimated_duration_minutes',
+                'actual_duration_minutes',
+                'actions_performed',
+                'parts_consumed',
+                'comments',
+                'failure_type',
+                'severity',
+                'machine_stopped',
+                'failure_started_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_03_12_000003_create_maintenance_plans_table.php
+++ b/database/migrations/2025_03_12_000003_create_maintenance_plans_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('maintenance_plans', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_id')->constrained('assets')->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('trigger_type');
+            $table->string('trigger_value')->nullable();
+            $table->date('fixed_date')->nullable();
+            $table->unsignedInteger('estimated_duration_minutes')->nullable();
+            $table->string('required_skill')->nullable();
+            $table->text('actions')->nullable();
+            $table->text('required_parts')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_plans');
+    }
+};

--- a/resources/views/assets/assets-show.blade.php
+++ b/resources/views/assets/assets-show.blade.php
@@ -46,5 +46,17 @@
             @endforelse
         </ul>
         <a href="{{ route('gmao.work-orders.create', ['asset_id' => $asset->id]) }}" class="btn btn-primary">New work order</a>
+        <h2 class="mt-4">Maintenance plans</h2>
+        <ul>
+            @forelse($asset->maintenancePlans as $plan)
+                <li>
+                    <a href="{{ route('gmao.maintenance-plans.show', $plan->id) }}">{{ $plan->title }}</a>
+                    ({{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }})
+                </li>
+            @empty
+                <li>{{ __('general_content.no_data_trans_key') }}</li>
+            @endforelse
+        </ul>
+        <a href="{{ route('gmao.maintenance-plans.create', ['asset_id' => $asset->id]) }}" class="btn btn-secondary">New maintenance plan</a>
     </x-adminlte-card>
 @stop

--- a/resources/views/gmao/maintenance-plans-create.blade.php
+++ b/resources/views/gmao/maintenance-plans-create.blade.php
@@ -1,0 +1,68 @@
+@extends('adminlte::page')
+
+@section('title', 'New Maintenance Plan')
+
+@section('content_header')
+    <h1>New Maintenance Plan</h1>
+@stop
+
+@section('content')
+    <form method="POST" action="{{ route('gmao.maintenance-plans.store') }}">
+        @csrf
+        <x-adminlte-card title="Maintenance Plan" theme="secondary" maximizable>
+            <div class="form-group">
+                <label for="asset_id">Asset</label>
+                <select class="form-control" name="asset_id" id="asset_id">
+                    <option value="">Select an asset</option>
+                    @foreach($assets as $asset)
+                        <option value="{{ $asset->id }}" @selected(old('asset_id', $selectedAssetId) == $asset->id)>{{ $asset->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="title">Title</label>
+                <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}">
+            </div>
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea class="form-control" name="description" id="description" rows="3">{{ old('description') }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="trigger_type">Trigger type</label>
+                <select class="form-control" name="trigger_type" id="trigger_type">
+                    @foreach($triggerTypes as $value => $label)
+                        <option value="{{ $value }}" @selected(old('trigger_type', 'time') == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="trigger_value">Trigger value (weekly, monthly, 500 hours, 200 cycles...)</label>
+                <input type="text" class="form-control" name="trigger_value" id="trigger_value" value="{{ old('trigger_value') }}">
+            </div>
+            <div class="form-group">
+                <label for="fixed_date">Fixed date</label>
+                <input type="date" class="form-control" name="fixed_date" id="fixed_date" value="{{ old('fixed_date') }}">
+            </div>
+            <div class="form-group">
+                <label for="estimated_duration_minutes">Estimated duration (minutes)</label>
+                <input type="number" min="0" class="form-control" name="estimated_duration_minutes" id="estimated_duration_minutes" value="{{ old('estimated_duration_minutes') }}">
+            </div>
+            <div class="form-group">
+                <label for="required_skill">Required skill</label>
+                <input type="text" class="form-control" name="required_skill" id="required_skill" value="{{ old('required_skill') }}">
+            </div>
+            <div class="form-group">
+                <label for="actions">Actions list</label>
+                <textarea class="form-control" name="actions" id="actions" rows="3">{{ old('actions') }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="required_parts">Required parts</label>
+                <textarea class="form-control" name="required_parts" id="required_parts" rows="3">{{ old('required_parts') }}</textarea>
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="Save" theme="success" icon="fas fa-lg fa-save" />
+                <a href="{{ route('gmao.maintenance-plans.index') }}" class="btn btn-secondary float-right">Back</a>
+            </x-slot>
+        </x-adminlte-card>
+    </form>
+@stop

--- a/resources/views/gmao/maintenance-plans-edit.blade.php
+++ b/resources/views/gmao/maintenance-plans-edit.blade.php
@@ -1,0 +1,69 @@
+@extends('adminlte::page')
+
+@section('title', 'Edit Maintenance Plan')
+
+@section('content_header')
+    <h1>Edit Maintenance Plan</h1>
+@stop
+
+@section('content')
+    <form method="POST" action="{{ route('gmao.maintenance-plans.update', $plan->id) }}">
+        @csrf
+        @method('PUT')
+        <x-adminlte-card title="Maintenance Plan" theme="secondary" maximizable>
+            <div class="form-group">
+                <label for="asset_id">Asset</label>
+                <select class="form-control" name="asset_id" id="asset_id">
+                    <option value="">Select an asset</option>
+                    @foreach($assets as $asset)
+                        <option value="{{ $asset->id }}" @selected(old('asset_id', $plan->asset_id) == $asset->id)>{{ $asset->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="title">Title</label>
+                <input type="text" class="form-control" name="title" id="title" value="{{ old('title', $plan->title) }}">
+            </div>
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea class="form-control" name="description" id="description" rows="3">{{ old('description', $plan->description) }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="trigger_type">Trigger type</label>
+                <select class="form-control" name="trigger_type" id="trigger_type">
+                    @foreach($triggerTypes as $value => $label)
+                        <option value="{{ $value }}" @selected(old('trigger_type', $plan->trigger_type) == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="trigger_value">Trigger value (weekly, monthly, 500 hours, 200 cycles...)</label>
+                <input type="text" class="form-control" name="trigger_value" id="trigger_value" value="{{ old('trigger_value', $plan->trigger_value) }}">
+            </div>
+            <div class="form-group">
+                <label for="fixed_date">Fixed date</label>
+                <input type="date" class="form-control" name="fixed_date" id="fixed_date" value="{{ old('fixed_date', optional($plan->fixed_date)->format('Y-m-d')) }}">
+            </div>
+            <div class="form-group">
+                <label for="estimated_duration_minutes">Estimated duration (minutes)</label>
+                <input type="number" min="0" class="form-control" name="estimated_duration_minutes" id="estimated_duration_minutes" value="{{ old('estimated_duration_minutes', $plan->estimated_duration_minutes) }}">
+            </div>
+            <div class="form-group">
+                <label for="required_skill">Required skill</label>
+                <input type="text" class="form-control" name="required_skill" id="required_skill" value="{{ old('required_skill', $plan->required_skill) }}">
+            </div>
+            <div class="form-group">
+                <label for="actions">Actions list</label>
+                <textarea class="form-control" name="actions" id="actions" rows="3">{{ old('actions', $plan->actions) }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="required_parts">Required parts</label>
+                <textarea class="form-control" name="required_parts" id="required_parts" rows="3">{{ old('required_parts', $plan->required_parts) }}</textarea>
+            </div>
+            <x-slot name="footerSlot">
+                <x-adminlte-button class="btn-flat" type="submit" label="Save" theme="success" icon="fas fa-lg fa-save" />
+                <a href="{{ route('gmao.maintenance-plans.show', $plan->id) }}" class="btn btn-secondary float-right">Back</a>
+            </x-slot>
+        </x-adminlte-card>
+    </form>
+@stop

--- a/resources/views/gmao/maintenance-plans-index.blade.php
+++ b/resources/views/gmao/maintenance-plans-index.blade.php
@@ -1,0 +1,50 @@
+@extends('adminlte::page')
+
+@section('title', 'GMAO - Maintenance Plans')
+
+@section('content_header')
+    <h1>GMAO - Maintenance Plans</h1>
+@stop
+
+@section('content')
+    <x-adminlte-card title="Maintenance Plans" theme="primary" maximizable>
+        <div class="card-body table-responsive p-0">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Asset</th>
+                        <th>Title</th>
+                        <th>Trigger</th>
+                        <th>Fixed date</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($plans as $plan)
+                        <tr>
+                            <td>{{ $plan->id }}</td>
+                            <td>{{ $plan->asset?->name }}</td>
+                            <td><a href="{{ route('gmao.maintenance-plans.show', $plan->id) }}">{{ $plan->title }}</a></td>
+                            <td>{{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }} {{ $plan->trigger_value ? '(' . $plan->trigger_value . ')' : '' }}</td>
+                            <td>{{ optional($plan->fixed_date)->format('Y-m-d') }}</td>
+                            <td class="text-right">
+                                <a href="{{ route('gmao.maintenance-plans.edit', $plan->id) }}" class="btn btn-xs btn-default text-primary mx-1 shadow" title="Edit">
+                                    <i class="fa fa-lg fa-fw fa-pen"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6">{{ __('general_content.no_data_trans_key') }}</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            <a href="{{ route('gmao.maintenance-plans.create') }}" class="btn btn-primary">New Maintenance Plan</a>
+            {{ $plans->links() }}
+        </div>
+    </x-adminlte-card>
+@stop

--- a/resources/views/gmao/maintenance-plans-show.blade.php
+++ b/resources/views/gmao/maintenance-plans-show.blade.php
@@ -1,0 +1,53 @@
+@extends('adminlte::page')
+
+@section('title', 'Maintenance Plan #' . $plan->id)
+
+@section('content_header')
+    <h1>Maintenance Plan #{{ $plan->id }}</h1>
+@stop
+
+@section('content')
+    <x-adminlte-card title="Maintenance Plan Details" theme="primary" maximizable>
+        <div class="row">
+            <div class="col-md-6">
+                <dl>
+                    <dt>Asset</dt>
+                    <dd>{{ $plan->asset?->name }}</dd>
+                    <dt>Title</dt>
+                    <dd>{{ $plan->title }}</dd>
+                    <dt>Description</dt>
+                    <dd>{{ $plan->description ?? 'N/A' }}</dd>
+                    <dt>Trigger type</dt>
+                    <dd>{{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }}</dd>
+                    <dt>Trigger value</dt>
+                    <dd>{{ $plan->trigger_value ?? 'N/A' }}</dd>
+                    <dt>Fixed date</dt>
+                    <dd>{{ optional($plan->fixed_date)->format('Y-m-d') }}</dd>
+                </dl>
+            </div>
+            <div class="col-md-6">
+                <dl>
+                    <dt>Estimated duration</dt>
+                    <dd>{{ $plan->estimated_duration_minutes ? $plan->estimated_duration_minutes . ' min' : 'N/A' }}</dd>
+                    <dt>Required skill</dt>
+                    <dd>{{ $plan->required_skill ?? 'N/A' }}</dd>
+                    <dt>Actions list</dt>
+                    <dd>{{ $plan->actions ?? 'N/A' }}</dd>
+                    <dt>Required parts</dt>
+                    <dd>{{ $plan->required_parts ?? 'N/A' }}</dd>
+                </dl>
+            </div>
+        </div>
+        <form method="POST" action="{{ route('gmao.maintenance-plans.generate-work-order', $plan->id) }}" class="d-inline">
+            @csrf
+            <button type="submit" class="btn btn-success">Generate work order</button>
+        </form>
+        <a href="{{ route('gmao.maintenance-plans.edit', $plan->id) }}" class="btn btn-info">Edit</a>
+        <a href="{{ route('gmao.maintenance-plans.index') }}" class="btn btn-secondary">Back</a>
+        <form method="POST" action="{{ route('gmao.maintenance-plans.destroy', $plan->id) }}" class="d-inline">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    </x-adminlte-card>
+@stop

--- a/resources/views/gmao/work-orders-create.blade.php
+++ b/resources/views/gmao/work-orders-create.blade.php
@@ -45,10 +45,27 @@
                 </select>
             </div>
             <div class="form-group">
+                <label for="work_type">Type</label>
+                <select class="form-control" name="work_type" id="work_type">
+                    @foreach($workTypes as $value => $label)
+                        <option value="{{ $value }}" @selected(old('work_type', 'preventive') == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
                 <label for="status">Status</label>
                 <select class="form-control" name="status" id="status">
                     @foreach($statuses as $value => $label)
-                        <option value="{{ $value }}" @selected(old('status', 'requested') == $value)>{{ $label }}</option>
+                        <option value="{{ $value }}" @selected(old('status', 'draft') == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="assigned_to">Assigned technician</label>
+                <select class="form-control" name="assigned_to" id="assigned_to">
+                    <option value="">Not assigned</option>
+                    @foreach($technicians as $technician)
+                        <option value="{{ $technician->id }}" @selected(old('assigned_to') == $technician->id)>{{ $technician->name }}</option>
                     @endforeach
                 </select>
             </div>
@@ -61,8 +78,55 @@
                 <input type="date" class="form-control" name="scheduled_at" id="scheduled_at" value="{{ old('scheduled_at') }}">
             </div>
             <div class="form-group">
+                <label for="started_at">Started at</label>
+                <input type="datetime-local" class="form-control" name="started_at" id="started_at" value="{{ old('started_at') }}">
+            </div>
+            <div class="form-group">
+                <label for="finished_at">Finished at</label>
+                <input type="datetime-local" class="form-control" name="finished_at" id="finished_at" value="{{ old('finished_at') }}">
+            </div>
+            <div class="form-group">
                 <label for="completed_at">Completed at</label>
                 <input type="date" class="form-control" name="completed_at" id="completed_at" value="{{ old('completed_at') }}">
+            </div>
+            <div class="form-group">
+                <label for="estimated_duration_minutes">Estimated duration (minutes)</label>
+                <input type="number" min="0" class="form-control" name="estimated_duration_minutes" id="estimated_duration_minutes" value="{{ old('estimated_duration_minutes') }}">
+            </div>
+            <div class="form-group">
+                <label for="actual_duration_minutes">Actual duration (minutes)</label>
+                <input type="number" min="0" class="form-control" name="actual_duration_minutes" id="actual_duration_minutes" value="{{ old('actual_duration_minutes') }}">
+            </div>
+            <div class="form-group">
+                <label for="actions_performed">Actions performed</label>
+                <textarea class="form-control" name="actions_performed" id="actions_performed" rows="4">{{ old('actions_performed') }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="parts_consumed">Parts consumed</label>
+                <textarea class="form-control" name="parts_consumed" id="parts_consumed" rows="3">{{ old('parts_consumed') }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="comments">Comments / photos</label>
+                <textarea class="form-control" name="comments" id="comments" rows="3">{{ old('comments') }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="failure_type">Failure type</label>
+                <input type="text" class="form-control" name="failure_type" id="failure_type" value="{{ old('failure_type') }}">
+            </div>
+            <div class="form-group">
+                <label for="severity">Severity</label>
+                <input type="text" class="form-control" name="severity" id="severity" value="{{ old('severity') }}">
+            </div>
+            <div class="form-group">
+                <label for="machine_stopped">Machine stopped</label>
+                <select class="form-control" name="machine_stopped" id="machine_stopped">
+                    <option value="0" @selected(old('machine_stopped', '0') === '0')>No</option>
+                    <option value="1" @selected(old('machine_stopped') === '1')>Yes</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="failure_started_at">Failure started at</label>
+                <input type="datetime-local" class="form-control" name="failure_started_at" id="failure_started_at" value="{{ old('failure_started_at') }}">
             </div>
             <x-slot name="footerSlot">
                 <x-adminlte-button class="btn-flat" type="submit" label="Save" theme="success" icon="fas fa-lg fa-save" />

--- a/resources/views/gmao/work-orders-edit.blade.php
+++ b/resources/views/gmao/work-orders-edit.blade.php
@@ -46,10 +46,27 @@
                 </select>
             </div>
             <div class="form-group">
+                <label for="work_type">Type</label>
+                <select class="form-control" name="work_type" id="work_type">
+                    @foreach($workTypes as $value => $label)
+                        <option value="{{ $value }}" @selected(old('work_type', $workOrder->work_type) == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
                 <label for="status">Status</label>
                 <select class="form-control" name="status" id="status">
                     @foreach($statuses as $value => $label)
                         <option value="{{ $value }}" @selected(old('status', $workOrder->status) == $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="assigned_to">Assigned technician</label>
+                <select class="form-control" name="assigned_to" id="assigned_to">
+                    <option value="">Not assigned</option>
+                    @foreach($technicians as $technician)
+                        <option value="{{ $technician->id }}" @selected(old('assigned_to', $workOrder->assigned_to) == $technician->id)>{{ $technician->name }}</option>
                     @endforeach
                 </select>
             </div>
@@ -62,8 +79,55 @@
                 <input type="date" class="form-control" name="scheduled_at" id="scheduled_at" value="{{ old('scheduled_at', optional($workOrder->scheduled_at)->format('Y-m-d')) }}">
             </div>
             <div class="form-group">
+                <label for="started_at">Started at</label>
+                <input type="datetime-local" class="form-control" name="started_at" id="started_at" value="{{ old('started_at', optional($workOrder->started_at)->format('Y-m-d\\TH:i')) }}">
+            </div>
+            <div class="form-group">
+                <label for="finished_at">Finished at</label>
+                <input type="datetime-local" class="form-control" name="finished_at" id="finished_at" value="{{ old('finished_at', optional($workOrder->finished_at)->format('Y-m-d\\TH:i')) }}">
+            </div>
+            <div class="form-group">
                 <label for="completed_at">Completed at</label>
                 <input type="date" class="form-control" name="completed_at" id="completed_at" value="{{ old('completed_at', optional($workOrder->completed_at)->format('Y-m-d')) }}">
+            </div>
+            <div class="form-group">
+                <label for="estimated_duration_minutes">Estimated duration (minutes)</label>
+                <input type="number" min="0" class="form-control" name="estimated_duration_minutes" id="estimated_duration_minutes" value="{{ old('estimated_duration_minutes', $workOrder->estimated_duration_minutes) }}">
+            </div>
+            <div class="form-group">
+                <label for="actual_duration_minutes">Actual duration (minutes)</label>
+                <input type="number" min="0" class="form-control" name="actual_duration_minutes" id="actual_duration_minutes" value="{{ old('actual_duration_minutes', $workOrder->actual_duration_minutes) }}">
+            </div>
+            <div class="form-group">
+                <label for="actions_performed">Actions performed</label>
+                <textarea class="form-control" name="actions_performed" id="actions_performed" rows="4">{{ old('actions_performed', $workOrder->actions_performed) }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="parts_consumed">Parts consumed</label>
+                <textarea class="form-control" name="parts_consumed" id="parts_consumed" rows="3">{{ old('parts_consumed', $workOrder->parts_consumed) }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="comments">Comments / photos</label>
+                <textarea class="form-control" name="comments" id="comments" rows="3">{{ old('comments', $workOrder->comments) }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="failure_type">Failure type</label>
+                <input type="text" class="form-control" name="failure_type" id="failure_type" value="{{ old('failure_type', $workOrder->failure_type) }}">
+            </div>
+            <div class="form-group">
+                <label for="severity">Severity</label>
+                <input type="text" class="form-control" name="severity" id="severity" value="{{ old('severity', $workOrder->severity) }}">
+            </div>
+            <div class="form-group">
+                <label for="machine_stopped">Machine stopped</label>
+                <select class="form-control" name="machine_stopped" id="machine_stopped">
+                    <option value="0" @selected(old('machine_stopped', $workOrder->machine_stopped ? '1' : '0') === '0')>No</option>
+                    <option value="1" @selected(old('machine_stopped', $workOrder->machine_stopped ? '1' : '0') === '1')>Yes</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="failure_started_at">Failure started at</label>
+                <input type="datetime-local" class="form-control" name="failure_started_at" id="failure_started_at" value="{{ old('failure_started_at', optional($workOrder->failure_started_at)->format('Y-m-d\\TH:i')) }}">
             </div>
             <x-slot name="footerSlot">
                 <x-adminlte-button class="btn-flat" type="submit" label="Save" theme="success" icon="fas fa-lg fa-save" />

--- a/resources/views/gmao/work-orders-index.blade.php
+++ b/resources/views/gmao/work-orders-index.blade.php
@@ -15,8 +15,10 @@
                         <th>#</th>
                         <th>Asset</th>
                         <th>Title</th>
+                        <th>Type</th>
                         <th>Priority</th>
                         <th>Status</th>
+                        <th>Technician</th>
                         <th>Requested at</th>
                         <th></th>
                     </tr>
@@ -27,8 +29,10 @@
                             <td>{{ $workOrder->id }}</td>
                             <td>{{ $workOrder->asset?->name }}</td>
                             <td><a href="{{ route('gmao.work-orders.show', $workOrder->id) }}">{{ $workOrder->title }}</a></td>
+                            <td>{{ ucfirst(str_replace('_', ' ', $workOrder->work_type)) }}</td>
                             <td>{{ ucfirst(str_replace('_', ' ', $workOrder->priority)) }}</td>
                             <td>{{ ucfirst(str_replace('_', ' ', $workOrder->status)) }}</td>
+                            <td>{{ $workOrder->technician?->name ?? 'N/A' }}</td>
                             <td>{{ optional($workOrder->requested_at)->format('Y-m-d') }}</td>
                             <td class="text-right">
                                 <a href="{{ route('gmao.work-orders.edit', $workOrder->id) }}" class="btn btn-xs btn-default text-primary mx-1 shadow" title="Edit">
@@ -38,7 +42,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="7">{{ __('general_content.no_data_trans_key') }}</td>
+                            <td colspan="9">{{ __('general_content.no_data_trans_key') }}</td>
                         </tr>
                     @endforelse
                 </tbody>

--- a/resources/views/gmao/work-orders-show.blade.php
+++ b/resources/views/gmao/work-orders-show.blade.php
@@ -21,8 +21,12 @@
                     <dd>{{ $workOrder->machineEvent?->label ?? 'Not specified' }}</dd>
                     <dt>Priority</dt>
                     <dd>{{ ucfirst(str_replace('_', ' ', $workOrder->priority)) }}</dd>
+                    <dt>Type</dt>
+                    <dd>{{ ucfirst(str_replace('_', ' ', $workOrder->work_type)) }}</dd>
                     <dt>Status</dt>
                     <dd>{{ ucfirst(str_replace('_', ' ', $workOrder->status)) }}</dd>
+                    <dt>Assigned technician</dt>
+                    <dd>{{ $workOrder->technician?->name ?? 'N/A' }}</dd>
                 </dl>
             </div>
             <div class="col-md-6">
@@ -31,10 +35,42 @@
                     <dd>{{ optional($workOrder->requested_at)->format('Y-m-d') }}</dd>
                     <dt>Scheduled at</dt>
                     <dd>{{ optional($workOrder->scheduled_at)->format('Y-m-d') }}</dd>
+                    <dt>Started at</dt>
+                    <dd>{{ optional($workOrder->started_at)->format('Y-m-d H:i') }}</dd>
+                    <dt>Finished at</dt>
+                    <dd>{{ optional($workOrder->finished_at)->format('Y-m-d H:i') }}</dd>
                     <dt>Completed at</dt>
                     <dd>{{ optional($workOrder->completed_at)->format('Y-m-d') }}</dd>
+                    <dt>Estimated duration</dt>
+                    <dd>{{ $workOrder->estimated_duration_minutes ? $workOrder->estimated_duration_minutes . ' min' : 'N/A' }}</dd>
+                    <dt>Actual duration</dt>
+                    <dd>{{ $workOrder->actual_duration_minutes ? $workOrder->actual_duration_minutes . ' min' : 'N/A' }}</dd>
                     <dt>Created by</dt>
                     <dd>{{ $workOrder->creator?->name ?? 'N/A' }}</dd>
+                </dl>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6">
+                <dl>
+                    <dt>Actions performed</dt>
+                    <dd>{{ $workOrder->actions_performed ?? 'N/A' }}</dd>
+                    <dt>Parts consumed</dt>
+                    <dd>{{ $workOrder->parts_consumed ?? 'N/A' }}</dd>
+                    <dt>Comments / photos</dt>
+                    <dd>{{ $workOrder->comments ?? 'N/A' }}</dd>
+                </dl>
+            </div>
+            <div class="col-md-6">
+                <dl>
+                    <dt>Failure type</dt>
+                    <dd>{{ $workOrder->failure_type ?? 'N/A' }}</dd>
+                    <dt>Severity</dt>
+                    <dd>{{ $workOrder->severity ?? 'N/A' }}</dd>
+                    <dt>Machine stopped</dt>
+                    <dd>{{ $workOrder->machine_stopped ? 'Yes' : 'No' }}</dd>
+                    <dt>Failure started at</dt>
+                    <dd>{{ optional($workOrder->failure_started_at)->format('Y-m-d H:i') }}</dd>
                 </dl>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -309,6 +309,14 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/work-orders/{id}/edit', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@edit')->name('gmao.work-orders.edit');
         Route::put('/work-orders/{id}', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@update')->name('gmao.work-orders.update');
         Route::delete('/work-orders/{id}', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@destroy')->name('gmao.work-orders.destroy');
+        Route::get('/maintenance-plans', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@index')->name('gmao.maintenance-plans.index');
+        Route::get('/maintenance-plans/create', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@create')->name('gmao.maintenance-plans.create');
+        Route::post('/maintenance-plans', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@store')->name('gmao.maintenance-plans.store');
+        Route::get('/maintenance-plans/{id}', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@show')->name('gmao.maintenance-plans.show');
+        Route::get('/maintenance-plans/{id}/edit', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@edit')->name('gmao.maintenance-plans.edit');
+        Route::put('/maintenance-plans/{id}', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@update')->name('gmao.maintenance-plans.update');
+        Route::delete('/maintenance-plans/{id}', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@destroy')->name('gmao.maintenance-plans.destroy');
+        Route::post('/maintenance-plans/{id}/generate-work-order', 'App\\Http\\Controllers\\Maintenance\\MaintenancePlanController@generateWorkOrder')->name('gmao.maintenance-plans.generate-work-order');
     });
 
     Route::group(['prefix' => 'times', 'middleware' => ['auth', 'check.factory']], function () {


### PR DESCRIPTION
### Motivation
- Introduce preventive maintenance planning and link it to the existing maintenance work order flow to support triggers (time, machine hours, cycles, fixed date) and automate OM generation.
- Extend the work order data model and UI to capture lifecycle, work type, technician assignment, timestamps, actual/estimated durations, actions, parts and failure details for better tracking and TRS impact reporting.

### Description
- Add `MaintenancePlan` model, migration (`2025_03_12_000003_create_maintenance_plans_table.php`), controller `MaintenancePlanController`, CRUD views and routes (`gmao.maintenance-plans.*`) and a `generateWorkOrder` action to create OMs from plans.
- Extend `maintenance_work_orders` via migration (`2025_03_12_000002_update_maintenance_work_orders_table.php`) with columns for `work_type`, `assigned_to`, `started_at`, `finished_at`, `estimated_duration_minutes`, `actual_duration_minutes`, `actions_performed`, `parts_consumed`, `comments`, `failure_type`, `severity`, `machine_stopped`, and `failure_started_at` and update `WorkOrder` model accordingly.
- Update `WorkOrderController` to support new lifecycle statuses, work types, validation and include technicians list; update create/edit/index/show views to surface new fields and assignment.
- Surface maintenance plans in the asset detail page by adding a `maintenancePlans` relation to `Asset`, updating the asset controller to eager-load plans and adding links to create/view plans from asset pages.

### Testing
- No automated tests were executed as part of this change.
- Database schema changes require running `php artisan migrate` in the target environment before use and should be validated on a staging instance.
- Manual verification recommended: create/edit/delete maintenance plans, generate a work order from a plan, and exercise the extended work order create/edit/show flows to confirm fields persist and display correctly.
- No unit/feature test failures were observed because test suite was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971334848ac832d91882c8f30fa826e)