### PR TITLE
Namespace API companies resource route names to avoid collision

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::middleware('auth:api')->group(function () {
 
-    Route::apiResource('companies', CompanyController::class);
+    Route::apiResource('companies', CompanyController::class)->names('api.companies');
 
     Route::apiResource('quote', QuoteController::class);
     Route::apiResource('order', OrderController::class);


### PR DESCRIPTION
### Motivation
- Resolve the route serialization error caused by duplicate route name `companies.show` when both web and API resources generate the same route name.

### Description
- Updated `routes/api.php` to change `Route::apiResource('companies', CompanyController::class)` to `Route::apiResource('companies', CompanyController::class)->names('api.companies')` so API routes are generated as `api.companies.*` and no longer collide with web route names.

### Testing
- Ran `php artisan route:list --name=companies.show`, which could not be executed in this environment due to missing Composer dependencies (`vendor/autoload.php`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ca5d73b8832dbb03b1b717decd56)