### PR TITLE
feat: toggle /pre-orders menu entry via PRE_ORDERS_MENU_ENABLED env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@ LDAP_TLS=false
 LDAP_SASL=false
 
 # Pre-orders import watcher
+PRE_ORDERS_MENU_ENABLED=false
 PRE_ORDERS_OUTPUT_PATH=output
 PRE_ORDERS_FILE_PATTERN=invoices_info*.csv
 PRE_ORDERS_PYTHON_EXECUTABLE=

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -378,6 +378,12 @@ return [
                     'url'  => 'production/calendar/orders',
                     'icon_color' => 'info',
                 ],
+                [
+                    'text' => 'pre_orders_trans_key',
+                    'url'  => 'pre-orders',
+                    'icon_color' => 'primary',
+                    'enabled' => (bool) config('pre_orders.menu_enabled', false),
+                ],
             ]
         ],
         [

--- a/config/pre_orders.php
+++ b/config/pre_orders.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'menu_enabled' => env('PRE_ORDERS_MENU_ENABLED', false),
     'input_path' => env('PRE_ORDERS_INPUT_PATH', 'pre-orders/input'),
     'output_path' => env('PRE_ORDERS_OUTPUT_PATH', 'output'),
     'file_pattern' => env('PRE_ORDERS_FILE_PATTERN', '*.csv'),

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -839,6 +839,7 @@ return [
     'order_confirm_trans_key'                  => 'Order Confirm',
     'internal_order_trans_key'                 => 'Internal order',
     'new_order_trans_key'                      => 'New order',
+    'pre_orders_trans_key'                    => 'Pre-orders',
     'new_pre_order_trans_key'                  => 'New pre-order',
     'name_order_trans_key'                     => 'Name of order',
     'historical_trans_key'                     => 'Historical',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -839,6 +839,7 @@ return [
     'order_confirm_trans_key'                  => 'Confirmation de commande',
     'internal_order_trans_key'                 => 'Commande interne',
     'new_order_trans_key'                      => 'Nouvelle commande',
+    'pre_orders_trans_key'                    => 'Pré-commandes',
     'new_pre_order_trans_key'                  => 'Nouvelle pré-commande',
     'name_order_trans_key'                     => 'Nom de la commande',
     'historical_trans_key'                     => 'Historique',


### PR DESCRIPTION
### Motivation
- Allow the `/pre-orders` menu entry to be shown or hidden without code changes by toggling an environment variable.

### Description
- Add `pre_orders.menu_enabled` configuration driven by the `PRE_ORDERS_MENU_ENABLED` env variable in `config/pre_orders.php`.
- Inject a `pre-orders` entry into the Orders submenu in `config/adminlte.php` with `enabled => (bool) config('pre_orders.menu_enabled', false)` so the item is conditionally displayed.
- Document the new flag in `.env.example` by adding `PRE_ORDERS_MENU_ENABLED=false`.
- Add `pre_orders_trans_key` translation keys in `resources/lang/en/general_content.php` and `resources/lang/fr/general_content.php` for i18n-compatible menu text.

### Testing
- Ran PHP syntax checks `php -l` on modified files (`config/pre_orders.php`, `config/adminlte.php`, `resources/lang/fr/general_content.php`, `resources/lang/en/general_content.php`) and they reported no syntax errors.
- Captured a UI snapshot with a Playwright script to validate the menu render path (screenshot artifact produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d1d67488832d8d8642e58bc0722b)