### PR TITLE
Add maintenancePlans relation to Asset model

### DIFF
--- a/app/Models/Assets/Asset.php
+++ b/app/Models/Assets/Asset.php
@@ -37,6 +37,11 @@ class Asset extends Model
         return $this->hasMany(WorkOrder::class);
     }
 
+    public function maintenancePlans(): HasMany
+    {
+        return $this->hasMany(MaintenancePlan::class);
+    }
+
     public function methodsRessource(): BelongsTo
     {
         return $this->belongsTo(MethodsRessources::class, 'methods_ressource_id');


### PR DESCRIPTION
### Motivation

- The controller was eager-loading `maintenancePlans` on `Asset` but the relationship was missing, causing a runtime error.

### Description

- Added a `maintenancePlans()` `HasMany` relationship to `App\Models\Assets\Asset` that returns `hasMany(MaintenancePlan::class)`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697139382a64832d80546275e3f10600)