### PR TITLE
Fix Blade translation keys and add missing general_content translations

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -340,6 +340,7 @@ return [
     'capability_index_trans_key'               => 'Capability index',
     'not_available_trans_key'                  => 'N/A',
 
+    'factory_trans_key'                        => 'مصنع',
     'factory_settings_trans_key'               => 'إعدادات المصنع',
     'announcements_trans_key'                  => 'الإعلانات',
     'workflow_settings_trans_key'              => 'إعدادات سير العمل',
@@ -369,6 +370,8 @@ return [
 
     // BUTTON
     'view_trans_key'                    => 'عرض',
+    'show_trans_key'                    => 'إظهار',
+    'search_trans_key'                  => 'بحث',
     'view_count_trans_key'              => 'عدد المشاهدات',
     'print_trans_key'                   => 'طباعة',
     'pdf_trans_key'                     => 'PDF',
@@ -511,6 +514,7 @@ return [
     'internal_comment_trans_key'    => 'التعليق الداخلي',
     'external_comment_trans_key'    => 'التعليق الخارجي',
     'identifier_trans_key'          => 'المعرف',
+    'payment_method_trans_key'      => 'طريقة الدفع',
     'payment_methods_trans_key'     => 'طرق الدفع',
     'payment_conditions_trans_key'  => 'شروط الدفع',
     'delevery_method_trans_key'     => 'طريقة التسليم',
@@ -737,6 +741,7 @@ return [
     'task_detail_trans_key'                    => 'تفاصيل المهمة',
     'logs_activity_trans_key'                  => 'سجل النشاط',
     'no_activity_trans_key'                    => 'لا توجد أنشطة.',
+    'unknown_activity_trans_key'               => 'نشاط غير معروف',
     'set_to_start_trans_key'                   => 'تعيين البدء للمهمة',
     'set_to_end_trans_key'                     => 'تعيين الانتهاء للمهمة',
     'set_to_finish_trans_key'                  => 'تعيين الانتهاء للمهمة',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -390,6 +390,7 @@ return [
     'capability_index_trans_key'               => 'Capability index',
     'not_available_trans_key'                  => 'N/A',
 
+    'factory_trans_key'                        => 'Factory',
     'factory_settings_trans_key'               => 'Factory settings',
     'announcements_trans_key'                  => 'Announcements',
     'workflow_settings_trans_key'              => 'Workflow settings',
@@ -426,6 +427,8 @@ return [
 
     // BUTTON
     'view_trans_key'                           => 'View',
+    'show_trans_key'                           => 'Show',
+    'search_trans_key'                         => 'Search',
     'view_count_trans_key'                     => 'View(s) count',
     'print_trans_key'                          => 'Print',
     'pdf_trans_key'                            => 'PDF',
@@ -573,6 +576,7 @@ return [
     'internal_comment_trans_key'               => 'Internal comment',
     'external_comment_trans_key'               => 'External comment',
     'identifier_trans_key'                     => 'Identifier',
+    'payment_method_trans_key'                 => 'Payment method',
     'payment_methods_trans_key'                => 'Payment Methods',
     'payment_conditions_trans_key'             => 'Payment Conditions',
     'delevery_method_trans_key'                => 'Delivery method',
@@ -881,6 +885,7 @@ return [
     'task_detail_trans_key'                    => 'Task  Detail',
     'logs_activity_trans_key'                  => 'Logs Activity',
     'no_activity_trans_key'                    => 'No activities.',
+    'unknown_activity_trans_key'               => 'Unknown activity',
     'set_to_start_trans_key'                   => 'Task set to start time',
     'set_to_end_trans_key'                     => 'Task set to end time',
     'set_to_finish_trans_key'                  => 'Task set to finish Task',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -337,6 +337,7 @@ return [
     'capability_index_trans_key'               => 'Índice de capacidad',
     'not_available_trans_key'                  => 'N/D',
 
+    'factory_trans_key'                        => 'Fábrica',
     'factory_settings_trans_key'               => 'Configuraciones de fábrica',
     'announcements_trans_key'                  => 'Anuncios',
     'workflow_settings_trans_key'              => 'Configuraciones de flujo de trabajo',
@@ -366,6 +367,8 @@ return [
 
     // BOTÓN
     'view_trans_key'                           => 'Ver',
+    'show_trans_key'                           => 'Mostrar',
+    'search_trans_key'                         => 'Buscar',
     'view_count_trans_key'                     => 'Número de vistas',
     'print_trans_key'                          => 'Imprimir',
     'pdf_trans_key'                            => 'PDF',
@@ -511,6 +514,7 @@ return [
         'internal_comment_trans_key'               => 'Comentario interno',
         'external_comment_trans_key'               => 'Comentario externo',
     'identifier_trans_key'                     => 'Identificador',
+    'payment_method_trans_key'                 => 'Método de pago',
     'payment_methods_trans_key'                => 'Métodos de pago',
     'payment_conditions_trans_key'             => 'Condiciones de pago',
     'delevery_method_trans_key'                => 'Método de entrega',
@@ -736,6 +740,7 @@ return [
     'task_detail_trans_key'                    => 'Detalle de la tarea',
     'logs_activity_trans_key'                  => 'Registro de actividades',
     'no_activity_trans_key'                    => 'Sin actividades.',
+    'unknown_activity_trans_key'               => 'Actividad desconocida',
     'set_to_start_trans_key'                   => 'Establecer inicio de tarea',
     'set_to_end_trans_key'                     => 'Establecer fin de tarea',
     'set_to_finish_trans_key'                  => 'Marcar tarea como finalizada',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -390,6 +390,7 @@ return [
     'capability_index_trans_key'               => 'Indice de capabilité',
     'not_available_trans_key'                  => 'N/D',
 
+    'factory_trans_key'                        => 'Usine',
     'factory_settings_trans_key'               => 'Réglage usine',
     'announcements_trans_key'                  => 'Annonces',
     'workflow_settings_trans_key'              => 'Workflow réglage',
@@ -426,6 +427,8 @@ return [
 
     // BUTTON    
     'view_trans_key'                           => 'Voir',
+    'show_trans_key'                           => 'Afficher',
+    'search_trans_key'                         => 'Rechercher',
     'view_count_trans_key'                     => 'Nombre de vue(s)',
     'print_trans_key'                          => 'Imprimer',
     'pdf_trans_key'                            => 'PDF',
@@ -573,6 +576,7 @@ return [
     'internal_comment_trans_key'               => 'Commentaire interne',
     'external_comment_trans_key'               => 'Commentaire externe',
     'identifier_trans_key'                     => 'Référence',
+    'payment_method_trans_key'                 => 'Mode de paiement',
     'payment_methods_trans_key'                => 'Méthode de paiement',
     'payment_conditions_trans_key'             => 'Condition de paiement',
     'delevery_method_trans_key'                => 'Mode de livraison',
@@ -881,6 +885,7 @@ return [
     'task_detail_trans_key'                    => 'Détail de la tâche',
     'logs_activity_trans_key'                  => 'Journal d\'activité',
     'no_activity_trans_key'                    => 'Aucune activité.',
+    'unknown_activity_trans_key'               => 'Activité inconnue',
     'set_to_start_trans_key'                   => 'Tâche démarée',
     'set_to_end_trans_key'                     => 'Tâche arrêtée',
     'set_to_finish_trans_key'                  => 'Tâche finie',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -24,6 +24,9 @@ return [
 
     // BUTTON
     'view_all_trans_key'                       => 'Xem toàn bộ',
+    'view_trans_key'                           => 'Xem',
+    'show_trans_key'                           => 'Hiển thị',
+    'search_trans_key'                         => 'Tìm kiếm',
 
     //DASHBOARD
     'dashboard_trans_key'                      => 'Bảng điều khiển',
@@ -145,6 +148,7 @@ return [
 
     'users_trans_key'                          => 'Người dùng',
     'your_company_trans_key'                   => 'Công ty',
+    'factory_trans_key'                        => 'Nhà máy',
     'header_font_color_trans_key'              => 'Màu chữ tiêu đề',
     'pdf_theme_trans_key'                      => 'Giao diện PDF',
     'pdf_theme_fallback_trans_key'             => 'Mặc định',
@@ -174,6 +178,8 @@ return [
     'no_documents_found_trans_key'             => 'Không có tài liệu phù hợp với bộ lọc',
     'hashtags_trans_key'                       => 'Hashtags',
     'customer_processing_cost_trans_key'       => 'Chi phí xử lý khách hàng',
+    'payment_method_trans_key'                 => 'Phương thức thanh toán',
+    'unknown_activity_trans_key'               => 'Hoạt động không xác định',
     'average_supply_delay_trans_key'           => 'Thời gian cung ứng trung bình',
     'order_site_trans_key'                     => 'Công trường',
     'characteristics_trans_key'                => 'Đặc điểm',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -380,6 +380,7 @@ return [
     'capability_index_trans_key'               => '能力指数',
     'not_available_trans_key'                  => 'N/A',
 
+    'factory_trans_key'                        => '工厂',
     'factory_settings_trans_key'               => '工厂设置',
     'announcements_trans_key'                  => '公告',
     'workflow_settings_trans_key'              => '流程设置',
@@ -416,6 +417,8 @@ return [
 
     // BUTTON    
     'view_trans_key'                           => '查看',
+    'show_trans_key'                           => '显示',
+    'search_trans_key'                         => '搜索',
     'view_count_trans_key'                     => '查看次数',
     'print_trans_key'                          => '打印',
     'pdf_trans_key'                            => 'PDF',
@@ -563,6 +566,7 @@ return [
     'internal_comment_trans_key'               => '内部备注',
     'external_comment_trans_key'               => '外部备注',
     'identifier_trans_key'                     => '参考号',
+    'payment_method_trans_key'                 => '付款方式',
     'payment_methods_trans_key'                => '支付方式',
     'payment_conditions_trans_key'             => '付款条件',
     'delevery_method_trans_key'                => '配送方式',
@@ -855,6 +859,7 @@ return [
     'task_detail_trans_key'                    => '任务详情',
     'logs_activity_trans_key'                  => '活动日志',
     'no_activity_trans_key'                    => '无活动。',
+    'unknown_activity_trans_key'               => '未知活动',
     'set_to_start_trans_key'                   => '任务已开始',
     'set_to_end_trans_key'                     => '任务已停止',
     'set_to_finish_trans_key'                  => '任务已完成',

--- a/resources/views/admin/factory-index.blade.php
+++ b/resources/views/admin/factory-index.blade.php
@@ -751,7 +751,7 @@
                                                             @csrf
                                                             <div class="card-body">
                                                                 <div class="form-group">
-                                                                    <label for="template">{{ __('general_content.template') }} :</label>
+                                                                    <label for="template">{{ __('general_content.template_trans_key') }} :</label>
                                                                     <div class="input-group">
                                                                         <div class="input-group-prepend">
                                                                             <span class="input-group-text"><i class="fas fa-code"></i></span>

--- a/resources/views/workshop/workshop-andon-orders.blade.php
+++ b/resources/views/workshop/workshop-andon-orders.blade.php
@@ -22,7 +22,7 @@
                             <small><i class="fas fa-clock"></i> {{ $order->order->delay_info }}</small>
                         </div>
                     @empty
-                        <p>{{ __('general_content.no_late_orders_trans_key_trans_key') }}</p>
+                        <p>{{ __('general_content.no_late_orders_trans_key') }}</p>
                     @endforelse
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Blade templates referenced translation keys that were incorrect or missing, causing inconsistent labels in the UI and potential missing-translation errors.
- Add the missing `general_content` keys across supported locales so views can rely on a consistent set of translation keys.

### Description
- Fixed blade references: replaced `no_late_orders_trans_key_trans_key` with `no_late_orders_trans_key` in `resources/views/workshop/workshop-andon-orders.blade.php` and changed the template label in `resources/views/admin/factory-index.blade.php` to use `template_trans_key`.
- Added new translation entries to `general_content.php` in multiple locales: English, French, Spanish, Arabic, Vietnamese and Simplified Chinese; keys added/normalized include `factory_trans_key`, `payment_method_trans_key`, `show_trans_key`, `search_trans_key`, and `unknown_activity_trans_key` (and corresponding locale translations).
- Total files updated: 2 Blade view files and 6 locale files under `resources/lang/{en,fr,es,ar,vi,zh-CN}/general_content.php`.

### Testing
- Performed repository-wide searches with `rg` to locate usages and confirm affected blades were updated; initial scan found missing keys.
- Ran a Python validation script that compares used translation keys in blades with keys in `resources/lang/en/general_content.php`; it reported 7 missing keys before the changes and `0` missing keys after the updates. 
- No unit or integration test suites (e.g. `phpunit`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971395f7e78832db6cb6c67c1b4ca2f)