### PR TITLE
Hide Nest2Prod actions when `n2p_enabled` is false

### DIFF
--- a/resources/views/livewire/orders-index.blade.php
+++ b/resources/views/livewire/orders-index.blade.php
@@ -1,6 +1,7 @@
 
 <div>
     @php
+        $nest2prodEnabled = (bool) app(\App\Services\Settings\SettingsService::class)->get('n2p_enabled', false);
         $nest2prodUrl = rtrim((string) app(\App\Services\Settings\SettingsService::class)->get('n2p_base_url'), '/');
     @endphp
     <!-- Modal -->
@@ -343,7 +344,7 @@
                                 <td>
                                     <x-ButtonTextView route="{{ route('orders.show', ['id' => $Order->id])}}" />
                                     <x-ButtonTextPDF route="{{ route('pdf.order', ['Document' => $Order->id])}}" />
-                                    @if($Order->statu != 1 && $nest2prodUrl !== '')
+                                    @if($Order->statu != 1 && $nest2prodEnabled && $nest2prodUrl !== '')
                                         <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm">
                                             <i class="fas fa-external-link-alt"></i> Nest2Prod
                                         </a>
@@ -411,7 +412,7 @@
                                         </div>
                                         <div class="col-4">
                                             <x-ButtonTextView route="{{ route('orders.show', ['id' => $Order->id])}}" />
-                                            @if($Order->statu != 1 && $nest2prodUrl !== '')
+                                            @if($Order->statu != 1 && $nest2prodEnabled && $nest2prodUrl !== '')
                                                 <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm mt-1">
                                                     <i class="fas fa-external-link-alt"></i>
                                                 </a>
@@ -502,7 +503,7 @@
                                                             </div>
                                                             <div class="col-4">
                                                                 <x-ButtonTextView route="{{ route('orders.show', ['id' => $Order->id])}}" />
-                                                                @if($Order->statu != 1 && $nest2prodUrl !== '')
+                                                                @if($Order->statu != 1 && $nest2prodEnabled && $nest2prodUrl !== '')
                                                                     <a href="{{ $nest2prodUrl }}/fr/orders/{{ rawurlencode($Order->code) }}" rel="noopener" target="_blank" class="btn btn-info btn-sm mt-1">
                                                                         <i class="fas fa-external-link-alt"></i>
                                                                     </a>

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -266,6 +266,7 @@
               <div class="table-responsive p-0">
                 <table class="table table-hover">
                     @php
+                      $nest2prodEnabled = (bool) app(\App\Services\Settings\SettingsService::class)->get('n2p_enabled', false);
                       $nest2prodUrl = rtrim((string) app(\App\Services\Settings\SettingsService::class)->get('n2p_base_url'), '/');
                     @endphp
                     @if($Order->type == 1)
@@ -302,7 +303,7 @@
                         </form>
                       </td>
                     </tr>
-                    @if($Order->statu != 1 && $nest2prodUrl !== '')
+                    @if($Order->statu != 1 && $nest2prodEnabled && $nest2prodUrl !== '')
                     <tr>
                       <td style="width:50%">Nest2Prod</td>
                       <td>


### PR DESCRIPTION
### Motivation
- Prevent Nest2Prod links/tabs from appearing when the Nest2Prod integration is disabled by adding an explicit `n2p_enabled` check in the order views.

### Description
- Add a boolean `n2p_enabled` read from the settings service and require it alongside the existing `statu != 1` and non-empty base URL checks before rendering Nest2Prod links in `resources/views/livewire/orders-index.blade.php` and `resources/views/workflow/orders-show.blade.php`.

### Testing
- Ran `php artisan view:cache` to validate views but it failed in this environment because `vendor/autoload.php` is missing and PHP dependencies are not installed (test failed due to environment, not the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d7b67fd4832d875e3fe5d87c9a88)