### PR TITLE
Trigger preorder CSV scan after Python extraction and handle absolute paths in scan command

### DIFF
--- a/app/Console/Commands/ScanPreOrdersOutputCommand.php
+++ b/app/Console/Commands/ScanPreOrdersOutputCommand.php
@@ -21,7 +21,7 @@ class ScanPreOrdersOutputCommand extends Command
         $patternOption = $this->option('pattern') ?: $configuredPattern;
         $donePathOption = $this->option('done-path') ?: $configuredDonePath;
 
-        $path = base_path($pathOption);
+        $path = $this->resolveConfiguredPath($pathOption);
 
         if (!is_dir($path)) {
             $this->warn("Directory not found: {$path}");
@@ -46,7 +46,7 @@ class ScanPreOrdersOutputCommand extends Command
 
     private function moveToDoneFolder(string $filePath, string $donePathOption): void
     {
-        $doneDirectory = base_path($donePathOption);
+        $doneDirectory = $this->resolveConfiguredPath($donePathOption);
 
         if (!is_dir($doneDirectory) && !mkdir($doneDirectory, 0775, true) && !is_dir($doneDirectory)) {
             $this->warn("Unable to create done directory: {$doneDirectory}");
@@ -65,5 +65,20 @@ class ScanPreOrdersOutputCommand extends Command
         if (!rename($filePath, $destination)) {
             $this->warn('Unable to move imported file to done folder: ' . basename($filePath));
         }
+    }
+
+    private function resolveConfiguredPath(string $pathOption): string
+    {
+        $normalized = trim(str_replace('\\', '/', $pathOption));
+
+        if ($normalized === '') {
+            return base_path();
+        }
+
+        if (preg_match('/^[A-Za-z]:\//', $normalized) === 1 || str_starts_with($normalized, '/')) {
+            return $normalized;
+        }
+
+        return base_path(ltrim($normalized, '/'));
     }
 }

--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -17,6 +17,7 @@ use App\Services\DocumentCodeGenerator;
 use App\Services\InvoiceReportInterpreter;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
@@ -111,7 +112,19 @@ class PreOrdersController extends Controller
                 );
             }
     
-            return redirect()->route('pre-orders.index')->with('success', 'PDF(s) envoyé(s) et traitement Python exécuté avec succès.');
+            $scanExitCode = Artisan::call('preorders:scan-output', [
+                '--path' => config('pre_orders.output_path', 'output'),
+                '--pattern' => config('pre_orders.file_pattern', '*.csv'),
+                '--done-path' => config('pre_orders.done_path', 'output/done'),
+            ]);
+
+            if ($scanExitCode !== 0) {
+                return redirect()->route('pre-orders.index')->withErrors(
+                    "PDF(s) traité(s), mais l'import des CSV a échoué. Vérifiez les logs de la commande preorders:scan-output."
+                );
+            }
+
+            return redirect()->route('pre-orders.index')->with('success', 'PDF(s) envoyé(s), traitement Python terminé et import CSV exécuté avec succès.');
         }
     
         return redirect()->route('pre-orders.index')->with('success', 'PDF(s) envoyé(s) dans le stockage avec succès.');


### PR DESCRIPTION
### Motivation
- Avoid requiring manual `artisan preorders:scan-output` runs by automatically importing CSVs right after the Python extraction completes. 
- Ensure the scan command correctly handles absolute Windows and Unix paths so configured `output` and `done` directories work as expected. 

### Description
- Call `Artisan::call('preorders:scan-output', [...])` at the end of `PreOrdersController::upload()` and return a clear error message if the scan/import fails or a success message when both extraction and import complete. 
- Add the `Artisan` import to `PreOrdersController` and pass `pre_orders` config values (`output_path`, `file_pattern`, `done_path`) as options to the command. 
- Replace direct `base_path()` usage in `ScanPreOrdersOutputCommand` with a new `resolveConfiguredPath()` helper and use it for the scan input directory and the `done` folder. 
- Update `moveToDoneFolder()` to use the resolved path so moved files go to the correct destination when configured paths are absolute. 

### Testing
- Ran `php -l app/Http/Controllers/Workflow/PreOrdersController.php` and it reported no syntax errors. 
- Ran `php -l app/Console/Commands/ScanPreOrdersOutputCommand.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de20fc894832db7b12624089251ad)