### PR TITLE
Add GMAO maintenance dashboard

### DIFF
--- a/app/Http/Controllers/Maintenance/DashboardController.php
+++ b/app/Http/Controllers/Maintenance/DashboardController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Maintenance;
+
+use App\Http\Controllers\Controller;
+
+class DashboardController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'check.factory', 'permission:asset_manager']);
+    }
+
+    public function __invoke()
+    {
+        $kpis = [
+            [
+                'name' => 'MTBF',
+                'description' => 'Temps moyen entre pannes',
+                'value' => '—',
+            ],
+            [
+                'name' => 'MTTR',
+                'description' => 'Temps moyen de réparation',
+                'value' => '—',
+            ],
+            [
+                'name' => 'Disponibilité',
+                'description' => '% temps machine dispo',
+                'value' => '—',
+            ],
+            [
+                'name' => 'Coût maintenance',
+                'description' => '€/machine / période',
+                'value' => '—',
+            ],
+            [
+                'name' => '% préventif vs curatif',
+                'description' => 'Qualité maintenance',
+                'value' => '—',
+            ],
+        ];
+
+        return view('gmao.dashboard', [
+            'kpis' => $kpis,
+        ]);
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -622,6 +622,11 @@ return [
             'can'  => ['asset_manager'],
             'submenu' => [
                 [
+                    'text' => 'Dashboard',
+                    'url'  => 'gmao/dashboard',
+                    'icon_color' => 'info',
+                ],
+                [
                     'text' => 'assets_trans_key',
                     'url'  => 'assets',
                     'icon_color' => 'info',

--- a/resources/views/gmao/dashboard.blade.php
+++ b/resources/views/gmao/dashboard.blade.php
@@ -1,0 +1,45 @@
+@extends('adminlte::page')
+
+@section('title', 'GMAO - Dashboard')
+
+@section('content_header')
+    <h1>GMAO - Dashboard</h1>
+@stop
+
+@section('content')
+    <div class="row">
+        @foreach($kpis as $kpi)
+            <div class="col-12 col-sm-6 col-lg-4">
+                <x-adminlte-info-box
+                    :title="$kpi['name']"
+                    :text="$kpi['description']"
+                    :number="$kpi['value']"
+                    icon="fas fa-chart-line"
+                    theme="info"
+                    icon-theme="white"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    <x-adminlte-card title="3. 📊 KPI & Indicateurs maintenance" theme="primary" maximizable>
+        <div class="card-body table-responsive p-0">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>KPI</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($kpis as $kpi)
+                        <tr>
+                            <td>{{ $kpi['name'] }}</td>
+                            <td>{{ $kpi['description'] }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </x-adminlte-card>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -302,6 +302,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     });
 
     Route::group(['prefix' => 'gmao', 'middleware' => ['auth', 'check.factory']], function () {
+        Route::get('/dashboard', 'App\\Http\\Controllers\\Maintenance\\DashboardController')->name('gmao.dashboard');
         Route::get('/work-orders', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@index')->name('gmao.work-orders.index');
         Route::get('/work-orders/create', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@create')->name('gmao.work-orders.create');
         Route::post('/work-orders', 'App\\Http\\Controllers\\Maintenance\\WorkOrderController@store')->name('gmao.work-orders.store');


### PR DESCRIPTION
### Motivation
- Provide a simple GMAO dashboard exposing key maintenance KPIs (MTBF, MTTR, Disponibilité, Coût maintenance, % préventif vs curatif) as placeholders so the maintenance menu has a dedicated dashboard page.

### Description
- Add `App\Http\Controllers\Maintenance\DashboardController` which prepares KPI placeholders and returns the `gmao.dashboard` view.
- Create `resources/views/gmao/dashboard.blade.php` to render KPI info boxes and a KPI/description table using AdminLTE components.
- Expose the dashboard route `GET /gmao/dashboard` in `routes/web.php` pointing to the new controller.
- Add a "Dashboard" entry to the GMAO submenu in `config/adminlte.php` so the page is accessible from the UI.

### Testing
- Attempted to run the app with `php artisan serve`, but it failed due to missing dependencies (`vendor/autoload.php`), so no runtime tests were completed.
- No automated unit or feature tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697138a2a50c832d8c016d6d29a6a37d)