### PR TITLE
Exclude stopped/canceled orders from delivery KPIs

### DIFF
--- a/app/Services/OrderLinesService.php
+++ b/app/Services/OrderLinesService.php
@@ -17,6 +17,9 @@ class OrderLinesService
                 ['delivery_date', '<=', Carbon::now()->addDays(2)->toDateString()],
             ])
             ->where('delivery_status', '<', 3)
+            ->whereHas('order', function ($q) {
+                $q->whereNotIn('statu', [5, 6]);
+            })
             ->groupBy('orders_id')
             ->orderBy('id', 'desc')
             ->take($limit)
@@ -33,6 +36,9 @@ class OrderLinesService
                 ['delivery_date', '<', Carbon::now()->addDays(2)->toDateString()],
             ])
             ->where('delivery_status', '<', 3)
+            ->whereHas('order', function ($q) {
+                $q->whereNotIn('statu', [5, 6]);
+            })
             ->groupBy('orders_id')
             ->count();
 
@@ -46,6 +52,9 @@ class OrderLinesService
     {
         return OrderLines::where('delivery_date', '<', Carbon::now()->toDateString())
             ->where('delivery_status', '<', 3)
+            ->whereHas('order', function ($q) {
+                $q->whereNotIn('statu', [5, 6]);
+            })
             ->groupBy('orders_id')
             ->orderBy('id', 'desc')
             ->take($limit)
@@ -59,6 +68,9 @@ class OrderLinesService
     {
         $count = OrderLines::where('delivery_date', '<', Carbon::now()->toDateString())
             ->where('delivery_status', '<', 3)
+            ->whereHas('order', function ($q) {
+                $q->whereNotIn('statu', [5, 6]);
+            })
             ->groupBy('orders_id')
             ->count();
 

--- a/tests/Unit/OrderLinesServiceTest.php
+++ b/tests/Unit/OrderLinesServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Workflow\OrderLines;
+use App\Models\Workflow\Orders;
+use App\Services\OrderLinesService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderLinesServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_incoming_orders_excludes_canceled_orders(): void
+    {
+        Carbon::setTestNow('2026-03-10');
+
+        $openOrder = Orders::factory()->create(['statu' => 1]);
+        $canceledOrder = Orders::factory()->create(['statu' => 6]);
+
+        OrderLines::factory()->create([
+            'orders_id' => $openOrder->id,
+            'delivery_date' => '2026-03-11',
+            'delivery_status' => 1,
+        ]);
+
+        OrderLines::factory()->create([
+            'orders_id' => $canceledOrder->id,
+            'delivery_date' => '2026-03-11',
+            'delivery_status' => 1,
+        ]);
+
+        $service = new OrderLinesService();
+        $incomingOrders = $service->getIncomingOrders();
+
+        $this->assertCount(1, $incomingOrders);
+        $this->assertSame($openOrder->id, $incomingOrders->first()->orders_id);
+    }
+}


### PR DESCRIPTION
### Motivation
- The dashboard delivery lanes showed orders that are stopped (statu 5) or canceled (statu 6), which incorrectly inflates the "Commandes à livrer" and "Commandes en retard" KPIs. 
- The intent is to filter out parent orders with statuses 5 and 6 so KPI cards only reflect active customer orders.

### Description
- Add a parent-order filter `->whereHas('order', fn($q) => $q->whereNotIn('statu', [5, 6]))` to `getIncomingOrders`, `getIncomingOrdersCount`, `getLateOrders`, and `getLateOrdersCount` in `app/Services/OrderLinesService.php` to exclude stopped/canceled orders. 
- Keep other query conditions intact (`delivery_status < 3`, date windows, grouping by `orders_id`).
- Add a unit test `tests/Unit/OrderLinesServiceTest.php` that asserts a canceled order is excluded from `getIncomingOrders()`.

### Testing
- A unit test `tests/Unit/OrderLinesServiceTest.php` was added to cover exclusion of canceled orders. 
- Attempted to run `php artisan test --filter=OrderLinesServiceTest` but execution failed in this environment due to missing dependencies (`vendor/autoload.php`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1df209778832dba39430c9329bcf7)