### PR TITLE
Avoid duplicate named routes for energy-consumptions API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -34,7 +34,9 @@ Route::middleware('auth:api')->group(function () {
     Route::apiResource('quote', QuoteController::class);
     Route::apiResource('order', OrderController::class);
     Route::apiResource('tasks', TaskController::class);
-    Route::apiResource('energy-consumptions', EnergyConsumptionController::class)->only(['index','store']);
+    Route::apiResource('energy-consumptions', EnergyConsumptionController::class)
+        ->only(['index','store'])
+        ->names('api.energy-consumptions');
 
     Route::get('/exports/sales-orders', ExportSalesOrderController::class);
 


### PR DESCRIPTION
### Motivation
- Prevent a `LogicException` during route serialization caused by the API resource routes for `energy-consumptions` colliding with existing web route names like `energy-consumptions.index`.

### Description
- Updated the API resource registration in `routes/api.php` for `energy-consumptions` to chain `->names('api.energy-consumptions')` so API routes are named with the `api.energy-consumptions.*` prefix.
- Reformatted the `Route::apiResource` call to a multi-line chain and restricted it to `->only(['index','store'])` as before.

### Testing
- Attempted to run `php artisan route:list --name=energy-consumptions`, but the command failed because `vendor/autoload.php` is missing so Laravel cannot be bootstrapped in this environment. (failure)
- Performed a local inspection of `routes/api.php` to confirm the `->names('api.energy-consumptions')` addition is present and correctly applied. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cc907d24832d9259bf78c71b976a)