### PR TITLE
Hide empty custom requirements card in task management view

### DIFF
--- a/resources/views/livewire/task-manage.blade.php
+++ b/resources/views/livewire/task-manage.blade.php
@@ -6,20 +6,16 @@
         }) : collect();
     @endphp
 
-    @if($detail)
+    @if($detail && $customRequirementsForDisplay->isNotEmpty())
         <x-adminlte-card title="{{ __('Custom requirements') }}" theme="secondary" icon="fas fa-swatchbook" class="mb-3">
-            @if($customRequirementsForDisplay->isNotEmpty())
-                <ul class="list-unstyled mb-0">
-                    @foreach($customRequirementsForDisplay as $requirement)
-                        <li>
-                            <strong>{{ $requirement['label'] ?? __('Requirement') }}:</strong>
-                            <span>{{ $requirement['value'] ?? '' }}</span>
-                        </li>
-                    @endforeach
-                </ul>
-            @else
-                <span class="text-muted">{{ __('No custom requirement added yet.') }}</span>
-            @endif
+            <ul class="list-unstyled mb-0">
+                @foreach($customRequirementsForDisplay as $requirement)
+                    <li>
+                        <strong>{{ $requirement['label'] ?? __('Requirement') }}:</strong>
+                        <span>{{ $requirement['value'] ?? '' }}</span>
+                    </li>
+                @endforeach
+            </ul>
         </x-adminlte-card>
     @endif
 


### PR DESCRIPTION
### Motivation
- Avoid rendering an empty "Custom requirements" card when there are no requirements to display, keeping the UI cleaner.

### Description
- Update `resources/views/livewire/task-manage.blade.php` to render the card only when `$customRequirementsForDisplay->isNotEmpty()` instead of rendering the card with an empty-state message.
- Remove the fallback "No custom requirement added yet." text and always render the requirements list only when items exist.

### Testing
- Ran a Playwright script to capture a screenshot artifact (`artifacts/task-manage-custom-req.png`) after the change, which completed successfully.
- Attempted `php artisan view:cache` but it failed due to missing local dependencies (`vendor/autoload.php` not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e0ffd480832d873696541ad05631)