### PR TITLE
Specify foreign key for MethodsRessources::locations relation

### DIFF
--- a/app/Models/Methods/MethodsRessources.php
+++ b/app/Models/Methods/MethodsRessources.php
@@ -35,7 +35,7 @@ class MethodsRessources extends Model
 
     public function locations()
     {
-        return $this->hasMany(MethodsLocation::class);
+        return $this->hasMany(MethodsLocation::class, 'ressource_id');
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Prevent queries from looking for the non-existent `methods_locations.methods_ressources_id` column by making the relationship use the actual `ressource_id` foreign key.

### Description
- Update `MethodsRessources::locations()` to return `hasMany(MethodsLocation::class, 'ressource_id')` so Eloquent uses `ressource_id` as the foreign key.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973576cc744832dae2e6632ef54201f)