### PR TITLE
Afficher la grille tarifaire client seulement si un produit est sélectionné

### DIFF
--- a/resources/views/livewire/form/customer-price-grid.blade.php
+++ b/resources/views/livewire/form/customer-price-grid.blade.php
@@ -1,3 +1,4 @@
+@if($product_id)
 <div class="mt-3">
     <div class="card card-outline card-info">
         <div class="card-header d-flex justify-content-between align-items-center">
@@ -11,9 +12,7 @@
             @if($priceSource)
                 <p class="mb-2"><strong>{{ __('general_content.price_source_trans_key') }}:</strong> {{ $priceSource }}</p>
             @endif
-            @if(!$product_id)
-                <p class="text-muted mb-0">{{ __('general_content.select_product_trans_key') }}</p>
-            @elseif(empty($customerPriceList))
+            @if(empty($customerPriceList))
                 <p class="text-muted mb-0">{{ __('general_content.no_price_defined_trans_key') }}</p>
             @else
                 <div class="table-responsive">
@@ -62,3 +61,4 @@
         </div>
     </div>
 </div>
+@endif


### PR DESCRIPTION
### Motivation
- Ne plus afficher la carte « Grille tarifaire client » tant qu'aucun article n'est sélectionné afin d'éviter le message intermédiaire "Sélectionner produit" et ne montrer la grille que lorsqu'un `product_id` est présent.

### Description
- Enveloppé le contenu de `resources/views/livewire/form/customer-price-grid.blade.php` avec une condition Blade `@if($product_id) ... @endif` et retiré le rendu du message `{{ __('general_content.select_product_trans_key') }}` puisque la carte est maintenant masquée quand aucun produit n'est choisi.

### Testing
- Exécuté `git diff --check` pour valider le diff et la vérification a réussi.
- Tentative de démarrer l'application via `php artisan serve --host=0.0.0.0 --port=8000` a échoué car les dépendances PHP sont manquantes (`vendor/autoload.php` introuvable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d3218f90832d8a25668c22bee671)