### PR TITLE
Normalize PRE_ORDERS input path for Windows-style paths

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -69,7 +69,7 @@ class PreOrdersController extends Controller
         ]);
 
         $disk = config('filesystems.default');
-        $inputPath = trim(config('pre_orders.input_path', 'pre-orders/input'), '/');
+        $inputPath = $this->resolveInputPath((string) config('pre_orders.input_path', 'pre-orders/input'));
 
         foreach ($data['pdfs'] as $pdfFile) {
             $originalName = pathinfo($pdfFile->getClientOriginalName(), PATHINFO_FILENAME);
@@ -96,6 +96,27 @@ class PreOrdersController extends Controller
         }
 
         return redirect()->route('pre-orders.index')->with('success', 'PDF(s) envoyé(s) dans le stockage avec succès.');
+    }
+
+    private function resolveInputPath(string $configuredPath): string
+    {
+        $normalizedPath = trim(str_replace('\\', '/', $configuredPath));
+
+        if ($normalizedPath === '') {
+            return 'pre-orders/input';
+        }
+
+        if (preg_match('/^[A-Za-z]:\//', $normalizedPath) === 1 || str_starts_with($normalizedPath, '/')) {
+            return ltrim(str_replace('\\', '/', basename($normalizedPath)), '/');
+        }
+
+        $normalizedPath = ltrim($normalizedPath, '/');
+
+        if (str_starts_with($normalizedPath, 'storage/app/')) {
+            $normalizedPath = substr($normalizedPath, strlen('storage/app/'));
+        }
+
+        return trim($normalizedPath, '/');
     }
 
     public function show(PreOrder $preOrder)


### PR DESCRIPTION
### Motivation
- Windows-style `PRE_ORDERS_INPUT_PATH` values (backslashes or full `storage\app\...` paths) could be passed verbatim to `Storage::putFileAs()` and cause duplicated `storage/app/storage/app/...` folders or incorrect disk-relative paths when storing uploaded PDFs.

### Description
- Replace the direct `trim(config('pre_orders.input_path', 'pre-orders/input'), '/')` usage with a call to a new `resolveInputPath()` method to produce a disk-relative path.
- Add `resolveInputPath(string $configuredPath)` which converts backslashes to slashes, strips a leading `storage/app/` prefix, handles absolute Windows (`C:/...`) and POSIX (`/...`) paths by using the basename, and falls back to `pre-orders/input` when the configured path is empty.

### Testing
- Ran `php -l app/Http/Controllers/Workflow/PreOrdersController.php` to verify no syntax errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd67e918c832d8b773fc2ed621fe1)