### PR TITLE
Rename companies.update route to companies.edit.update to fix route name collision

### DIFF
--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -116,7 +116,7 @@
         <div class="row">
           <div class="col-md-9">
             @include('include.alert-result')
-            <form method="POST" action="{{ route('companies.update', ['id' => $Companie->id]) }}" enctype="multipart/form-data">
+            <form method="POST" action="{{ route('companies.edit.update', ['id' => $Companie->id]) }}" enctype="multipart/form-data">
               @csrf
               <x-adminlte-card title="{{ __('general_content.general_information_trans_key') }}" theme="primary" maximizable>
                 <div class="row">

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,7 +94,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         });
     
         Route::post('/import', 'App\Http\Controllers\Admin\ImportsExportsController@importCompanies')->name('companies.import');
-        Route::post('/edit/{id}', 'App\Http\Controllers\Companies\CompaniesController@update')->name('companies.update');
+        Route::post('/edit/{id}', 'App\Http\Controllers\Companies\CompaniesController@update')->name('companies.edit.update');
         Route::get('/{id}', 'App\Http\Controllers\Companies\CompaniesController@show')->name('companies.show');
 
         Route::get('/store/quote/{id}', 'App\Http\Controllers\Companies\CompaniesController@storeQuote')->name('companies.store.quote');


### PR DESCRIPTION
### Motivation
- Prevent a duplicate route name collision on `companies.update` that caused Laravel to fail when serializing/caching routes and led to container restart loops.

### Description
- Renamed the POST edit route in `routes/web.php` from `companies.update` to `companies.edit.update` and updated the company edit form in `resources/views/companies/companies-show.blade.php` to use the new route name.

### Testing
- Ran syntax checks with `php -l` on the modified files which passed, searched the codebase for remaining `companies.update` usages which no longer appear, and attempted `php artisan route:cache` which could not be executed in this environment due to missing `vendor/autoload.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7344960c832db6ce323578b3fbe8)