### PR TITLE
Add Methods overview page and move menu entry to Scheduling

### DIFF
--- a/app/Http/Controllers/Methods/MethodsController.php
+++ b/app/Http/Controllers/Methods/MethodsController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Methods;
 
 use App\Services\SelectDataService;
+use App\Models\Methods\MethodsSection;
+use App\Models\Methods\MethodsServices;
 
 class MethodsController extends Controller
 {
@@ -19,5 +21,40 @@ class MethodsController extends Controller
     public function index()
     {
         return view('methods/methods-index');
+    }
+
+    public function overview()
+    {
+        $statusTitles = ['Started', 'In progress'];
+
+        $sections = MethodsSection::query()
+            ->with(['Ressources' => function ($query) use ($statusTitles) {
+                $query->with([
+                    'service',
+                    'locations',
+                    'tasks' => function ($taskQuery) use ($statusTitles) {
+                        $taskQuery->whereHas('status', function ($statusQuery) use ($statusTitles) {
+                            $statusQuery->whereIn('title', $statusTitles);
+                        })
+                        ->with(['status', 'Products'])
+                        ->orderBy('due_date');
+                    },
+                ])
+                ->orderBy('ordre');
+            }])
+            ->orderBy('ordre')
+            ->get();
+
+        $services = MethodsServices::query()
+            ->withCount('Ressources')
+            ->withCount(['Tasks as tasks_in_progress_count' => function ($query) use ($statusTitles) {
+                $query->whereHas('status', function ($statusQuery) use ($statusTitles) {
+                    $statusQuery->whereIn('title', $statusTitles);
+                });
+            }])
+            ->orderBy('ordre')
+            ->get();
+
+        return view('methods/methods-overview', compact('sections', 'services'));
     }
 }

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -397,6 +397,11 @@ return [
                     'icon_color' => 'info',
                 ],
                 [
+                    'text' => 'methods_overview_trans_key',
+                    'url'  => 'methods/overview',
+                    'icon_color' => 'success',
+                ],
+                [
                     'text' => 'tasks_calendar_trans_key',
                     'url'  => 'production/calendar/tasks',
                     'icon_color' => 'primary',

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -1110,4 +1110,5 @@ return [
     'gmao_duration_trans_key'                      => 'Duration',
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
+    'methods_overview_trans_key'               => 'نظرة عامة على الطرق',
 ];

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1328,4 +1328,5 @@ return [
     'gmao_duration_trans_key'                      => 'Duration',
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -1111,4 +1111,5 @@ return [
     'gmao_duration_trans_key'                      => 'Duration',
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
+    'methods_overview_trans_key'               => 'Resumen de métodos',
 ];

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1328,4 +1328,5 @@ return [
     'gmao_duration_trans_key'                      => 'Durée',
     'gmao_next_scheduled_trans_key'                => 'Prochaine planification',
     'gmao_maintenance_work_orders_trans_key'       => 'Ordres de travail de maintenance',
+    'methods_overview_trans_key'               => 'Vue d'ensemble méthodes',
 ];

--- a/resources/lang/vendor/adminlte/de/menu.php
+++ b/resources/lang/vendor/adminlte/de/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Warnung',
     'information'                   => 'Information',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -90,4 +90,5 @@ return [
     'logs_view_trans_key'                      => 'Logs view',
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Release notes',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/es/menu.php
+++ b/resources/lang/vendor/adminlte/es/menu.php
@@ -18,4 +18,5 @@ return [
     'information'                   => 'Información',
     'whiteboard_trans_key'          => 'Pizarra',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Resumen de métodos',
 ];

--- a/resources/lang/vendor/adminlte/fr/menu.php
+++ b/resources/lang/vendor/adminlte/fr/menu.php
@@ -90,4 +90,5 @@ return [
     'logs_view_trans_key'                      => 'Logs view',
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Release notes',
+    'methods_overview_trans_key'               => 'Vue d'ensemble méthodes',
 ];

--- a/resources/lang/vendor/adminlte/id/menu.php
+++ b/resources/lang/vendor/adminlte/id/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Peringatan',
     'information'                   => 'Informasi',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/it/menu.php
+++ b/resources/lang/vendor/adminlte/it/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Avvertimento',
     'information'                   => 'Informazione',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/ja/menu.php
+++ b/resources/lang/vendor/adminlte/ja/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => '警告',
     'information'                   => 'インフォメーション',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/la/menu.php
+++ b/resources/lang/vendor/adminlte/la/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'ຄຳເຕືອນ',
     'information'                   => 'ຂໍ້ມູນ',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/pl/menu.php
+++ b/resources/lang/vendor/adminlte/pl/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Ostrzeżenie',
     'information'                   => 'Informacja',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/pt-br/menu.php
+++ b/resources/lang/vendor/adminlte/pt-br/menu.php
@@ -17,4 +17,5 @@ return [
     'Warning'                       => 'Aviso',
     'Information'                   => 'Informação',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/ru/menu.php
+++ b/resources/lang/vendor/adminlte/ru/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Внимание',
     'information'                   => 'Информация',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/sr/menu.php
+++ b/resources/lang/vendor/adminlte/sr/menu.php
@@ -19,4 +19,5 @@ return [
     'menu'                          => 'MENI',
     'users'                         => 'Korisnici',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/tr/menu.php
+++ b/resources/lang/vendor/adminlte/tr/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Uyarı',
     'information'                   => 'Bilgi',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/uk/menu.php
+++ b/resources/lang/vendor/adminlte/uk/menu.php
@@ -17,4 +17,5 @@ return [
     'warning'                       => 'Увага',
     'information'                   => 'Інформація',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Methods overview',
 ];

--- a/resources/lang/vendor/adminlte/vi/menu.php
+++ b/resources/lang/vendor/adminlte/vi/menu.php
@@ -56,4 +56,5 @@ return [
     'licence_trans_key'                        => 'Bản quyền',
     'release_note_trans_key'                   => 'Ghi chú phát hành',
     'inspection_trans_key'                 => 'Inspection',
+    'methods_overview_trans_key'               => 'Tổng quan phương pháp',
 ];

--- a/resources/lang/vendor/adminlte/zh-CN/menu.php
+++ b/resources/lang/vendor/adminlte/zh-CN/menu.php
@@ -90,4 +90,5 @@ return [
     'logs_view_trans_key'                      => '日志查看',
     'licence_trans_key'                        => '许可证',
     'release_note_trans_key'                   => '版本说明',
+    'methods_overview_trans_key'               => '方法总览',
 ];

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -283,4 +283,5 @@ return [
     'gmao_duration_trans_key'                      => 'Duration',
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
+    'methods_overview_trans_key'               => 'Tổng quan phương pháp',
 ];

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -1290,4 +1290,5 @@ return [
     'gmao_duration_trans_key'                      => 'Duration',
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
+    'methods_overview_trans_key'               => '方法总览',
 ];

--- a/resources/views/methods/methods-overview.blade.php
+++ b/resources/views/methods/methods-overview.blade.php
@@ -1,0 +1,123 @@
+@extends('adminlte::page')
+
+@section('title', __('general_content.methods_overview_trans_key'))
+
+@section('content_header')
+    <h1>{{ __('general_content.methods_overview_trans_key') }}</h1>
+@stop
+
+@section('right-sidebar')
+
+@section('content')
+    @include('include.alert-result')
+
+    <div class="row">
+        <div class="col-12">
+            <x-adminlte-card title="{{ __('general_content.service_trans_key') }}" theme="info" maximizable>
+                <div class="row">
+                    @forelse ($services as $service)
+                        <div class="col-md-4 mb-3">
+                            <div class="border rounded p-3 h-100">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <div class="font-weight-bold">{{ $service->label }}</div>
+                                        <small class="text-muted">{{ $service->code }}</small>
+                                    </div>
+                                    <span class="badge text-white" style="background-color: {{ $service->color }};">&nbsp;</span>
+                                </div>
+                                <div class="mt-2">
+                                    <div><strong>{{ __('general_content.ressource_trans_key') }}</strong> : {{ $service->ressources_count }}</div>
+                                    <div><strong>{{ __('general_content.in_progress_trans_key') }}</strong> : {{ $service->tasks_in_progress_count }}</div>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="col-12">
+                            <x-EmptyDataLine col="12" text="{{ __('general_content.no_data_trans_key') }}" />
+                        </div>
+                    @endforelse
+                </div>
+            </x-adminlte-card>
+        </div>
+    </div>
+
+    <div class="row">
+        @forelse ($sections as $section)
+            <div class="col-12">
+                <x-adminlte-card title="{{ $section->label }}" theme="primary" maximizable>
+                    <div class="row">
+                        @forelse ($section->Ressources as $resource)
+                            <div class="col-lg-6">
+                                <div class="border rounded p-3 mb-3 h-100">
+                                    <div class="d-flex justify-content-between align-items-start">
+                                        <div>
+                                            <h5 class="mb-1">{{ $resource->label }}</h5>
+                                            <small class="text-muted">
+                                                {{ __('general_content.service_trans_key') }} :
+                                                {{ $resource->service?->label ?? __('general_content.no_data_trans_key') }}
+                                            </small>
+                                        </div>
+                                        <span class="badge badge-light">
+                                            {{ __('general_content.location_trans_key') }} : {{ $resource->locations->count() }}
+                                        </span>
+                                    </div>
+
+                                    <div class="mt-3">
+                                        <strong>{{ __('general_content.location_in_workshop_trans_key') }}</strong>
+                                        <div class="d-flex flex-wrap mt-2">
+                                            @forelse ($resource->locations as $location)
+                                                <span class="badge badge-pill text-white mr-2 mb-2" style="background-color: {{ $location->color }};">
+                                                    {{ $location->label }}
+                                                </span>
+                                            @empty
+                                                <span class="text-muted">{{ __('general_content.no_data_trans_key') }}</span>
+                                            @endforelse
+                                        </div>
+                                    </div>
+
+                                    <div class="mt-3">
+                                        <strong>{{ __('general_content.tasks_trans_key') }} - {{ __('general_content.in_progress_trans_key') }}</strong>
+                                        <div class="mt-2">
+                                            @forelse ($resource->tasks as $task)
+                                                <div class="border rounded p-2 mb-2">
+                                                    <div class="d-flex justify-content-between">
+                                                        <div>
+                                                            <div class="font-weight-bold">{{ $task->code }} - {{ $task->label }}</div>
+                                                            @if ($task->Products)
+                                                                <small class="text-muted">{{ $task->Products->label }}</small>
+                                                            @endif
+                                                        </div>
+                                                        <span class="badge badge-info">{{ $task->status->title ?? __('general_content.in_progress_trans_key') }}</span>
+                                                    </div>
+                                                    <div class="mt-2">
+                                                        <x-adminlte-progress theme="info" value="{{ $task->progress() }}" with-label animated/>
+                                                    </div>
+                                                </div>
+                                            @empty
+                                                <p class="text-muted mb-0">{{ __('general_content.no_task_trans_key') }}</p>
+                                            @endforelse
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @empty
+                            <div class="col-12">
+                                <x-EmptyDataLine col="12" text="{{ __('general_content.no_data_trans_key') }}" />
+                            </div>
+                        @endforelse
+                    </div>
+                </x-adminlte-card>
+            </div>
+        @empty
+            <div class="col-12">
+                <x-EmptyDataLine col="12" text="{{ __('general_content.no_section_trans_key') }}" />
+            </div>
+        @endforelse
+    </div>
+@stop
+
+@section('css')
+@stop
+
+@section('js')
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -641,6 +641,8 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
             Route::post('/create', 'App\Http\Controllers\Methods\SectionsController@store')->name('methods.section.create');
             Route::post('/edit/{id}', 'App\Http\Controllers\Methods\SectionsController@update')->name('methods.section.update');
         });
+
+        Route::get('/overview', 'App\Http\Controllers\Methods\MethodsController@overview')->name('methods.overview');
     
         // Routes for Ressources
         Route::group(['prefix' => 'ressources'], function () {


### PR DESCRIPTION
### Motivation
- Provide a consolidated visual overview of services, sections, resources, locations and in-progress tasks so operators can get a quick snapshot of workshop activity. 
- Place the overview link in the planning/tasks area so it is discoverable alongside related scheduling features.

### Description
- Added an `overview` action to `App\Http\Controllers\Methods\MethodsController` that eager-loads `MethodsSection` → `Ressources` → `service`, `locations` and `tasks` (filtered for statuses `Started` and `In progress`) and aggregates counts for services and tasks. 
- Created the Blade view `resources/views/methods/methods-overview.blade.php` to render service cards, section/resource snapshots, location badges and per-task progress bars. 
- Registered the route `methods/overview` in `routes/web.php` and added/updated translation keys `methods_overview_trans_key` in `resources/lang/*` and the vendor AdminLTE menu translations. 
- Moved the `methods_overview_trans_key` menu entry from the Methods submenu into the Scheduling (`scheduling_trans_key`) submenu in `config/adminlte.php` to align navigation with planning/tasks.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697348f34234832db3121b776fceadaf)