### PR TITLE
Hide Assets tab in Accounting when user lacks asset permission

### DIFF
--- a/resources/views/accounting/accounting-index.blade.php
+++ b/resources/views/accounting/accounting-index.blade.php
@@ -20,7 +20,9 @@
       <li class="nav-item"><a class="nav-link" href="#VAT" data-toggle="tab">{{ __('general_content.vat_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#AccountingAllocations" data-toggle="tab">{{ __('general_content.accounting_allocations_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Delevery" data-toggle="tab">{{ __('general_content.delevery_method_trans_key') }}</a></li>
+      @can('asset-menu')
       <li class="nav-item"><a class="nav-link" href="#Assets" data-toggle="tab">{{ __('general_content.assets_trans_key') }}</a></li>
+      @endcan
     </ul>
   </div>
   <!-- /.card-header -->
@@ -714,9 +716,11 @@
       <!-- /.row -->
     </div>
     <!-- /.tab-pane -->
+    @can('asset-menu')
     <div class="tab-pane" id="Assets">
       @include('assets.partials.assets-list', ['assets' => $Assets])
     </div>
+    @endcan
   </div>
   <!-- /.card -->
 </div>


### PR DESCRIPTION
### Motivation
- Prevent the Assets tab and its content from being visible in the Accounting page to users who do not have the `asset-menu` permission to avoid exposing asset UI elements without authorization.

### Description
- Wrap the Assets navigation item and the Assets tab pane in `resources/views/accounting/accounting-index.blade.php` with `@can('asset-menu')` so the tab and its included partial are only rendered for authorized users.

### Testing
- Ran `php -l resources/views/accounting/accounting-index.blade.php` and it reported no syntax errors.
- Captured a UI screenshot via Playwright (`artifacts/accounting-assets-permission.png`) to validate the tab is hidden in the rendered page for the test context.
- Verified the change with `git diff -- resources/views/accounting/accounting-index.blade.php` which shows the added `@can` guards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ccaf82d4832db32bee8bdf2a3722)