### PR TITLE
Use document code templates when converting pre-orders to orders

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -13,6 +13,7 @@ use App\Models\Workflow\OrderLineDetails;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\Orders;
 use App\Models\Workflow\PreOrder;
+use App\Services\DocumentCodeGenerator;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -20,6 +21,10 @@ use Illuminate\Support\Str;
 
 class PreOrdersController extends Controller
 {
+    public function __construct(protected DocumentCodeGenerator $documentCodeGenerator)
+    {
+    }
+
     public function index()
     {
         $preOrders = PreOrder::withCount('lines')
@@ -45,6 +50,7 @@ class PreOrdersController extends Controller
             'vats' => AccountingVat::orderBy('code')->get(),
             'defaultUnit' => MethodsUnits::where('default', 1)->first(),
             'defaultVat' => AccountingVat::where('default', 1)->first(),
+            'generatedOrderCode' => $this->generateOrderCodeByType(1),
         ]);
     }
 
@@ -55,7 +61,7 @@ class PreOrdersController extends Controller
         }
 
         $data = $request->validate([
-            'code' => 'required|string|max:255',
+            'code' => 'nullable|string|max:255',
             'label' => 'required|string|max:255',
             'user_id' => 'required|exists:users,id',
             'companies_id' => 'nullable|exists:companies,id',
@@ -71,6 +77,8 @@ class PreOrdersController extends Controller
             'discount' => 'nullable|numeric|min:0',
             'type' => 'required|in:1,2',
         ]);
+
+        $data['code'] = $data['code'] ?? $this->generateOrderCodeByType((int) $data['type']);
 
         $preOrder->load('lines', 'importBatch');
 
@@ -125,5 +133,13 @@ class PreOrdersController extends Controller
         });
 
         return redirect()->route('pre-orders.show', $preOrder)->with('success', 'Pré-commande convertie en commande.');
+    }
+
+    private function generateOrderCodeByType(int $type): string
+    {
+        $lastOrderId = Orders::query()->max('id') ?? 0;
+        $documentType = $type === 2 ? 'internal-order' : 'order';
+
+        return $this->documentCodeGenerator->generateDocumentCode($documentType, (int) $lastOrderId);
     }
 }

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -67,7 +67,7 @@
                 @else
                     <form method="POST" action="{{ route('pre-orders.convert', $preOrder) }}">
                         @csrf
-                        <x-adminlte-input name="code" label="Code commande" value="ORD-PRE-{{ now()->format('YmdHis') }}" required />
+                        <x-adminlte-input name="code" label="Code commande" value="{{ old('code', $generatedOrderCode) }}" required />
                         <x-adminlte-input name="label" label="Libellé" value="Pré-commande issue de {{ $preOrder->source_pdf }}" required />
                         <x-adminlte-input name="customer_reference" label="Référence client" />
 


### PR DESCRIPTION
### Motivation
- Replace the hardcoded `ORD-PRE-...` timestamp-based default with the project-wide document code templates so converted orders use the same templating system as other documents.
- Allow conversion to gracefully auto-generate a code server-side when the user does not supply one, using the correct template for `order` vs `internal-order`.

### Description
- Inject `DocumentCodeGenerator` into `PreOrdersController` and add a private `generateOrderCodeByType` helper that picks the document type (`order` / `internal-order`) and generates a code using the configured template.
- Pass a generated default `generatedOrderCode` to the `workflow.pre-orders-show` view so the conversion form shows a template-driven default instead of `ORD-PRE-{{ now()->format('YmdHis') }}`.
- Make the `code` field nullable in the conversion request validation and auto-fill it server-side with the generated code when omitted.
- Update the Blade form to use `old('code', $generatedOrderCode)` as the default value for the `Code commande` input.

### Testing
- Checked PHP syntax for the controller with `php -l app/Http/Controllers/Workflow/PreOrdersController.php` which succeeded.
- Checked PHP syntax for the view with `php -l resources/views/workflow/pre-orders-show.blade.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcd1e5624832da85e9f31510b6c73)