### PR TITLE
UI: remove view-toggle text labels so buttons stay on one line

### DIFF
--- a/resources/views/livewire/leads-index.blade.php
+++ b/resources/views/livewire/leads-index.blade.php
@@ -4,13 +4,13 @@
         <!-- View toggle button -->
         <div class="col-2">
             <button class="btn {{ $viewType === 'table' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('table')">
-                <i class="fas fa-table mr-1"></i> Table
+                <i class="fas fa-table" title="Table" aria-label="Table"></i>
             </button>
             <button class="btn {{ $viewType === 'cards' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('cards')">
-                <i class="fas fa-th-large mr-1"></i> Cards
+                <i class="fas fa-th-large" title="Cards" aria-label="Cards"></i>
             </button>
             <button class="btn {{ $viewType === 'kanban' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('kanban')">
-                <i class="fas  fa-tasks mr-1"></i> Kanban
+                <i class="fas fa-tasks" title="Kanban" aria-label="Kanban"></i>
             </button>
         </div>
         <div class="col-6">

--- a/resources/views/livewire/opportunities-index.blade.php
+++ b/resources/views/livewire/opportunities-index.blade.php
@@ -158,13 +158,13 @@
                 <!-- View toggle button -->
                 <div class="col-2">
                     <button class="btn {{ $viewType === 'table' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('table')">
-                        <i class="fas fa-table mr-1"></i> Table
+                        <i class="fas fa-table" title="Table" aria-label="Table"></i>
                     </button>
                     <button class="btn {{ $viewType === 'cards' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('cards')">
-                        <i class="fas fa-th-large mr-1"></i> Cards
+                        <i class="fas fa-th-large" title="Cards" aria-label="Cards"></i>
                     </button>
                     <button class="btn {{ $viewType === 'kanban' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('kanban')">
-                        <i class="fas  fa-tasks mr-1"></i> Kanban
+                        <i class="fas fa-tasks" title="Kanban" aria-label="Kanban"></i>
                     </button>
                 </div>
                 <div class="col-6">

--- a/resources/views/livewire/orders-index.blade.php
+++ b/resources/views/livewire/orders-index.blade.php
@@ -222,13 +222,13 @@
                 <!-- View toggle button -->
                 <div class="col-2">
                     <button class="btn {{ $viewType === 'table' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('table')">
-                        <i class="fas fa-table mr-1"></i> Table
+                        <i class="fas fa-table" title="Table" aria-label="Table"></i>
                     </button>
                     <button class="btn {{ $viewType === 'cards' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('cards')">
-                        <i class="fas fa-th-large mr-1"></i> Cards
+                        <i class="fas fa-th-large" title="Cards" aria-label="Cards"></i>
                     </button>
                     <button class="btn {{ $viewType === 'kanban' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('kanban')">
-                        <i class="fas  fa-tasks mr-1"></i> Kanban
+                        <i class="fas fa-tasks" title="Kanban" aria-label="Kanban"></i>
                     </button>
                 </div>
                 <div class="col-6">

--- a/resources/views/livewire/quotes-index.blade.php
+++ b/resources/views/livewire/quotes-index.blade.php
@@ -344,13 +344,13 @@
                 <!-- View toggle button -->
                 <div class="col-2">
                     <button class="btn {{ $viewType === 'table' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('table')">
-                        <i class="fas fa-table mr-1"></i> Table
+                        <i class="fas fa-table" title="Table" aria-label="Table"></i>
                     </button>
                     <button class="btn {{ $viewType === 'cards' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('cards')">
-                        <i class="fas fa-th-large mr-1"></i> Cards
+                        <i class="fas fa-th-large" title="Cards" aria-label="Cards"></i>
                     </button>
                     <button class="btn {{ $viewType === 'kanban' ? 'btn-primary' : 'btn-secondary' }}" wire:click="changeView('kanban')">
-                        <i class="fas  fa-tasks mr-1"></i> Kanban
+                        <i class="fas fa-tasks" title="Kanban" aria-label="Kanban"></i>
                     </button>
                 </div>
                 <div class="col-6">


### PR DESCRIPTION
### Motivation
- Reduce the width of the view-toggle controls so the three buttons remain on a single line in narrow layout columns.

### Description
- Replaced the `Table`, `Cards`, and `Kanban` text labels with icon-only markup in the view-toggle buttons of the index views. 
- Preserved accessibility by adding `title` and `aria-label` attributes to each icon. 
- Modified files: `resources/views/livewire/leads-index.blade.php`, `resources/views/livewire/opportunities-index.blade.php`, `resources/views/livewire/orders-index.blade.php`, and `resources/views/livewire/quotes-index.blade.php`.

### Testing
- Ran `git diff` to confirm only the toggle button markup changed and the diff matched expectations (success).
- Committed changes with `git commit` (success).
- Ran a Playwright script to open the app and capture a screenshot to validate the toggles appear compact and on one line; the screenshot artifact was produced (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d2e34fb8832d91c0e76d4aa02ef5)