### PR TITLE
Ajouter import de pré-commandes (watcher CSV, modèles, vues, conversion)

### DIFF
--- a/app/Console/Commands/ScanPreOrdersOutputCommand.php
+++ b/app/Console/Commands/ScanPreOrdersOutputCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\PreOrderImportService;
+use Illuminate\Console\Command;
+
+class ScanPreOrdersOutputCommand extends Command
+{
+    protected $signature = 'preorders:scan-output {--path=output}';
+
+    protected $description = 'Scan output folder and import CSV files as pre-orders';
+
+    public function handle(PreOrderImportService $importService): int
+    {
+        $path = base_path($this->option('path'));
+
+        if (!is_dir($path)) {
+            $this->warn("Directory not found: {$path}");
+            return self::SUCCESS;
+        }
+
+        $files = glob($path . '/*.csv') ?: [];
+        $importedCount = 0;
+
+        foreach ($files as $file) {
+            if ($importService->importCsvFile($file)) {
+                $importedCount++;
+                $this->info('Imported: ' . basename($file));
+            }
+        }
+
+        $this->info("Done. Imported {$importedCount} file(s).");
+
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends ConsoleKernel
         $schedule->job(new DispatchGtdTaskReminders())->dailyAt('08:00')->withoutOverlapping();
         $schedule->command('quality:dispatch-calibration-alerts')->dailyAt('07:30')->withoutOverlapping();
         $schedule->command('emails:send-auto-reports')->everyMinute()->withoutOverlapping();
+        $schedule->command('preorders:scan-output')->everyMinute()->withoutOverlapping();
     }
 
     /**

--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers\Workflow;
+
+use App\Http\Controllers\Controller;
+use App\Models\Accounting\AccountingDelivery;
+use App\Models\Accounting\AccountingPaymentConditions;
+use App\Models\Accounting\AccountingPaymentMethod;
+use App\Models\Accounting\AccountingVat;
+use App\Models\Companies\Companies;
+use App\Models\Methods\MethodsUnits;
+use App\Models\Workflow\OrderLineDetails;
+use App\Models\Workflow\OrderLines;
+use App\Models\Workflow\Orders;
+use App\Models\Workflow\PreOrder;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class PreOrdersController extends Controller
+{
+    public function index()
+    {
+        $preOrders = PreOrder::withCount('lines')
+            ->withSum('lines', 'total_price')
+            ->with(['convertedOrder', 'importBatch'])
+            ->orderByDesc('id')
+            ->paginate(25);
+
+        return view('workflow.pre-orders-index', compact('preOrders'));
+    }
+
+    public function show(PreOrder $preOrder)
+    {
+        $preOrder->load('lines', 'convertedOrder');
+
+        return view('workflow.pre-orders-show', [
+            'preOrder' => $preOrder,
+            'companies' => Companies::orderBy('code')->get(),
+            'users' => User::orderBy('name')->get(),
+            'paymentConditions' => AccountingPaymentConditions::orderBy('code')->get(),
+            'paymentMethods' => AccountingPaymentMethod::orderBy('code')->get(),
+            'deliveries' => AccountingDelivery::orderBy('code')->get(),
+            'units' => MethodsUnits::orderBy('code')->get(),
+            'vats' => AccountingVat::orderBy('code')->get(),
+            'defaultUnit' => MethodsUnits::where('default', 1)->first(),
+            'defaultVat' => AccountingVat::where('default', 1)->first(),
+        ]);
+    }
+
+    public function convert(Request $request, PreOrder $preOrder)
+    {
+        if ($preOrder->status === PreOrder::STATUS_CONVERTED) {
+            return redirect()->route('pre-orders.show', $preOrder)->withErrors('Pré-commande déjà convertie.');
+        }
+
+        $data = $request->validate([
+            'code' => 'required|string|max:255',
+            'label' => 'required|string|max:255',
+            'user_id' => 'required|exists:users,id',
+            'companies_id' => 'nullable|exists:companies,id',
+            'customer_reference' => 'nullable|string|max:255',
+            'validity_date' => 'nullable|date',
+            'accounting_payment_conditions_id' => 'nullable|exists:accounting_payment_conditions,id',
+            'accounting_payment_methods_id' => 'nullable|exists:accounting_payment_methods,id',
+            'accounting_deliveries_id' => 'nullable|exists:accounting_deliveries,id',
+            'comment' => 'nullable|string',
+            'methods_units_id' => 'required|exists:methods_units,id',
+            'accounting_vats_id' => 'required|exists:accounting_vats,id',
+            'delivery_date' => 'nullable|date',
+            'discount' => 'nullable|numeric|min:0',
+            'type' => 'required|in:1,2',
+        ]);
+
+        $preOrder->load('lines');
+
+        DB::transaction(function () use ($preOrder, $data) {
+            $order = Orders::create([
+                'uuid' => Str::uuid(),
+                'code' => $data['code'],
+                'label' => $data['label'],
+                'customer_reference' => $data['customer_reference'] ?? null,
+                'companies_id' => $data['companies_id'] ?? null,
+                'validity_date' => $data['validity_date'] ?? null,
+                'statu' => 1,
+                'user_id' => $data['user_id'],
+                'accounting_payment_conditions_id' => $data['accounting_payment_conditions_id'] ?? null,
+                'accounting_payment_methods_id' => $data['accounting_payment_methods_id'] ?? null,
+                'accounting_deliveries_id' => $data['accounting_deliveries_id'] ?? null,
+                'comment' => $data['comment'] ?? null,
+                'type' => $data['type'],
+                'csv_file_name' => $preOrder->importBatch?->file_name,
+            ]);
+
+            foreach ($preOrder->lines as $index => $line) {
+                $orderLine = OrderLines::create([
+                    'orders_id' => $order->id,
+                    'ordre' => $index + 1,
+                    'code' => $line->reference,
+                    'label' => $line->product ?: $line->reference,
+                    'qty' => max((int) $line->quantity, 1),
+                    'delivered_remaining_qty' => max((int) $line->quantity, 1),
+                    'invoiced_remaining_qty' => max((int) $line->quantity, 1),
+                    'methods_units_id' => $data['methods_units_id'],
+                    'selling_price' => $line->unit_price,
+                    'discount' => $data['discount'] ?? 0,
+                    'accounting_vats_id' => $data['accounting_vats_id'],
+                    'delivery_date' => $data['delivery_date'] ?? null,
+                ]);
+
+                OrderLineDetails::create([
+                    'order_lines_id' => $orderLine->id,
+                ]);
+            }
+
+            $preOrder->update([
+                'status' => PreOrder::STATUS_CONVERTED,
+                'converted_order_id' => $order->id,
+                'converted_at' => now(),
+            ]);
+        });
+
+        return redirect()->route('pre-orders.show', $preOrder)->with('success', 'Pré-commande convertie en commande.');
+    }
+}
+

--- a/app/Models/Workflow/PreOrder.php
+++ b/app/Models/Workflow/PreOrder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PreOrder extends Model
+{
+    use HasFactory;
+
+    public const STATUS_PENDING = 1;
+    public const STATUS_CONVERTED = 2;
+
+    protected $fillable = [
+        'pre_order_import_id',
+        'source_pdf',
+        'status',
+        'converted_order_id',
+        'converted_at',
+        'comment',
+    ];
+
+    protected $casts = [
+        'converted_at' => 'datetime',
+    ];
+
+    public function importBatch()
+    {
+        return $this->belongsTo(PreOrderImport::class, 'pre_order_import_id');
+    }
+
+    public function lines()
+    {
+        return $this->hasMany(PreOrderLine::class);
+    }
+
+    public function convertedOrder()
+    {
+        return $this->belongsTo(Orders::class, 'converted_order_id');
+    }
+}
+

--- a/app/Models/Workflow/PreOrderImport.php
+++ b/app/Models/Workflow/PreOrderImport.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PreOrderImport extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'file_name',
+        'checksum',
+        'imported_at',
+    ];
+
+    protected $casts = [
+        'imported_at' => 'datetime',
+    ];
+
+    public function preOrders()
+    {
+        return $this->hasMany(PreOrder::class);
+    }
+}
+

--- a/app/Models/Workflow/PreOrderLine.php
+++ b/app/Models/Workflow/PreOrderLine.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Workflow;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PreOrderLine extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'pre_order_id',
+        'row_index',
+        'reference',
+        'product',
+        'quantity',
+        'unit_price',
+        'total_price',
+    ];
+
+    public function preOrder()
+    {
+        return $this->belongsTo(PreOrder::class);
+    }
+}
+

--- a/app/Services/PreOrderImportService.php
+++ b/app/Services/PreOrderImportService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Workflow\PreOrder;
+use App\Models\Workflow\PreOrderImport;
+use Illuminate\Support\Carbon;
+
+class PreOrderImportService
+{
+    public function importCsvFile(string $filePath): bool
+    {
+        if (!is_file($filePath)) {
+            return false;
+        }
+
+        $checksum = sha1_file($filePath);
+        if (PreOrderImport::where('checksum', $checksum)->exists()) {
+            return false;
+        }
+
+        $rows = $this->readRows($filePath);
+        if (empty($rows)) {
+            return false;
+        }
+
+        $groupedRows = [];
+        foreach ($rows as $index => $row) {
+            $sourcePdf = trim((string) ($row['source_pdf'] ?? 'unknown.pdf'));
+            $groupedRows[$sourcePdf][] = [
+                'row_index' => $index + 1,
+                'reference' => $row['reference'] ?? null,
+                'product' => $row['product'] ?? null,
+                'quantity' => $this->asDecimal($row['quantity'] ?? 0),
+                'unit_price' => $this->asDecimal($row['unit_price'] ?? 0),
+                'total_price' => $this->asDecimal($row['total_price'] ?? 0),
+            ];
+        }
+
+        $import = PreOrderImport::create([
+            'file_name' => basename($filePath),
+            'checksum' => $checksum,
+            'imported_at' => Carbon::now(),
+        ]);
+
+        foreach ($groupedRows as $sourcePdf => $lines) {
+            $preOrder = $import->preOrders()->create([
+                'source_pdf' => $sourcePdf,
+                'status' => PreOrder::STATUS_PENDING,
+            ]);
+
+            $preOrder->lines()->createMany($lines);
+        }
+
+        return true;
+    }
+
+    private function readRows(string $filePath): array
+    {
+        $handle = fopen($filePath, 'r');
+        if (!$handle) {
+            return [];
+        }
+
+        $firstLine = fgets($handle);
+        if ($firstLine === false) {
+            fclose($handle);
+            return [];
+        }
+
+        $delimiter = substr_count($firstLine, ';') > substr_count($firstLine, ',') ? ';' : ',';
+        rewind($handle);
+
+        $headers = fgetcsv($handle, 0, $delimiter);
+        if (!$headers) {
+            fclose($handle);
+            return [];
+        }
+
+        $headers = array_map(function ($header) {
+            return strtolower(trim((string) $header));
+        }, $headers);
+
+        $rows = [];
+        while (($data = fgetcsv($handle, 0, $delimiter)) !== false) {
+            if (count(array_filter($data, fn ($value) => trim((string) $value) !== '')) === 0) {
+                continue;
+            }
+
+            $rows[] = array_combine($headers, array_pad($data, count($headers), null));
+        }
+
+        fclose($handle);
+
+        return $rows;
+    }
+
+    private function asDecimal($value): float
+    {
+        $normalized = str_replace(',', '.', (string) $value);
+        return (float) $normalized;
+    }
+}
+

--- a/database/migrations/2026_02_12_000001_create_pre_orders_tables.php
+++ b/database/migrations/2026_02_12_000001_create_pre_orders_tables.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pre_order_imports', function (Blueprint $table) {
+            $table->id();
+            $table->string('file_name');
+            $table->string('checksum')->unique();
+            $table->timestamp('imported_at');
+            $table->timestamps();
+        });
+
+        Schema::create('pre_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pre_order_import_id')->constrained('pre_order_imports')->cascadeOnDelete();
+            $table->string('source_pdf');
+            $table->unsignedTinyInteger('status')->default(1);
+            // 1 = Pending, 2 = Converted
+            $table->unsignedBigInteger('converted_order_id')->nullable();
+            $table->timestamp('converted_at')->nullable();
+            $table->text('comment')->nullable();
+            $table->timestamps();
+
+            $table->unique(['pre_order_import_id', 'source_pdf']);
+        });
+
+        Schema::create('pre_order_lines', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pre_order_id')->constrained('pre_orders')->cascadeOnDelete();
+            $table->unsignedInteger('row_index')->default(0);
+            $table->string('reference')->nullable();
+            $table->string('product')->nullable();
+            $table->decimal('quantity', 12, 3)->default(0);
+            $table->decimal('unit_price', 12, 3)->default(0);
+            $table->decimal('total_price', 12, 3)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pre_order_lines');
+        Schema::dropIfExists('pre_orders');
+        Schema::dropIfExists('pre_order_imports');
+    }
+};
+

--- a/resources/views/workflow/pre-orders-index.blade.php
+++ b/resources/views/workflow/pre-orders-index.blade.php
@@ -1,0 +1,57 @@
+@extends('adminlte::page')
+
+@section('title', 'Pré-commandes importées')
+
+@section('content_header')
+    <h1>Pré-commandes importées</h1>
+@stop
+
+@section('content')
+    <x-adminlte-card title="Pré-commandes" theme="primary" maximizable>
+        <div class="card-body table-responsive p-0">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Fichier source</th>
+                        <th>PDF source</th>
+                        <th>Nb lignes</th>
+                        <th>Total</th>
+                        <th>Statut</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($preOrders as $preOrder)
+                        <tr>
+                            <td>{{ $preOrder->id }}</td>
+                            <td>{{ $preOrder->importBatch?->file_name }}</td>
+                            <td>{{ $preOrder->source_pdf }}</td>
+                            <td>{{ $preOrder->lines_count }}</td>
+                            <td>{{ number_format((float) $preOrder->lines_sum_total_price, 2, ',', ' ') }}</td>
+                            <td>
+                                @if($preOrder->status === \App\Models\Workflow\PreOrder::STATUS_CONVERTED)
+                                    <span class="badge badge-success">Convertie</span>
+                                @else
+                                    <span class="badge badge-warning">À traiter</span>
+                                @endif
+                            </td>
+                            <td class="text-right">
+                                <a href="{{ route('pre-orders.show', $preOrder) }}" class="btn btn-xs btn-default text-primary">
+                                    <i class="fa fa-lg fa-fw fa-eye"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7">Aucune pré-commande importée.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            {{ $preOrders->links() }}
+        </div>
+    </x-adminlte-card>
+@stop

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -1,0 +1,133 @@
+@extends('adminlte::page')
+
+@section('title', 'Pré-commande #'.$preOrder->id)
+
+@section('content_header')
+    <h1>Pré-commande #{{ $preOrder->id }}</h1>
+@stop
+
+@section('content')
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    @if($errors->any())
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                @foreach($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <div class="row">
+        <div class="col-lg-8">
+            <x-adminlte-card title="Lignes importées" theme="primary" maximizable>
+                <div class="table-responsive p-0">
+                    <table class="table table-sm table-hover">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Référence</th>
+                                <th>Produit</th>
+                                <th>Quantité</th>
+                                <th>PU</th>
+                                <th>Total</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($preOrder->lines as $line)
+                                <tr>
+                                    <td>{{ $line->row_index }}</td>
+                                    <td>{{ $line->reference }}</td>
+                                    <td>{{ $line->product }}</td>
+                                    <td>{{ $line->quantity }}</td>
+                                    <td>{{ number_format((float) $line->unit_price, 2, ',', ' ') }}</td>
+                                    <td>{{ number_format((float) $line->total_price, 2, ',', ' ') }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </x-adminlte-card>
+        </div>
+        <div class="col-lg-4">
+            <x-adminlte-card title="Transformation en commande" theme="lightblue">
+                @if($preOrder->status === \App\Models\Workflow\PreOrder::STATUS_CONVERTED)
+                    <p class="mb-2"><span class="badge badge-success">Déjà convertie</span></p>
+                    <p>Commande créée :
+                        <a href="{{ route('orders.show', ['id' => $preOrder->converted_order_id]) }}">#{{ $preOrder->converted_order_id }}</a>
+                    </p>
+                @else
+                    <form method="POST" action="{{ route('pre-orders.convert', $preOrder) }}">
+                        @csrf
+                        <x-adminlte-input name="code" label="Code commande" value="ORD-PRE-{{ now()->format('YmdHis') }}" required />
+                        <x-adminlte-input name="label" label="Libellé" value="Pré-commande issue de {{ $preOrder->source_pdf }}" required />
+                        <x-adminlte-input name="customer_reference" label="Référence client" />
+
+                        <x-adminlte-select name="companies_id" label="Client">
+                            <option value="">-- Sélectionner --</option>
+                            @foreach($companies as $company)
+                                <option value="{{ $company->id }}">{{ $company->code }} - {{ $company->label }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-select name="user_id" label="Responsable" required>
+                            @foreach($users as $user)
+                                <option value="{{ $user->id }}" @selected(auth()->id() === $user->id)>{{ $user->name }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-input name="validity_date" type="date" label="Date validité" />
+
+                        <x-adminlte-select name="accounting_payment_conditions_id" label="Condition de paiement">
+                            <option value="">--</option>
+                            @foreach($paymentConditions as $item)
+                                <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-select name="accounting_payment_methods_id" label="Mode de paiement">
+                            <option value="">--</option>
+                            @foreach($paymentMethods as $item)
+                                <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-select name="accounting_deliveries_id" label="Mode de livraison">
+                            <option value="">--</option>
+                            @foreach($deliveries as $item)
+                                <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-select name="methods_units_id" label="Unité ligne" required>
+                            @foreach($units as $item)
+                                <option value="{{ $item->id }}" @selected(optional($defaultUnit)->id === $item->id)>{{ $item->code }} - {{ $item->label }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-select name="accounting_vats_id" label="TVA ligne" required>
+                            @foreach($vats as $item)
+                                <option value="{{ $item->id }}" @selected(optional($defaultVat)->id === $item->id)>{{ $item->code }} - {{ $item->rate }}</option>
+                            @endforeach
+                        </x-adminlte-select>
+
+                        <x-adminlte-input name="delivery_date" type="date" label="Date livraison des lignes" />
+                        <x-adminlte-input name="discount" type="number" step="0.001" min="0" label="Remise (%)" value="0" />
+
+                        <x-adminlte-select name="type" label="Type commande" required>
+                            <option value="1">Client</option>
+                            <option value="2">Interne</option>
+                        </x-adminlte-select>
+
+                        <x-adminlte-textarea name="comment" label="Commentaire" rows=3 />
+
+                        <button type="submit" class="btn btn-success btn-block">Créer la commande</button>
+                    </form>
+                @endif
+            </x-adminlte-card>
+        </div>
+    </div>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -179,6 +179,12 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::delete('/{order}/site/{site}/implantation/{implantation}', 'App\Http\Controllers\Workflow\OrderSiteController@destroyImplantation')->name('orders.site.implantation.destroy');
     });
 
+    Route::group(['prefix' => 'pre-orders', 'middleware' => ['auth', 'check.factory', 'check.task.status']], function () {
+        Route::get('/', 'App\Http\Controllers\Workflow\PreOrdersController@index')->name('pre-orders.index');
+        Route::get('/{preOrder}', 'App\Http\Controllers\Workflow\PreOrdersController@show')->name('pre-orders.show');
+        Route::post('/{preOrder}/convert', 'App\Http\Controllers\Workflow\PreOrdersController@convert')->name('pre-orders.convert');
+    });
+
     Route::group(['prefix' => 'deliverys', 'middleware' => ['auth', 'check.factory']], function () {
         Route::get('/', 'App\Http\Controllers\Workflow\DeliverysController@index')->name('deliverys'); 
         Route::get('/request', 'App\Http\Controllers\Workflow\DeliverysController@request')->name('deliverys-request'); 


### PR DESCRIPTION
### Motivation
- Permettre d’ingérer automatiquement les CSV produits par l’analyse PDF (dossier `output`) et de créer des « pré-commandes » quand il manque des informations client/commande complètes.
- Offrir une interface pour visualiser ces pré-commandes, renseigner les métadonnées manquantes et convertir manuellement en commandes réelles.
- Éviter les réimportations en dédupliquant les fichiers par checksum et conserver trace de l’import.

### Description
- Ajout d’une migration qui crée `pre_order_imports`, `pre_orders` et `pre_order_lines` pour stocker les imports, les pré-commandes et leurs lignes. 
- Nouveaux modèles Eloquent `PreOrderImport`, `PreOrder`, `PreOrderLine` avec relations (import → pré-orders → lignes) et champ de liaison vers la commande convertie. 
- Service `PreOrderImportService` qui parse les CSV (`;` ou `,`), normalise les valeurs, regroupe par `source_pdf`, crée l’import et les pré-commandes/lignes et vérifie le checksum pour éviter les doublons. 
- Commande artisan `preorders:scan-output` (option `--path=`) et enregistrement du cron scheduler toutes les minutes; contrôleur `PreOrdersController`, routes `/pre-orders` (index, show, convert) et deux vues Blade pour lister/visualiser/transformer les pré-commandes en `orders` + `order_lines` + `order_line_details`.

### Testing
- Exécution de vérifications syntaxiques PHP: `php -l` sur `ScanPreOrdersOutputCommand`, `PreOrdersController`, `PreOrder*` modèles, `PreOrderImportService`, la migration, `Kernel.php` et `routes/web.php` — toutes les vérifications se sont bien terminées. 
- Vérification de l’enregistrement de la commande planifiée (`preorders:scan-output`) dans `app/Console/Kernel.php` (modification visible). 
- Tentative de `php artisan route:list --name=pre-orders` échouée dans cet environnement car `vendor/autoload.php` est absent, donc les routes n’ont pas pu être listées à l’exécution ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dab1d0da0832d80ffc1ffa46197c3)