### PR TITLE
Ajout de filtres order_ref uniques et affichage order_ref sur l'écran TaskLines

### DIFF
--- a/app/Livewire/TaskLines.php
+++ b/app/Livewire/TaskLines.php
@@ -22,6 +22,7 @@ class TaskLines extends Component
     public $sortAsc = true; // default sort direction
     public $ShowGenericTask = false;
     public $selectedStatuses = [];
+    public $selectedOrderRef = '';
 
     public $Tasklist;
     public $Factory = [];
@@ -40,6 +41,16 @@ class TaskLines extends Component
     public function updatingSearch()
     {
         $this->resetPage();
+    }
+
+    public function filterByOrderRef(string $orderRef): void
+    {
+        $this->selectedOrderRef = $orderRef;
+    }
+
+    public function clearOrderRefFilter(): void
+    {
+        $this->selectedOrderRef = '';
     }
     
     public function mount() 
@@ -69,61 +80,89 @@ class TaskLines extends Component
 
     public function render()
     {
-        
         $ServicesSelect = MethodsServices::select('id', 'label')->orderBy('ordre')->get();
         $StatusSelect = Status::orderBy('order', 'ASC')->get();
         $RessourceSelect = MethodsRessources::select('id', 'label')->orderBy('label')->get();
 
-        if($this->ShowGenericTask){
-            $Tasklist = $this->Tasklist = Task::with('OrderLines.order')
-                                        ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
-                                        ->orWhere(
-                                            function($query) {
-                                                return $query // Tasks with non-null id lines
-                                                        ->whereNull('quote_lines_id')
-                                                        ->whereNull('order_lines_id')
-                                                        ->whereNull('products_id') //https://github.com/SMEWebify/WebErpMesv2/issues/334
-                                                        ->whereNull('sub_assembly_id');
-                                        })
-                                        ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
-                                        ->where('label','like', '%'.$this->search.'%')
-                                        ->when($this->searchIdRessource, function($query){
-                                            $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
-                                        })
-                                        ->when($this->selectedStatuses, function($query){
-                                            $query->whereIn('status_id', $this->selectedStatuses);
-                                        })
-                                        ->get();
-        }
-        else{
-            $Tasklist = $this->Tasklist = Task::with('OrderLines.order')
-                            ->where(function ($query) {
-                                $query->where(function ($query) {
-                                    $query->whereNotNull('sub_assembly_id')
-                                            ->whereHas('SubAssembly', function ($query) {
-                                                $query->whereNotNull('order_lines_id');
-                                            });
-                                })
-                                ->orWhereNotNull('order_lines_id'); // Combine 'or' within the first 'where'
-                            })
-                            ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
-                            ->where('label', 'like', '%'.$this->search.'%')
-                            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
-                            ->when($this->searchIdRessource, function($query){
-                                $query->whereHas('resources', fn($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
-                            })
-                            ->when($this->selectedStatuses, function($query){
-                                $query->whereIn('status_id', $this->selectedStatuses);
-                            })
-                            ->get();
+        $taskQuery = $this->buildTaskQuery();
 
+        $availableOrderRefs = (clone $taskQuery)
+            ->get()
+            ->map(function ($task) {
+                if ($task->SubAssembly && $task->SubAssembly->order_lines_id) {
+                    return $task->SubAssembly->OrderLines->order->code ?? null;
+                }
+
+                return $task->OrderLines->order->code ?? null;
+            })
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
+
+        if ($this->selectedOrderRef) {
+            $taskQuery->where(function ($query) {
+                $query->whereHas('OrderLines.order', function ($orderQuery) {
+                    $orderQuery->where('code', $this->selectedOrderRef);
+                })->orWhereHas('SubAssembly.OrderLines.order', function ($orderQuery) {
+                    $orderQuery->where('code', $this->selectedOrderRef);
+                });
+            });
         }
+
+        $Tasklist = $this->Tasklist = $taskQuery
+            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+            ->get();
 
         return view('livewire.task-lines', [
             'Tasklist' => $Tasklist,
             'ServicesSelect' => $ServicesSelect,
             'StatusSelect' => $StatusSelect,
             'RessourceSelect' => $RessourceSelect,
+            'availableOrderRefs' => $availableOrderRefs,
         ]);
+    }
+
+    private function buildTaskQuery()
+    {
+        $query = Task::with(['OrderLines.order', 'SubAssembly.OrderLines.order']);
+
+        if ($this->ShowGenericTask) {
+            $query->where(function ($query) {
+                $query->where(function ($query) {
+                    $query->whereNotNull('sub_assembly_id')
+                        ->whereHas('SubAssembly', function ($query) {
+                            $query->whereNotNull('order_lines_id');
+                        });
+                })
+                ->orWhereNotNull('order_lines_id')
+                ->orWhere(function ($query) {
+                    $query->whereNull('quote_lines_id')
+                        ->whereNull('order_lines_id')
+                        ->whereNull('products_id')
+                        ->whereNull('sub_assembly_id');
+                });
+            });
+        } else {
+            $query->where(function ($query) {
+                $query->where(function ($query) {
+                    $query->whereNotNull('sub_assembly_id')
+                        ->whereHas('SubAssembly', function ($query) {
+                            $query->whereNotNull('order_lines_id');
+                        });
+                })
+                ->orWhereNotNull('order_lines_id');
+            });
+        }
+
+        return $query
+            ->where('methods_services_id', 'like', '%'.$this->searchIdService.'%')
+            ->where('label', 'like', '%'.$this->search.'%')
+            ->when($this->searchIdRessource, function ($query) {
+                $query->whereHas('resources', fn ($q) => $q->where('methods_ressources.id', $this->searchIdRessource));
+            })
+            ->when($this->selectedStatuses, function ($query) {
+                $query->whereIn('status_id', $this->selectedStatuses);
+            });
     }
 }

--- a/resources/views/livewire/task-lines.blade.php
+++ b/resources/views/livewire/task-lines.blade.php
@@ -85,6 +85,21 @@
                     </div>
                 </div>
             </div>
+            <div class="row px-3 pb-2">
+                <div class="col-12">
+                    <label class="mb-2">Order ref</label>
+                    <div class="d-flex flex-wrap" style="gap: 8px;">
+                        <button type="button" class="btn btn-sm {{ $selectedOrderRef === '' ? 'btn-primary' : 'btn-outline-primary' }}" wire:click="clearOrderRefFilter">
+                            Tous
+                        </button>
+                        @foreach ($availableOrderRefs as $orderRef)
+                            <button type="button" class="btn btn-sm {{ $selectedOrderRef === $orderRef ? 'btn-primary' : 'btn-outline-primary' }}" wire:click="filterByOrderRef('{{ $orderRef }}')">
+                                {{ $orderRef }}
+                            </button>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
             <div class="table-responsive p-0">
                 <table class="table table-hover">
                     <thead>
@@ -113,14 +128,12 @@
                         @forelse ($Tasklist as $Task)
                         <tr > 
                             <td>
-                                @if($Task->SubAssembly) <!-- Checks if the task is linked to a subset -->
-                                    @if($Task->SubAssembly->order_lines_id) <!-- Checks if the subset is linked to a command line -->
-                                        <x-OrderButton id="{{ $Task->SubAssembly->OrderLines->orders_id }}" code="{{ $Task->SubAssembly->OrderLines->order->code }}"  />
-                                    @endif
-                                @elseif($Task->OrderLines) <!-- If the task is linked directly to a command line -->
-                                    <x-OrderButton id="{{ $Task->OrderLines->orders_id }}" code="{{ $Task->OrderLines->order->code }}"  /> 
+                                @if($Task->SubAssembly && $Task->SubAssembly->order_lines_id)
+                                    {{ $Task->SubAssembly->OrderLines->order->code }}
+                                @elseif($Task->OrderLines)
+                                    {{ $Task->OrderLines->order->code }}
                                 @else
-                                    {{__('general_content.generic_trans_key') }} <!-- Otherwise, it's a generic task -->
+                                    {{__('general_content.generic_trans_key') }}
                                 @endif
                             </td>
                             @if($Task->SubAssembly)


### PR DESCRIPTION
### Motivation
- Permettre de filtrer rapidement la liste des tâches/jobs par référence de commande (`order_ref`) et d'afficher seulement cette référence dans la colonne commande pour une lecture plus simple.

### Description
- Ajout d'un état `selectedOrderRef` et des actions `filterByOrderRef` / `clearOrderRefFilter` dans le composant Livewire `TaskLines` pour gérer le filtre par référence de commande.
- Refactorisation de la construction de la requête en `buildTaskQuery()` pour centraliser la logique de filtrage et pouvoir appliquer proprement le filtre `order_ref` sur les relations `OrderLines.order` et `SubAssembly.OrderLines.order`.
- Calcul des références de commande uniques disponibles (`availableOrderRefs`) à partir du jeu de résultats courant et exposition à la vue pour générer des boutons de filtrage rapides.
- Mise à jour de la vue `resources/views/livewire/task-lines.blade.php` pour afficher les boutons de filtre `order_ref` (y compris un bouton « Tous ») et remplacer le composant bouton/lien de commande par l'affichage direct de la `order->code` dans la colonne commande.

### Testing
- Lint PHP avec `php -l app/Livewire/TaskLines.php` a réussi.
- Exécution des tests avec `php artisan test --filter=TaskLines --stop-on-failure` a échoué en environnement CI local à cause de l'absence du dossier `vendor` (`vendor/autoload.php` manquant), donc les tests unitaires/feature n'ont pas pu s'exécuter ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8e6dfe0c832dbf1e3b92c63aa63d)