### PR TITLE
Add back link to pre-orders index on pre-order detail

### DIFF
--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -3,7 +3,12 @@
 @section('title', 'Pré-commande #'.$preOrder->id)
 
 @section('content_header')
-    <h1>Pré-commande #{{ $preOrder->id }}</h1>
+    <div class="d-flex justify-content-between align-items-center">
+        <h1 class="mb-0">Pré-commande #{{ $preOrder->id }}</h1>
+        <a href="{{ route('pre-orders.index') }}" class="btn btn-default btn-sm">
+            <i class="fas fa-arrow-left mr-1"></i> Retour à l'index
+        </a>
+    </div>
 @stop
 
 @section('content')


### PR DESCRIPTION
### Motivation
- Restore a right-aligned "return" action on the pre-order detail page so it matches other resource show pages and provides a quick way to go back to the pre-orders index.

### Description
- Replaced the standalone `<h1>` in `resources/views/workflow/pre-orders-show.blade.php` with a flex header that keeps the title and adds a `Retour à l'index` button linking to `route('pre-orders.index')` (includes a FontAwesome arrow icon).

### Testing
- Captured an automated UI screenshot of `/fr/pre-orders/2` which succeeded and shows the new header button, and attempted `php artisan route:list --name=pre-orders` which failed in this environment due to missing `vendor/autoload.php` (dependency issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dc9d2d6e4832db3509d5a4741c26e)