### PR TITLE
Fix currency formatting on pre-order prices

### DIFF
--- a/app/Models/Workflow/PreOrderLine.php
+++ b/app/Models/Workflow/PreOrderLine.php
@@ -4,6 +4,7 @@ namespace App\Models\Workflow;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Number;
 
 class PreOrderLine extends Model
 {
@@ -29,9 +30,29 @@ class PreOrderLine extends Model
         return (float) ($this->quantity ?? 0) * (float) ($this->unit_price ?? 0);
     }
 
+    public function getSellingPriceAttribute(): float
+    {
+        return (float) ($this->unit_price ?? 0);
+    }
+
+    public function getFormattedSellingPriceAttribute(): string
+    {
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+
+        return Number::currency($this->getSellingPriceAttribute(), $currency, config('app.locale'));
+    }
+
+    public function getFormattedTotalPriceAttribute(): string
+    {
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+
+        return Number::currency($this->effective_total_price, $currency, config('app.locale'));
+    }
+
     public function preOrder()
     {
         return $this->belongsTo(PreOrder::class);
     }
 }
-

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -48,8 +48,8 @@
                                     <td>{{ $line->reference }}</td>
                                     <td>{{ $line->product }}</td>
                                     <td>{{ $line->quantity }}</td>
-                                    <td>{{ number_format((float) $line->unit_price, 2, ',', ' ') }}</td>
-                                    <td>{{ number_format((float) $line->effective_total_price, 2, ',', ' ') }}</td>
+                                    <td>{{ $line->formatted_selling_price }}</td>
+                                    <td>{{ $line->formatted_total_price }}</td>
                                 </tr>
                             @endforeach
                         </tbody>


### PR DESCRIPTION
### Motivation
- Pre-order lines were displayed with `number_format(...)` and therefore lacked the app-wide currency formatting and currency code used elsewhere. 
- Align pre-order price display with the existing `Number::currency(...)` pattern that uses `app('Factory')->curency` and `config('app.locale')`.

### Description
- Add `getSellingPriceAttribute()` to `app/Models/Workflow/PreOrderLine.php` to expose the unit price as a selling price. 
- Add `getFormattedSellingPriceAttribute()` and `getFormattedTotalPriceAttribute()` to `app/Models/Workflow/PreOrderLine.php` using `Number::currency(..., $factory->curency ?? 'EUR', config('app.locale'))`.
- Replace raw `number_format(...)` calls with the new `$line->formatted_selling_price` and `$line->formatted_total_price` attributes in `resources/views/workflow/pre-orders-show.blade.php`.

### Testing
- Ran `php -l app/Models/Workflow/PreOrderLine.php` and the file reported no syntax errors. 
- Ran `php -l resources/views/workflow/pre-orders-show.blade.php` and the file reported no syntax errors. 
- Automated Playwright script loaded `/workflow/pre-orders/1` and captured a screenshot showing formatted currency values (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcce1a890832da49657350ed7e630)