### PR TITLE
Hide task 'Voir' action when user lacks scheduling permission

### DIFF
--- a/resources/views/livewire/task-manage.blade.php
+++ b/resources/views/livewire/task-manage.blade.php
@@ -273,7 +273,7 @@
                         @forelse ($Line->TechnicalCut as $TechLine)
                         <tr>
                             <td>
-                                @if($idType == "order_lines_id")
+                                @if($idType == "order_lines_id" && auth()->user()->can('scheduling-menu'))
                                     <a href="{{ route('production.task.statu.id', ['id' => $TechLine->id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a> #{{ $TechLine->id }}</a>
                                 @else
                                     #{{ $TechLine->id }}
@@ -389,7 +389,7 @@
                         <tr>
                             <td>
                                 
-                                @if($idType == "order_lines_id")
+                                @if($idType == "order_lines_id" && auth()->user()->can('scheduling-menu'))
                                     <a href="{{ route('production.task.statu.id', ['id' => $BOMline->id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a> #{{ $BOMline->id }}</a>
                                 @else
                                     #{{ $BOMline->id }}


### PR DESCRIPTION
### Motivation
- Masquer le bouton « Voir » sur les lignes de tâche du découpage technique/BOM quand l'utilisateur n'a pas le droit `scheduling-menu`, afin d'empêcher l'accès au détail de la tâche depuis ces vues si la planification n'est pas autorisée.

### Description
- Restreint l'affichage du lien vers `route('production.task.statu.id', ...)` dans `resources/views/livewire/task-manage.blade.php` en ajoutant la condition `idType == "order_lines_id" && auth()->user()->can('scheduling-menu')` pour les sections TechnicalCut et BOM.

### Testing
- Executed `php -l resources/views/livewire/task-manage.blade.php` and it passed with no syntax errors.
- Attempted `php artisan --version` to run the app for UI verification but it failed due to missing dependencies (`vendor/autoload.php`), so no runtime/integration tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1da6962f4832d95d162809a349fbf)