### PR TITLE
Add bulk price increase for quote and order lines (UI + Livewire handlers + i18n)

### DIFF
--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -77,6 +77,7 @@ class OrderLine extends Component
     public $RemoveFromStock = false;
     public $CreateSerialNumber = false;
     public $selectAllLines = false;
+    public $priceIncreaseAmount = 0;
     
     private $deleveryOrdre = 10;
     private $invoiceOrdre = 10;
@@ -291,6 +292,29 @@ class OrderLine extends Component
         $this->customRequirements[$detailId][] = ['label' => '', 'value' => ''];
     }
 
+
+    public function applyPriceIncreaseToAllLines(): void
+    {
+        if ((int) $this->order_Statu === 6 || (int) $this->OrderType === 2) {
+            session()->flash('error', __('general_content.order_canceled_no_document_trans_key'));
+            return;
+        }
+
+        $this->validate([
+            'priceIncreaseAmount' => 'required|numeric|gt:0',
+        ]);
+
+        $updatedLines = OrderLines::where('orders_id', $this->orders_id)
+            ->increment('selling_price', (float) $this->priceIncreaseAmount);
+
+        if ($updatedLines === 0) {
+            session()->flash('error', __('general_content.no_data_trans_key'));
+            return;
+        }
+
+        $this->priceIncreaseAmount = 0;
+        session()->flash('success', __('general_content.price_increase_applied_trans_key', ['count' => $updatedLines]));
+    }
     public function removeCustomRequirement($detailId, $index): void
     {
         if (!isset($this->customRequirements[$detailId][$index])) {

--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -70,6 +70,7 @@ class QuoteLine extends Component
     public $data = [];
     public $customRequirements = [];
     public $selectAllLines = false;
+    public $priceIncreaseAmount = 0;
 
     protected $orderService;
 
@@ -252,6 +253,29 @@ class QuoteLine extends Component
         }
 
         $this->customRequirements[$detailId][] = ['label' => '', 'value' => ''];
+    }
+
+    public function applyPriceIncreaseToAllLines(): void
+    {
+        if ((int) $this->quote_Statu !== 1) {
+            session()->flash('error', __('general_content.quote_not_open_trans_key'));
+            return;
+        }
+
+        $this->validate([
+            'priceIncreaseAmount' => 'required|numeric|gt:0',
+        ]);
+
+        $updatedLines = QuoteLines::where('quotes_id', $this->quotes_id)
+            ->increment('selling_price', (float) $this->priceIncreaseAmount);
+
+        if ($updatedLines === 0) {
+            session()->flash('error', __('general_content.no_data_trans_key'));
+            return;
+        }
+
+        $this->priceIncreaseAmount = 0;
+        session()->flash('success', __('general_content.price_increase_applied_trans_key', ['count' => $updatedLines]));
     }
 
     private function loadProductCustomFields($quoteLines): void

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -784,6 +784,10 @@ return [
     'new_quote_trans_key'                      => 'New Quote',
     'select_all_lines_trans_key'               => 'Select all',
     'deselect_all_lines_trans_key'             => 'Deselect all',
+
+    'price_increase_amount_trans_key'          => 'Amount to add',
+    'apply_price_increase_to_lines_trans_key'  => 'Add amount to lines',
+    'price_increase_applied_trans_key'         => 'Price increase applied to :count line(s).',
     'header_line_ask_trans_key'                => 'Header line ?',
     'quote_not_open_trans_key'                 => 'Quote curently not open',
     'name_quote_trans_key'                     => 'Name of quote',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -784,6 +784,10 @@ return [
     'new_quote_trans_key'                      => 'Nouveau devis',
     'select_all_lines_trans_key'               => 'Tout sélectionner',
     'deselect_all_lines_trans_key'             => 'Tout désélectionner',
+
+    'price_increase_amount_trans_key'          => 'Montant à ajouter',
+    'apply_price_increase_to_lines_trans_key'  => 'Ajouter montant aux lignes',
+    'price_increase_applied_trans_key'         => 'Majoration appliquée à :count ligne(s).',
     'header_line_ask_trans_key'                => 'En-tête ?',
     'quote_not_open_trans_key'                 => 'Devis actuellement non ouvert',
     'name_quote_trans_key'                     => 'Nom du devis',

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -29,6 +29,24 @@
                     @include('include.search-card')
                 </div>
             </div>
+            <div class="row mb-3">
+                <div class="col-md-8">
+                    <div class="input-group">
+                        <input type="number" step="0.01" min="0" class="form-control"
+                               wire:model.live="priceIncreaseAmount"
+                               placeholder="{{ __('general_content.price_increase_amount_trans_key') }}"
+                               @disabled($OrderStatu == 6 || $OrderType == 2)>
+                        <div class="input-group-append">
+                            <button class="btn btn-primary" type="button" wire:click="applyPriceIncreaseToAllLines" @disabled($OrderStatu == 6 || $OrderType == 2)>
+                                <i class="fas fa-plus-circle"></i> {{ __('general_content.apply_price_increase_to_lines_trans_key') }}
+                            </button>
+                        </div>
+                    </div>
+                    @error('priceIncreaseAmount')
+                        <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                </div>
+            </div>
             <div class="table-responsive p-0">
                 <table class="table table-hover">
                     <thead>

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -27,6 +27,24 @@
                     @include('include.search-card')
                 </div>
             </div>
+            <div class="row mb-3">
+                <div class="col-md-8">
+                    <div class="input-group">
+                        <input type="number" step="0.01" min="0" class="form-control"
+                               wire:model.live="priceIncreaseAmount"
+                               placeholder="{{ __('general_content.price_increase_amount_trans_key') }}"
+                               @disabled($QuoteStatu != 1)>
+                        <div class="input-group-append">
+                            <button class="btn btn-primary" type="button" wire:click="applyPriceIncreaseToAllLines" @disabled($QuoteStatu != 1)>
+                                <i class="fas fa-plus-circle"></i> {{ __('general_content.apply_price_increase_to_lines_trans_key') }}
+                            </button>
+                        </div>
+                    </div>
+                    @error('priceIncreaseAmount')
+                        <span class="text-danger">{{ $message }}</span>
+                    @enderror
+                </div>
+            </div>
             <div class="table-responsive p-0">
                 <table class="table table-hover">
                     <thead>


### PR DESCRIPTION
### Motivation
- Provide a convenient way to add an absolute amount to the unit price of all lines in a quote or order to avoid editing ~100 lines one-by-one.

### Description
- Added a numeric input and action button to the quotes and orders lines views (`resources/views/livewire/quote-lines.blade.php`, `resources/views/livewire/order-lines.blade.php`) to enter an amount and trigger the bulk update, with the control disabled when the document state prevents changes.
- Implemented `priceIncreaseAmount` property and `applyPriceIncreaseToAllLines()` on both Livewire components (`app/Livewire/QuoteLine.php`, `app/Livewire/OrderLine.php`) to validate the amount and perform a DB-side `->increment('selling_price', $amount)` on the corresponding lines, then reset the input and flash success/error messages.
- Added i18n keys for the new UI and messages in English and French (`resources/lang/en/general_content.php`, `resources/lang/fr/general_content.php`).
- The components guard against applying the change when the quote is not open or when the order is cancelled / internal, and they validate the amount as `required|numeric|gt:0` before applying.

### Testing
- No automated tests were executed as part of this change; manual verification was used during development (file updates, view injection, and basic validation flows).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b046b9d668832dbcba020a6e7cadef)