### PR TITLE
Add pre-order notifications with user opt-out setting

### DIFF
--- a/app/Http/Controllers/NotificationsController.php
+++ b/app/Http/Controllers/NotificationsController.php
@@ -45,10 +45,15 @@ class NotificationsController extends Controller
                 $type = 'fas fa-undo';
                 $route = route('returns.show', ['id' => $id]);
             }
+            if($notification->type == 'App\Notifications\PreOrderNotification') {
+                $type = 'fas fa-file-import';
+                $route = route('pre-orders.show', ['preOrder' => $id]);
+            }
 
             $code = $notification->data['code'];
-            $notificationOriginUser = User::find($notification->data['user_id']);
-            $text = ''.$code .' created by '. $notificationOriginUser['name'] .'';
+            $notificationOriginUser = User::find($notification->data['user_id'] ?? null);
+            $originUserName = $notificationOriginUser?->name ?? 'System';
+            $text = ''.$code .' created by '. $originUserName .'';
 
             array_push($notifications,[
                             'icon' => $type,

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -69,7 +69,11 @@ class UsersController extends Controller
 
         if($request->non_conformity_notification) $settingNotification->non_conformity_notification=1;
         else $settingNotification->non_conformity_notification = 0;
-        
+
+
+        if($request->pre_order_notification) $settingNotification->pre_order_notification=1;
+        else $settingNotification->pre_order_notification = 0;
+
         $settingNotification->save();
 
         return redirect()->route('user.profile', ['id' => Auth::user()->id])->with('success', 'Successfully update notification settings.');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -86,6 +86,7 @@ class User extends Authenticatable
         'orders_notification',
         'non_conformity_notification',
         'return_notification',
+        'pre_order_notification',
         'banned_until',
     ];
 

--- a/app/Notifications/PreOrderNotification.php
+++ b/app/Notifications/PreOrderNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class PreOrderNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private array $data)
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param mixed $notifiable
+     * @return array<int, string>
+     */
+    public function via($notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return array<string, mixed>
+     */
+    public function toArray($notifiable): array
+    {
+        return [
+            'id' => $this->data['id'],
+            'code' => $this->data['code'],
+            'user_id' => $this->data['user_id'],
+        ];
+    }
+}

--- a/app/Services/PreOrderImportService.php
+++ b/app/Services/PreOrderImportService.php
@@ -3,12 +3,19 @@
 namespace App\Services;
 
 use App\Models\Workflow\PreOrder;
+use App\Models\User;
 use App\Models\Workflow\PreOrderImport;
+use App\Notifications\PreOrderNotification;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class PreOrderImportService
 {
+    public function __construct(private NotificationService $notificationService)
+    {
+    }
+
     private const REQUIRED_HEADERS = [
         'reference',
         'product',
@@ -69,6 +76,19 @@ class PreOrderImportService
                 ]);
 
                 $preOrder->lines()->createMany($lines);
+
+                $originUserId = Auth::id() ?? User::query()->value('id');
+                $payload = [
+                    'id' => $preOrder->id,
+                    'code' => $preOrder->source_pdf,
+                    'user_id' => $originUserId,
+                ];
+
+                $this->notificationService->sendNotification(
+                    PreOrderNotification::class,
+                    $payload,
+                    'pre_order_notification'
+                );
             }
         });
 

--- a/database/migrations/2026_02_12_000003_add_pre_order_notification_to_users_table.php
+++ b/database/migrations/2026_02_12_000003_add_pre_order_notification_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'pre_order_notification')) {
+                $table->boolean('pre_order_notification')->default(1)->after('return_notification');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'pre_order_notification')) {
+                $table->dropColumn('pre_order_notification');
+            }
+        });
+    }
+};

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -702,6 +702,7 @@ return [
     'order_confirm_trans_key'                  => 'تأكيد الطلب',
     'internal_order_trans_key'                 => 'طلب داخلي',
     'new_order_trans_key'                      => 'طلب جديد',
+    'new_pre_order_trans_key'                  => 'طلب مسبق جديد',
     'name_order_trans_key'                     => 'اسم الطلب',
     'historical_trans_key'                     => 'تاريخي',
     'order_create_from_trans_key'              => 'إنشاء طلب من',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -835,6 +835,7 @@ return [
     'order_confirm_trans_key'                  => 'Order Confirm',
     'internal_order_trans_key'                 => 'Internal order',
     'new_order_trans_key'                      => 'New order',
+    'new_pre_order_trans_key'                  => 'New pre-order',
     'name_order_trans_key'                     => 'Name of order',
     'historical_trans_key'                     => 'Historical',
     'order_create_from_trans_key'              => 'Order Create from',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -702,6 +702,7 @@ return [
     'order_confirm_trans_key'                  => 'Confirmar orden',
     'internal_order_trans_key'                 => 'Orden interna',
     'new_order_trans_key'                      => 'Nueva orden',
+    'new_pre_order_trans_key'                  => 'Nuevo pre-pedido',
     'name_order_trans_key'                     => 'Nombre de la orden',
     'historical_trans_key'                     => 'Histórico',
     'order_create_from_trans_key'              => 'Crear orden desde',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -835,6 +835,7 @@ return [
     'order_confirm_trans_key'                  => 'Confirmation de commande',
     'internal_order_trans_key'                 => 'Commande interne',
     'new_order_trans_key'                      => 'Nouvelle commande',
+    'new_pre_order_trans_key'                  => 'Nouvelle pré-commande',
     'name_order_trans_key'                     => 'Nom de la commande',
     'historical_trans_key'                     => 'Historique',
     'order_create_from_trans_key'              => 'Commande créée à partir de ',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -806,6 +806,7 @@ return [
     'order_confirm_trans_key'                  => '订单确认',
     'internal_order_trans_key'                 => '内部订单',
     'new_order_trans_key'                      => '新建订单',
+    'new_pre_order_trans_key'                  => '新建预订单',
     'name_order_trans_key'                     => '订单名称',
     'historical_trans_key'                     => '历史',
     'order_create_from_trans_key'              => '订单创建自 ',

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -134,6 +134,18 @@
                                             is-checked="{{ $UserProfil->non_conformity_notification }}" />
                                     </div>
                                 </div>
+
+                                <div class="row">
+                                    <div class="col-4 text-right"><label for="pre_order_notification" class="col-form-label">{{ __('general_content.new_pre_order_trans_key') }}</label></div>
+                                    <div class="col-8">
+                                        <x-adminlte-input-switch name="pre_order_notification" 
+                                            data-on-text="{{ __('general_content.yes_trans_key') }}" 
+                                            data-off-text="{{ __('general_content.no_trans_key') }}"
+                                            data-on-color="teal" 
+                                            data-off-color="danger" 
+                                            is-checked="{{ $UserProfil->pre_order_notification }}" />
+                                    </div>
+                                </div>
                                 <x-slot name="footerSlot">
                                     <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="info" icon="fas fa-lg fa-save"/>
                                 </x-slot>

--- a/tests/Feature/PreOrderNotificationTest.php
+++ b/tests/Feature/PreOrderNotificationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Notifications\PreOrderNotification;
+use App\Services\PreOrderImportService;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PreOrderNotificationTest extends TestCase
+{
+    public function test_it_sends_pre_order_notification_only_to_opted_in_users(): void
+    {
+        Notification::fake();
+
+        $originUser = User::factory()->create();
+        $optedInUser = User::factory()->create(['pre_order_notification' => 1]);
+        $optedOutUser = User::factory()->create(['pre_order_notification' => 0]);
+
+        $this->actingAs($originUser);
+
+        $csvPath = base_path('tests_tmp/preorders/preorder_notification.csv');
+        @mkdir(dirname($csvPath), 0775, true);
+        file_put_contents($csvPath, "reference,product,quantity,unit_price,total_price,source_pdf\nA1,Prod,1,10,10,source.pdf\n");
+
+        $result = app(PreOrderImportService::class)->importCsvFile($csvPath);
+
+        $this->assertTrue($result);
+        Notification::assertSentTo($optedInUser, PreOrderNotification::class);
+        Notification::assertNotSentTo($optedOutUser, PreOrderNotification::class);
+
+        @unlink($csvPath);
+        @rmdir(dirname($csvPath));
+    }
+
+    public function test_user_can_disable_pre_order_notifications_from_profile_settings(): void
+    {
+        $user = User::factory()->create(['pre_order_notification' => 1]);
+
+        $response = $this->actingAs($user)->post(route('notifications.setting'), [
+            'companies_notification' => 1,
+            'users_notification' => 1,
+            'quotes_notification' => 1,
+            'orders_notification' => 1,
+            'non_conformity_notification' => 1,
+        ]);
+
+        $response->assertRedirect(route('user.profile', ['id' => $user->id]));
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'pre_order_notification' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation

- Add notification support for pre-orders so users are informed when a pre-order is imported, while allowing users to opt out from their profile.

### Description

- Add a `PreOrderNotification` class that stores notification payload in the `database` channel (`app/Notifications/PreOrderNotification.php`).
- Trigger pre-order notifications from the CSV import flow by injecting `NotificationService` into `PreOrderImportService` and calling `sendNotification` with the `pre_order_notification` preference (`app/Services/PreOrderImportService.php`).
- Add a boolean user preference column `pre_order_notification` with a migration and expose it in the `User` model fillable list (`database/migrations/2026_02_12_000003_add_pre_order_notification_to_users_table.php`, `app/Models/User.php`).
- Expose the new switch in the profile UI and persist the setting in `UsersController::settingNotification` (`resources/views/profile.blade.php`, `app/Http/Controllers/UsersController.php`).
- Update `NotificationsController` dropdown rendering to support `PreOrderNotification` (icon and route) and make origin user handling tolerant of missing users (`app/Http/Controllers/NotificationsController.php`).
- Add translation keys for `new_pre_order_trans_key` in FR/EN/ES/AR/ZH-CN and a feature test verifying dispatch filtering and profile opt-out behavior (`resources/lang/*/general_content.php`, `tests/Feature/PreOrderNotificationTest.php`).

### Testing

- Ran syntax checks with `php -l` for modified files and they all reported "No syntax errors detected" for `NotificationsController`, `UsersController`, `User` model, `PreOrderImportService`, `PreOrderNotification`, migration and the new feature test.
- Added `tests/Feature/PreOrderNotificationTest.php` that asserts notifications are sent only to opted-in users and that profile settings can disable pre-order notifications.
- Attempted to run `php artisan test tests/Feature/PreOrderNotificationTest.php` but it failed in this environment because `vendor/autoload.php` is missing, so feature tests could not be executed here.
- Attempt to capture a UI screenshot with Playwright failed due to a Chromium crash in the environment, so no runtime UI snapshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd03e720c832d864894469ec99dae)