### PR TITLE
Afficher le PDF source directement sur la fiche pré-commande

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PreOrdersController extends Controller
 {
@@ -156,6 +157,10 @@ class PreOrdersController extends Controller
     {
         $preOrder->load('lines', 'convertedOrder');
 
+        $sourcePdfUrl = $this->resolveSourcePdfPath($preOrder)
+            ? route('pre-orders.source-pdf', $preOrder)
+            : null;
+
         return view('workflow.pre-orders-show', [
             'preOrder' => $preOrder,
             'companies' => Companies::orderBy('code')->get(),
@@ -168,7 +173,24 @@ class PreOrdersController extends Controller
             'defaultUnit' => MethodsUnits::where('default', 1)->first(),
             'defaultVat' => AccountingVat::where('default', 1)->first(),
             'generatedOrderCode' => $this->generateOrderCodeByType(1),
+            'sourcePdfUrl' => $sourcePdfUrl,
         ]);
+    }
+
+    public function sourcePdf(PreOrder $preOrder): StreamedResponse
+    {
+        $sourcePdfPath = $this->resolveSourcePdfPath($preOrder);
+
+        abort_if($sourcePdfPath === null, 404);
+
+        return Storage::disk(config('filesystems.default'))->response(
+            $sourcePdfPath,
+            basename($sourcePdfPath),
+            [
+                'Content-Type' => 'application/pdf',
+                'Content-Disposition' => 'inline; filename="' . basename($sourcePdfPath) . '"',
+            ]
+        );
     }
 
     public function convert(Request $request, PreOrder $preOrder)
@@ -258,5 +280,31 @@ class PreOrdersController extends Controller
         $documentType = $type === 2 ? 'internal-order' : 'order';
 
         return $this->documentCodeGenerator->generateDocumentCode($documentType, (int) $lastOrderId);
+    }
+
+    private function resolveSourcePdfPath(PreOrder $preOrder): ?string
+    {
+        $sourcePdfName = basename(trim((string) $preOrder->source_pdf));
+
+        if ($sourcePdfName === '' || ! Str::of($sourcePdfName)->lower()->endsWith('.pdf')) {
+            return null;
+        }
+
+        $disk = Storage::disk(config('filesystems.default'));
+        $paths = [
+            $this->resolveInputPath((string) config('pre_orders.input_path', 'pre-orders/input')),
+            trim((string) config('pre_orders.output_path', 'output'), '/'),
+            trim((string) config('pre_orders.done_path', 'output/done'), '/'),
+        ];
+
+        foreach ($paths as $path) {
+            $candidate = trim($path . '/' . $sourcePdfName, '/');
+
+            if ($disk->exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 }

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -56,6 +56,25 @@
                     </table>
                 </div>
             </x-adminlte-card>
+
+            <x-adminlte-card title="PDF source" theme="info" maximizable class="mt-3">
+                @if($sourcePdfUrl)
+                    <div class="mb-2">
+                        <a href="{{ $sourcePdfUrl }}" target="_blank" rel="noopener" class="btn btn-default btn-sm">
+                            <i class="fas fa-external-link-alt mr-1"></i> Ouvrir dans un nouvel onglet
+                        </a>
+                    </div>
+                    <iframe
+                        src="{{ $sourcePdfUrl }}#toolbar=1&navpanes=0"
+                        title="PDF source de la pré-commande"
+                        width="100%"
+                        height="700"
+                        style="border: 1px solid #dee2e6; border-radius: .25rem;"
+                    ></iframe>
+                @else
+                    <p class="text-muted mb-0">PDF source introuvable pour cette pré-commande.</p>
+                @endif
+            </x-adminlte-card>
         </div>
         <div class="col-lg-4">
             <x-adminlte-card title="Transformation en commande" theme="lightblue">

--- a/routes/web.php
+++ b/routes/web.php
@@ -183,6 +183,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/', 'App\Http\Controllers\Workflow\PreOrdersController@index')->name('pre-orders.index');
         Route::post('/upload', 'App\Http\Controllers\Workflow\PreOrdersController@upload')->name('pre-orders.upload');
         Route::get('/{preOrder}', 'App\Http\Controllers\Workflow\PreOrdersController@show')->name('pre-orders.show');
+        Route::get('/{preOrder}/source-pdf', 'App\Http\Controllers\Workflow\PreOrdersController@sourcePdf')->name('pre-orders.source-pdf');
         Route::post('/{preOrder}/convert', 'App\Http\Controllers\Workflow\PreOrdersController@convert')->name('pre-orders.convert');
     });
 


### PR DESCRIPTION
### Motivation
- Permettre à l'utilisateur de visualiser directement le PDF d'origine lié à une pré-commande depuis sa fiche sans télécharger manuellement le fichier.

### Description
- Ajoute une route `pre-orders.source-pdf` qui sert le PDF source avec `Content-Disposition: inline` (fichier exposé en aperçu). 
- Étend `PreOrdersController` pour résoudre de manière sécurisée le nom du PDF (`basename`, vérification de l'extension `.pdf`) dans les emplacements configurés (`input_path`, `output_path`, `done_path`) et ajoute l'action `sourcePdf()` qui renvoie la réponse du disque.
- Injecte `sourcePdfUrl` dans la vue `pre-orders.show` et met à jour `resources/views/workflow/pre-orders-show.blade.php` pour afficher une carte « PDF source » contenant un bouton d'ouverture dans un nouvel onglet et un `iframe` d'aperçu, avec fallback si le PDF est introuvable.
- Fichiers modifiés : `app/Http/Controllers/Workflow/PreOrdersController.php`, `routes/web.php`, `resources/views/workflow/pre-orders-show.blade.php`.

### Testing
- Lint PHP sur les fichiers modifiés avec `php -l app/Http/Controllers/Workflow/PreOrdersController.php` et `php -l routes/web.php` a réussi.
- Tentative dister la route avec `php artisan route:list --name=pre-orders.source-pdf` a échoué pour des raisons d'environnement (dépendances `vendor` manquantes), donc la vérification runtime de route n'a pas pu être effectuée.
- Une capture automatisée via Playwright a été produite pour inspection visuelle, mais l'application locale n'était pas démarrée ce qui limite la validation end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0c488f90832db51c2ae511b4914f)