### PR TITLE
Refine maintenance plan details layout

### DIFF
--- a/resources/views/gmao/maintenance-plans-show.blade.php
+++ b/resources/views/gmao/maintenance-plans-show.blade.php
@@ -2,52 +2,160 @@
 
 @section('title', 'Maintenance Plan #' . $plan->id)
 
-@section('content_header')
-    <h1>Maintenance Plan #{{ $plan->id }}</h1>
-@stop
-
 @section('content')
-    <x-adminlte-card title="Maintenance Plan Details" theme="primary" maximizable>
-        <div class="row">
-            <div class="col-md-6">
-                <dl>
-                    <dt>Asset</dt>
-                    <dd>{{ $plan->asset?->name }}</dd>
-                    <dt>Title</dt>
-                    <dd>{{ $plan->title }}</dd>
-                    <dt>Description</dt>
-                    <dd>{{ $plan->description ?? 'N/A' }}</dd>
-                    <dt>Trigger type</dt>
-                    <dd>{{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }}</dd>
-                    <dt>Trigger value</dt>
-                    <dd>{{ $plan->trigger_value ?? 'N/A' }}</dd>
-                    <dt>Fixed date</dt>
-                    <dd>{{ optional($plan->fixed_date)->format('Y-m-d') }}</dd>
-                </dl>
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-center justify-content-between mb-3">
+                        <div class="d-flex align-items-center">
+                            <i class="fas fa-cog text-muted mr-2"></i>
+                            <h5 class="mb-0 font-weight-bold">General Information</h5>
+                        </div>
+                        <span class="badge badge-success px-3 py-2">Active</span>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Asset</div>
+                            <div class="font-weight-bold">{{ $plan->asset?->name ?? 'N/A' }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Frequency</div>
+                            <div class="font-weight-bold">{{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Title</div>
+                            <div class="font-weight-bold">{{ $plan->title }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Estimated Duration</div>
+                            <div class="font-weight-bold">{{ $plan->estimated_duration_minutes ? $plan->estimated_duration_minutes . ' min' : 'N/A' }}</div>
+                        </div>
+                        <div class="col-12">
+                            <div class="text-uppercase text-muted small">Description</div>
+                            <div>{{ $plan->description ?? 'N/A' }}</div>
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-6">
-                <dl>
-                    <dt>Estimated duration</dt>
-                    <dd>{{ $plan->estimated_duration_minutes ? $plan->estimated_duration_minutes . ' min' : 'N/A' }}</dd>
-                    <dt>Required skill</dt>
-                    <dd>{{ $plan->required_skill ?? 'N/A' }}</dd>
-                    <dt>Actions list</dt>
-                    <dd>{{ $plan->actions ?? 'N/A' }}</dd>
-                    <dt>Required parts</dt>
-                    <dd>{{ $plan->required_parts ?? 'N/A' }}</dd>
-                </dl>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-center mb-3">
+                        <i class="fas fa-bolt text-muted mr-2"></i>
+                        <h5 class="mb-0 font-weight-bold">Trigger Configuration</h5>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Trigger Type</div>
+                            <div class="font-weight-bold">{{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Trigger Value</div>
+                            <div class="font-weight-bold">{{ $plan->trigger_value ?? 'N/A' }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-center mb-3">
+                        <i class="far fa-calendar-alt text-muted mr-2"></i>
+                        <h5 class="mb-0 font-weight-bold">Schedule Information</h5>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Fixed Date</div>
+                            <div class="font-weight-bold">{{ optional($plan->fixed_date)->format('Y-m-d') ?? 'N/A' }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Next Scheduled Date</div>
+                            <div class="font-weight-bold">{{ optional($plan->fixed_date)->format('Y-m-d') ?? 'N/A' }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Created At</div>
+                            <div class="font-weight-bold">{{ $plan->created_at?->format('Y-m-d') ?? 'N/A' }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Last Modified</div>
+                            <div class="font-weight-bold">{{ $plan->updated_at?->format('Y-m-d') ?? 'N/A' }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-center mb-3">
+                        <i class="fas fa-tools text-muted mr-2"></i>
+                        <h5 class="mb-0 font-weight-bold">Execution Resources</h5>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Required Skill</div>
+                            <div class="font-weight-bold">{{ $plan->required_skill ?? 'Not specified' }}</div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="text-uppercase text-muted small">Required Parts</div>
+                            <div class="font-weight-bold">{{ $plan->required_parts ?? 'Not specified' }}</div>
+                        </div>
+                        <div class="col-12 mb-0">
+                            <div class="text-uppercase text-muted small">Actions List</div>
+                            <div class="font-weight-bold">{{ $plan->actions ?? 'No actions defined' }}</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
-        <form method="POST" action="{{ route('gmao.maintenance-plans.generate-work-order', $plan->id) }}" class="d-inline">
-            @csrf
-            <button type="submit" class="btn btn-success">Generate work order</button>
-        </form>
-        <a href="{{ route('gmao.maintenance-plans.edit', $plan->id) }}" class="btn btn-info">Edit</a>
-        <a href="{{ route('gmao.maintenance-plans.index') }}" class="btn btn-secondary">Back</a>
-        <form method="POST" action="{{ route('gmao.maintenance-plans.destroy', $plan->id) }}" class="d-inline">
-            @csrf
-            @method('DELETE')
-            <button type="submit" class="btn btn-danger">Delete</button>
-        </form>
-    </x-adminlte-card>
+
+        <div class="col-lg-4">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <div class="text-uppercase text-muted small mb-3">Actions</div>
+                    <form method="POST" action="{{ route('gmao.maintenance-plans.generate-work-order', $plan->id) }}" class="mb-2">
+                        @csrf
+                        <button type="submit" class="btn btn-success btn-block">
+                            <i class="fas fa-bolt mr-1"></i> Generate Work Order
+                        </button>
+                    </form>
+                    <a href="{{ route('gmao.maintenance-plans.edit', $plan->id) }}" class="btn btn-info btn-block mb-2">
+                        <i class="fas fa-edit mr-1"></i> Edit Plan
+                    </a>
+                    <a href="{{ route('gmao.maintenance-plans.index') }}" class="btn btn-outline-secondary btn-block mb-2">
+                        <i class="fas fa-arrow-left mr-1"></i> Back to List
+                    </a>
+                    <form method="POST" action="{{ route('gmao.maintenance-plans.destroy', $plan->id) }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger btn-block">
+                            <i class="fas fa-trash-alt mr-1"></i> Delete
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <div class="text-uppercase text-muted small mb-3">Plan Summary</div>
+                    <div class="mb-3">
+                        <div class="text-muted small">Status</div>
+                        <div class="font-weight-bold text-success">Active</div>
+                    </div>
+                    <div class="mb-3">
+                        <div class="text-muted small">Frequency</div>
+                        <div class="font-weight-bold">{{ ucfirst(str_replace('_', ' ', $plan->trigger_type)) }}</div>
+                    </div>
+                    <div class="mb-3">
+                        <div class="text-muted small">Duration</div>
+                        <div class="font-weight-bold">{{ $plan->estimated_duration_minutes ? $plan->estimated_duration_minutes . ' min' : 'N/A' }}</div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Next Scheduled</div>
+                        <div class="font-weight-bold">{{ optional($plan->fixed_date)->format('Y-m-d') ?? 'N/A' }}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 @stop


### PR DESCRIPTION
### Motivation
- Restyle the maintenance plan show page to match the provided card-based reference and improve usability and readability.
- Surface key actions in a dedicated sidebar and group related fields into clear sections for faster comprehension.

### Description
- Replaced the original single `x-adminlte-card` details layout in `resources/views/gmao/maintenance-plans-show.blade.php` with multiple card panels and a right-side actions/summary column.
- Grouped fields into `General Information`, `Trigger Configuration`, `Schedule Information`, and `Execution Resources` cards and added a `Plan Summary` card with a status badge and icons.
- Kept existing actions (`Generate Work Order`, `Edit`, `Back`, `Delete`) and preserved field rendering and date formatting using null-safe helpers like `optional($plan->fixed_date)->format('Y-m-d')`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a76112ec832d8b3bf898718d5628)