### PR TITLE
Align PHPUnit DB env with CI MySQL credentials

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,9 +15,9 @@
         <env name="DB_CONNECTION" value="mysql"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3306"/>
-        <env name="DB_DATABASE" value="weberpmesv2_testing"/>
-        <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value=""/>
+        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_USERNAME" value="test"/>
+        <env name="DB_PASSWORD" value="test"/>
 
         <!-- Neutralise Redis -->
         <env name="CACHE_DRIVER" value="array"/>


### PR DESCRIPTION
### Motivation
- Align PHPUnit test environment DB settings with the MySQL service configured in CI to avoid mismatched credentials between the migration step and the test run.

### Description
- Updated `phpunit.xml` to set `DB_DATABASE` to `testing`, `DB_USERNAME` to `test`, and `DB_PASSWORD` to `test` so the PHPUnit environment matches `.github/workflows/ci.yml`.

### Testing
- Validated that `phpunit.xml` parses with `php -r 'simplexml_load_file("phpunit.xml")'` which succeeded, and attempted `composer install` and `./vendor/bin/phpunit` but those failed in this environment due to a missing `ext-ldap` extension and an incompatible local PHP version so vendor binaries were not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ce840efc832da9bb2b53718da74c)