### PR TITLE
Fix MethodsSection resources relationship

### DIFF
--- a/app/Models/Methods/MethodsSection.php
+++ b/app/Models/Methods/MethodsSection.php
@@ -24,7 +24,7 @@ class MethodsSection extends Model
 
     public function Ressources()
     {
-        return $this->hasMany(MethodsRessources::class);
+        return $this->hasMany(MethodsRessources::class, 'section_id');
     }
 
     public function Risque()


### PR DESCRIPTION
### Motivation
- Fix the relationship so queries do not reference the non-existent `methods_section_id` column which produced `SQLSTATE[42S22]` errors.

### Description
- Update `Ressources()` in `app/Models/Methods/MethodsSection.php` to use the `section_id` foreign key by returning `hasMany(MethodsRessources::class, 'section_id')`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697355a67b64832d837d4c4ffd16d566)