### PR TITLE
Add missing French translation for pre-orders menu

### DIFF
--- a/resources/lang/vendor/adminlte/fr/menu.php
+++ b/resources/lang/vendor/adminlte/fr/menu.php
@@ -19,6 +19,7 @@ return [
     'orders_lines_list_trans_key'              => 'Liste des ligne de commandes',
     'scheduling_trans_key'                     => 'Planification',
     'order_calendar_trans_key'                 => 'Calendrier des commandes',
+    'pre_orders_trans_key'                     => 'Pré-commandes',
     'load_planning_trans_key'                  => 'Planning de charge',
     'tasks_list_trans_key'                     => 'Liste des tâches',
     'tasks_trans_key'                          => 'Tâches',


### PR DESCRIPTION
### Motivation
- The French AdminLTE menu displayed the raw key `pre_orders_trans_key` instead of a localized label for the pre-orders sidebar entry.

### Description
- Added the entry `"pre_orders_trans_key" => "Pré-commandes"` to `resources/lang/vendor/adminlte/fr/menu.php` so the pre-orders menu item is shown in French.

### Testing
- Verified the new key with `rg "pre_orders_trans_key" -n resources/lang/vendor/adminlte/fr/menu.php`, linted the file with `php -l resources/lang/vendor/adminlte/fr/menu.php`, and ran a headless browser check via Playwright to capture a screenshot, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d8abd4a0832da8961233194ef75a)