### PR TITLE
Translate labels and localize disabled-customer warning on quote show

### DIFF
--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -1111,4 +1111,8 @@ return [
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
     'methods_overview_trans_key'               => 'نظرة عامة على الطرق',
+    'logs_trans_key'                            => 'السجلات',
+    'beta_trans_key'                            => 'بيتا',
+    'info_trans_key'                            => 'معلومات',
+    'customer_disabled_warning_trans_key'       => 'العميل :customer معطل حاليًا. لا يمكنك تغيير اسم العميل أو جهة الاتصال أو العنوان.',
 ];

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1345,4 +1345,8 @@ return [
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
     'methods_overview_trans_key'               => 'Methods overview',
+    'logs_trans_key'                            => 'Logs',
+    'beta_trans_key'                            => 'Beta',
+    'info_trans_key'                            => 'Info',
+    'customer_disabled_warning_trans_key'       => 'The customer :customer is currently disabled. You cannot change the customer name, contact, or address.',
 ];

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -1112,4 +1112,8 @@ return [
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
     'methods_overview_trans_key'               => 'Resumen de métodos',
+    'logs_trans_key'                            => 'Registros',
+    'beta_trans_key'                            => 'Beta',
+    'info_trans_key'                            => 'Info',
+    'customer_disabled_warning_trans_key'       => 'El cliente :customer está deshabilitado actualmente. No puede cambiar el nombre, el contacto ni la dirección del cliente.',
 ];

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1345,4 +1345,8 @@ return [
     'gmao_next_scheduled_trans_key'                => 'Prochaine planification',
     'gmao_maintenance_work_orders_trans_key'       => 'Ordres de travail de maintenance',
     'methods_overview_trans_key'               => 'Vue d'ensemble méthodes',
+    'logs_trans_key'                            => 'Journaux',
+    'beta_trans_key'                            => 'Bêta',
+    'info_trans_key'                            => 'Info',
+    'customer_disabled_warning_trans_key'       => 'Le client :customer est actuellement désactivé. Vous ne pouvez pas modifier le nom, le contact ou l\'adresse.',
 ];

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -284,4 +284,8 @@ return [
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
     'methods_overview_trans_key'               => 'Tổng quan phương pháp',
+    'logs_trans_key'                            => 'Nhật ký',
+    'beta_trans_key'                            => 'Beta',
+    'info_trans_key'                            => 'Thông tin',
+    'customer_disabled_warning_trans_key'       => 'Khách hàng :customer hiện đang bị vô hiệu hóa. Bạn không thể thay đổi tên, liên hệ hoặc địa chỉ khách hàng.',
 ];

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -1291,4 +1291,8 @@ return [
     'gmao_next_scheduled_trans_key'                => 'Next Scheduled',
     'gmao_maintenance_work_orders_trans_key'       => 'Maintenance work orders',
     'methods_overview_trans_key'               => '方法总览',
+    'logs_trans_key'                            => '日志',
+    'beta_trans_key'                            => '测试版',
+    'info_trans_key'                            => '信息',
+    'customer_disabled_warning_trans_key'       => '客户:customer 当前已被停用。您无法更改客户名称、联系人或地址。',
 ];

--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -19,14 +19,14 @@
     <ul class="nav nav-pills"  id="DocumentTabs">
       <li class="nav-item"><a class="nav-link " href="#Quote" data-toggle="tab">{{ __('general_content.quote_info_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Lines" data-toggle="tab">{{ __('general_content.quote_line_trans_key') }} ({{ count($Quote->QuoteLines) }})</a></li>
-      <li class="nav-item"><a class="nav-link" href="#Construction" data-toggle="tab">{{ __('general_content.construction_site_trans_key') }} <span class="badge badge-danger right">Beta</span></a></li>
+      <li class="nav-item"><a class="nav-link" href="#Construction" data-toggle="tab">{{ __('general_content.construction_site_trans_key') }} <span class="badge badge-danger right">{{ __('general_content.beta_trans_key') }}</span></a></li>
       <li class="nav-item"><a class="nav-link" href="#Charts" data-toggle="tab">{{ __('general_content.charts_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Views" data-toggle="tab">{{ __('general_content.guest_page_trans_key') }} ( {{  $Quote->visitsCount() }} )</a></li>
       @if(count($CustomFields)> 0)
       <li class="nav-item"><a class="nav-link" href="#CustomFields" data-toggle="tab">{{ __('general_content.custom_fields_trans_key') }} ({{ count($CustomFields) }})</a></li>
       @endif
       <li class="nav-item"><a class="nav-link" href="#LinesImport" data-toggle="tab">{{ __('general_content.lines_import_trans_key') }}</a></li>
-      <li class="nav-item"><a class="nav-link" href="#Logs" data-toggle="tab">Logs</a></li>
+      <li class="nav-item"><a class="nav-link" href="#Logs" data-toggle="tab">{{ __('general_content.logs_trans_key') }}</a></li>
     </ul>
   </div>
   <!-- /.card-header -->
@@ -79,8 +79,14 @@
                 <input type="hidden" name="customer_reference" value="{{ $Quote->customer_reference }}">
                 <input type="hidden" name="companies_addresses_id" value="{{ $Quote->companies_addresses_id }}">
                 <input type="hidden" name="companies_contacts_id" value="{{ $Quote->companies_contacts_id }}">
-                <x-adminlte-alert theme="info" title="Info">
-                  The customer <x-CompanieButton id="{{ $Quote->companie['id'] }}" label="{{ $Quote->companie['label'] }}"  /> is currently disabled, you cannot change the you cannot change the customer name, contact and address.
+                @php
+                  $customerButton = view('components.companie-button', [
+                    'id' => $Quote->companie['id'],
+                    'label' => $Quote->companie['label'],
+                  ])->render();
+                @endphp
+                <x-adminlte-alert theme="info" title="{{ __('general_content.info_trans_key') }}">
+                  {!! __('general_content.customer_disabled_warning_trans_key', ['customer' => $customerButton]) !!}
                 </x-adminlte-alert>
                 @endif
                   <div class="row">
@@ -595,7 +601,7 @@
           </x-adminlte-card>
         </form>
         @else
-        <x-adminlte-alert theme="info" title="Info">
+        <x-adminlte-alert theme="info" title="{{ __('general_content.info_trans_key') }}">
             {{ __('general_content.info_statu_trans_key') }}
         </x-adminlte-alert>
         @endif


### PR DESCRIPTION
### Motivation
- Fix untranslated hardcoded strings on the quote "show" page and provide localized messages for UI elements and the disabled-customer warning.

### Description
- Replace hardcoded "Beta" badge, "Logs" tab and alert titles in `resources/views/workflow/quotes-show.blade.php` with translation keys and switch the disabled-customer alert to a localized message that can include the rendered company button HTML.
- Add translation keys `logs_trans_key`, `beta_trans_key`, `info_trans_key` and `customer_disabled_warning_trans_key` to language files for `en`, `fr`, `es`, `vi`, `zh-CN` and `ar` under `resources/lang/*/general_content.php`.
- Render the `CompanieButton` component server-side into a variable and inject it into the translated warning using `{!! __('general_content.customer_disabled_warning_trans_key', ['customer' => $customerButton]) !!}` to keep the message localized while preserving HTML.
- Update instances of the hardcoded alert title "Info" to use `__('general_content.info_trans_key')` for consistent localization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ce3b1a0c832dabbfaceadd66c0d7)