### PR TITLE
Afficher uniquement les erreurs dans le log d'import

### DIFF
--- a/resources/views/workflow/pre-orders-index.blade.php
+++ b/resources/views/workflow/pre-orders-index.blade.php
@@ -90,13 +90,17 @@
         </div>
     </x-adminlte-card>
 
-    <x-adminlte-card title="Rapport de traitement Python (aujourd'hui)" theme="secondary" maximizable>
+    @php
+        $invoiceErrorRows = $invoiceReportRows->filter(fn (array $row) => $row['is_error'] ?? false)->values();
+    @endphp
+
+    <x-adminlte-card title="Log d'import" theme="secondary" maximizable>
         @if(!empty($invoiceReportReadError))
             <x-adminlte-alert theme="warning" title="Rapport indisponible" dismissable>
                 {{ $invoiceReportReadError }}
             </x-adminlte-alert>
-        @elseif($invoiceReportRows->isEmpty())
-            <p class="mb-0 text-muted">Aucun résultat de traitement disponible pour aujourd'hui.</p>
+        @elseif($invoiceErrorRows->isEmpty())
+            <p class="mb-0 text-muted">Aucune erreur d'import disponible pour aujourd'hui.</p>
         @else
             <div class="card-body table-responsive p-0">
                 <table class="table table-hover">
@@ -111,7 +115,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach($invoiceReportRows as $reportRow)
+                        @foreach($invoiceErrorRows as $reportRow)
                             <tr>
                                 <td>{{ $reportRow['filename'] }}</td>
                                 <td>{{ $reportRow['date'] }}</td>


### PR DESCRIPTION
### Motivation
- Afficher uniquement les lignes en erreur du rapport d'importation et clarifier le titre du bloc pour que les utilisateurs voient rapidement les erreurs (`Rapport de traitement Python (aujourd'hui)` → `Log d'import`).

### Description
- Filtrage des lignes d'import avec `$invoiceErrorRows = $invoiceReportRows->filter(fn (array $row) => $row['is_error'] ?? false)->values();`, remplacement du titre de la carte, mise à jour du message vide et itération sur `$invoiceErrorRows` dans `resources/views/workflow/pre-orders-index.blade.php`.

### Testing
- Tentative d'exécution de `php artisan view:cache` (automatisée) a échoué à cause de l'environnement (dépendances PHP manquantes, `vendor/autoload.php` absent). 
- Capture automatique de la page réalisée avec Playwright et sauvegardée en tant qu'artifact (`artifacts/pre-orders-log-import.png`) avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0a53ad4c832db8cdf3e3b73201fe)