### PR TITLE
Add edit action for purchase quotation lines

### DIFF
--- a/resources/views/livewire/purchases-quotation-lines.blade.php
+++ b/resources/views/livewire/purchases-quotation-lines.blade.php
@@ -108,7 +108,7 @@
                             <th>{{ __('general_content.qty_trans_key') }}</th>
                             <th>{{ __('general_content.price_trans_key') }}</th>
                             <th>{{__('general_content.total_price_trans_key') }}</th>
-                            <th></th>
+                            <th>{{ __('general_content.action_trans_key') }}</th>
                             <th>{{__('general_content.qty_accepted_trans_key') }}</th>
                             <th>{{ __('general_content.qty_canceled_trans_key') }}</th>
                         </tr>
@@ -159,6 +159,11 @@
                             <td>{{ $PurchaseQuotationLine->formatted_unit_price }}</td>
                             <td>{{ $PurchaseQuotationLine->formatted_total_price }}</td>
                             <td>
+                                @if($PurchaseQuotation->statu == 1)
+                                <button type="button" class="btn btn-outline-secondary btn-sm mb-2" wire:click.prevent="editPurchaseQuotationLine({{ $PurchaseQuotationLine->id }})">
+                                    <i class="fas fa-edit"></i> {{ __('general_content.edit_trans_key') }}
+                                </button>
+                                @endif
                                 @if($PurchaseQuotationLine->qty_to_order > $PurchaseQuotationLine->qty_accepted)
                                 <div class="form-group">
                                     <div class="custom-control custom-checkbox">


### PR DESCRIPTION
### Motivation
- Allow editing of RFQ/quotation line details from the quotation view by exposing the existing Livewire edit action so line pricing can be updated before creating purchase orders.

### Description
- Update `resources/views/livewire/purchases-quotation-lines.blade.php` to add an `{{ __('general_content.action_trans_key') }}` column header and an "Edit" button that calls the Livewire method `editPurchaseQuotationLine` for lines when the quotation `statu == 1`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729d1d5b6c832d8d7a412692e1b902)