### PR TITLE
Add GED (Documents) and Reports menu permissions

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -671,6 +671,7 @@ return [
             'icon' => 'fas fa-folder-open',
             'icon_color' => 'cyan',
             'url'  => 'documents',
+            'can'  => ['documents-menu'],
         ],
         [
             'text' => 'osh_trans_key',
@@ -704,6 +705,7 @@ return [
             'icon' => 'fas fa-chart-pie',
             'icon_color' => 'purple',
             'url'  => 'reports',
+            'can'  => ['reports-menu'],
             'submenu' => [
                 [
                     'text' => 'dashboard_trans_key',

--- a/database/seeders/PermissionTableSeeder.php
+++ b/database/seeders/PermissionTableSeeder.php
@@ -31,6 +31,8 @@ class PermissionTableSeeder  extends Seeder
                         'methods-menu',
                         'accounting-menu',
                         'human-resources-menu',
+                        'documents-menu',
+                        'reports-menu',
                         'osh-menu',
                         'your-company-menu',
                         'asset_manager',


### PR DESCRIPTION
### Motivation
- Allow role-based control over visibility of the GED/Documents and Reports sidebar items so menus can be shown/hidden per factory roles.

### Description
- Added `'can' => ['documents-menu']` to the Documents entry and `'can' => ['reports-menu']` to the Reports entry in `config/adminlte.php`, and registered `documents-menu` and `reports-menu` in `database/seeders/PermissionTableSeeder.php`.

### Testing
- Ran `php -l config/adminlte.php` and `php -l database/seeders/PermissionTableSeeder.php` which passed, and attempted `php artisan serve` which failed due to missing `vendor/autoload.php` (Composer dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1cccf7e20832dae676b2bb060b845)