### PR TITLE
Use app-wide currency formatting for pre-order totals and line prices

### DIFF
--- a/app/Models/Workflow/PreOrder.php
+++ b/app/Models/Workflow/PreOrder.php
@@ -4,6 +4,7 @@ namespace App\Models\Workflow;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Number;
 
 class PreOrder extends Model
 {
@@ -45,6 +46,14 @@ class PreOrder extends Model
         return $this->lines->sum(function (PreOrderLine $line) {
             return $line->effective_total_price;
         });
+    }
+
+    public function getFormattedTotalPriceAttribute(): string
+    {
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+
+        return Number::currency($this->computed_total_price, $currency, config('app.locale'));
     }
 
 }

--- a/app/Models/Workflow/PreOrderLine.php
+++ b/app/Models/Workflow/PreOrderLine.php
@@ -4,6 +4,7 @@ namespace App\Models\Workflow;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Number;
 
 class PreOrderLine extends Model
 {
@@ -29,9 +30,29 @@ class PreOrderLine extends Model
         return (float) ($this->quantity ?? 0) * (float) ($this->unit_price ?? 0);
     }
 
+    public function getSellingPriceAttribute(): float
+    {
+        return (float) ($this->unit_price ?? 0);
+    }
+
+    public function getFormattedSellingPriceAttribute(): string
+    {
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+
+        return Number::currency($this->getSellingPriceAttribute(), $currency, config('app.locale'));
+    }
+
+    public function getFormattedTotalPriceAttribute(): string
+    {
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+
+        return Number::currency($this->effective_total_price, $currency, config('app.locale'));
+    }
+
     public function preOrder()
     {
         return $this->belongsTo(PreOrder::class);
     }
 }
-

--- a/resources/views/workflow/pre-orders-index.blade.php
+++ b/resources/views/workflow/pre-orders-index.blade.php
@@ -28,7 +28,7 @@
                             <td>{{ $preOrder->importBatch?->file_name }}</td>
                             <td>{{ $preOrder->source_pdf }}</td>
                             <td>{{ $preOrder->lines_count }}</td>
-                            <td>{{ number_format((float) $preOrder->computed_total_price, 2, ',', ' ') }}</td>
+                            <td>{{ $preOrder->formatted_total_price }}</td>
                             <td>
                                 @if($preOrder->status === \App\Models\Workflow\PreOrder::STATUS_CONVERTED)
                                     <span class="badge badge-success">Convertie</span>

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -48,8 +48,8 @@
                                     <td>{{ $line->reference }}</td>
                                     <td>{{ $line->product }}</td>
                                     <td>{{ $line->quantity }}</td>
-                                    <td>{{ number_format((float) $line->unit_price, 2, ',', ' ') }}</td>
-                                    <td>{{ number_format((float) $line->effective_total_price, 2, ',', ' ') }}</td>
+                                    <td>{{ $line->formatted_selling_price }}</td>
+                                    <td>{{ $line->formatted_total_price }}</td>
                                 </tr>
                             @endforeach
                         </tbody>


### PR DESCRIPTION
### Motivation
- Pre-order prices were rendered with raw `number_format(...)`, producing inconsistent formatting and missing the app-wide currency/code and locale rules. 
- Align pre-order displays with the rest of the app by reusing the same `Number::currency(...)` formatter driven by `app('Factory')->curency` and `config('app.locale')`.

### Description
- Add `getSellingPriceAttribute()`, `getFormattedSellingPriceAttribute()` and `getFormattedTotalPriceAttribute()` to `app/Models/Workflow/PreOrderLine.php` and import `Illuminate\Support\Number` to format per-line unit and total prices using the factory currency (fallback `EUR`) and app locale.
- Add `getFormattedTotalPriceAttribute()` to `app/Models/Workflow/PreOrder.php` and import `Illuminate\Support\Number` to expose a formatted total for each pre-order using the same currency/locale logic.
- Replace raw `number_format(...)` occurrences in `resources/views/workflow/pre-orders-show.blade.php` and `resources/views/workflow/pre-orders-index.blade.php` with the new formatted accessors `{{ $line->formatted_selling_price }}`, `{{ $line->formatted_total_price }}`, and `{{ $preOrder->formatted_total_price }}`.

### Testing
- Ran `php -l` for the modified model files and view files (`app/Models/Workflow/PreOrder.php`, `app/Models/Workflow/PreOrderLine.php`, `resources/views/workflow/pre-orders-show.blade.php`, and `resources/views/workflow/pre-orders-index.blade.php`) and no syntax errors were reported.
- Ran automated Playwright scripts that loaded `/workflow/pre-orders` and `/workflow/pre-orders/1` and captured screenshots showing the formatted currency values; the scripts completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcce1a890832da49657350ed7e630)