### PR TITLE
Allow .pdf uploads when client sends a generic MIME type

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -42,7 +42,19 @@ class PreOrdersController extends Controller
     {
         $data = $request->validate([
             'pdfs' => 'required|array|min:1',
-            'pdfs.*' => 'required|file|mimes:pdf|max:20480',
+            'pdfs.*' => [
+                'required',
+                'file',
+                'max:20480',
+                function (string $attribute, $file, $fail): void {
+                    $extension = strtolower((string) $file->getClientOriginalExtension());
+                    $mimeType = strtolower((string) $file->getMimeType());
+
+                    if ($extension !== 'pdf' && ! str_contains($mimeType, 'pdf')) {
+                        $fail('Le champ ' . $attribute . ' doit être un fichier de type : pdf.');
+                    }
+                },
+            ],
         ]);
 
         $disk = config('filesystems.default');

--- a/tests/Feature/PreOrdersUploadTest.php
+++ b/tests/Feature/PreOrdersUploadTest.php
@@ -46,6 +46,30 @@ class PreOrdersUploadTest extends TestCase
         $this->assertCount(1, Storage::disk('local')->files('pre-orders/input'));
     }
 
+
+    public function test_it_accepts_pdf_extension_even_with_generic_mime_type(): void
+    {
+        Process::fake();
+
+        Config::set('pre_orders.python_executable', null);
+        Config::set('pre_orders.python_script', null);
+        Config::set('pre_orders.input_path', 'pre-orders/input');
+
+        $this->actingAs(User::factory()->create());
+
+        $response = $this->post(route('pre-orders.upload'), [
+            'pdfs' => [
+                UploadedFile::fake()->create('pdf1.pdf', 100, 'application/octet-stream'),
+            ],
+        ]);
+
+        $response
+            ->assertRedirect(route('pre-orders.index'))
+            ->assertSessionHas('success', 'PDF(s) envoyé(s) dans le stockage avec succès.');
+
+        $this->assertCount(1, Storage::disk('local')->files('pre-orders/input'));
+    }
+
     public function test_it_only_uploads_pdfs_when_python_script_is_not_configured(): void
     {
         Process::fake();


### PR DESCRIPTION
### Motivation

- The upload endpoint rejected some valid PDF files with the error message `Le champ pdfs.1 doit être un fichier de type : pdf.` when the client sent a generic MIME type like `application/octet-stream` despite the filename ending in `.pdf`.
- The change aims to accept legitimate PDF files even when the browser or client provides a non-PDF MIME while keeping size and file constraints.

### Description

- Replaced the strict `mimes:pdf` rule on `pdfs.*` with a custom validation closure that accepts the upload when the client file extension is `.pdf` or when the MIME type contains `pdf`, while preserving `file` and `max:20480` constraints (file: `app/Http/Controllers/Workflow/PreOrdersController.php`).
- Added a feature test `test_it_accepts_pdf_extension_even_with_generic_mime_type` which uploads `pdf1.pdf` with MIME `application/octet-stream` to verify the new behavior (file: `tests/Feature/PreOrdersUploadTest.php`).
- Kept existing behavior that runs the configured Python processing when `pre_orders.python_executable` and `pre_orders.python_script` are set.

### Testing

- Attempted to run `php artisan test --filter=PreOrdersUploadTest`, but the test run could not be executed in this environment because `vendor/autoload.php` is missing and PHP dependencies are not installed, so automated tests could not be completed here.
- The added feature test covers the reported regression and should pass in CI or a local environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd49c2960832d93013b138a389af9)