### PR TITLE
Use in-memory SQLite for PHPUnit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,12 +12,9 @@
     <php>
         <env name="APP_ENV" value="testing"/>
 
-        <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_HOST" value="127.0.0.1"/>
-        <env name="DB_PORT" value="3306"/>
-        <env name="DB_DATABASE" value="weberpmesv2_testing"/>
-        <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value=""/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_FOREIGN_KEYS" value="true"/>
 
         <!-- Neutralise Redis -->
         <env name="CACHE_DRIVER" value="array"/>


### PR DESCRIPTION
### Motivation
- Replace the external MySQL test database with an in-memory SQLite database to simplify CI/local testing and remove dependency on an external DB.

### Description
- Update `phpunit.xml` to set `DB_CONNECTION` to `sqlite`, `DB_DATABASE` to `:memory:`, and add `DB_FOREIGN_KEYS` = `true`, removing MySQL-specific `DB_HOST`, `DB_PORT`, `DB_USERNAME`, and `DB_PASSWORD` entries.
- Preserve existing neutralization of external services by keeping `CACHE_DRIVER`, `SESSION_DRIVER`, `QUEUE_CONNECTION`, and `BROADCAST_DRIVER` settings.

### Testing
- Ran the PHPUnit test suite (`phpunit`) with the new configuration and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1bccc9bf4832db65f2a7f4745c791)