### PR TITLE
Make pre-order PDF names clickable and serve PDFs via new route

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PreOrdersController extends Controller
 {
@@ -151,6 +152,24 @@ class PreOrdersController extends Controller
 
         return trim($normalizedPath, '/');
     }
+
+    public function pdf(PreOrder $preOrder): StreamedResponse
+    {
+        $disk = config('filesystems.default');
+        $inputPath = $this->resolveInputPath((string) config('pre_orders.input_path', 'pre-orders/input'));
+        $relativePath = trim($inputPath . '/' . ltrim($preOrder->source_pdf, '/'), '/');
+
+        if (!Storage::disk($disk)->exists($relativePath)) {
+            abort(404, 'PDF introuvable.');
+        }
+
+        return Storage::disk($disk)->response(
+            $relativePath,
+            $preOrder->source_pdf,
+            ['Content-Type' => 'application/pdf']
+        );
+    }
+
 
     public function show(PreOrder $preOrder)
     {

--- a/resources/views/workflow/pre-orders-index.blade.php
+++ b/resources/views/workflow/pre-orders-index.blade.php
@@ -57,7 +57,11 @@
                 <tbody>
                     @forelse($preOrders as $preOrder)
                         <tr>
-                            <td>{{ $preOrder->source_pdf }}</td>
+                            <td>
+                                <a href="{{ route('pre-orders.pdf', $preOrder) }}" target="_blank" rel="noopener noreferrer">
+                                    {{ $preOrder->source_pdf }}
+                                </a>
+                            </td>
                             <td>{{ $preOrder->lines_count }}</td>
                             <td>{{ $preOrder->formatted_total_price }}</td>
                             <td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -182,6 +182,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     Route::group(['prefix' => 'pre-orders', 'middleware' => ['auth', 'check.factory', 'check.task.status']], function () {
         Route::get('/', 'App\Http\Controllers\Workflow\PreOrdersController@index')->name('pre-orders.index');
         Route::post('/upload', 'App\Http\Controllers\Workflow\PreOrdersController@upload')->name('pre-orders.upload');
+        Route::get('/pdf/{preOrder}', 'App\Http\Controllers\Workflow\PreOrdersController@pdf')->name('pre-orders.pdf');
         Route::get('/{preOrder}', 'App\Http\Controllers\Workflow\PreOrdersController@show')->name('pre-orders.show');
         Route::post('/{preOrder}/convert', 'App\Http\Controllers\Workflow\PreOrdersController@convert')->name('pre-orders.convert');
     });


### PR DESCRIPTION
### Motivation
- Allow users to open the source PDF for a pre-order directly from the pre-orders list for faster inspection and validation.

### Description
- Add a new route `pre-orders.pdf` to serve the PDF associated with a `PreOrder` via `GET /pre-orders/pdf/{preOrder}`.
- Implement `pdf(PreOrder $preOrder)` in `PreOrdersController` to resolve the configured input path, check existence on the configured disk, return the file as `application/pdf`, and abort with 404 if missing.
- Make the "PDF source" column in the pre-orders index view a clickable link that opens the PDF in a new tab using the new route.

### Testing
- Run `php -l app/Http/Controllers/Workflow/PreOrdersController.php` and `php -l routes/web.php` and `php -l resources/views/workflow/pre-orders-index.blade.php`, all of which reported no syntax errors. 
- Generated a headless browser screenshot showing the UI with the clickable PDF link to validate the link presence (Playwright script executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0bf7f3f4832d8cc5f7722ff3cab2)