### PR TITLE
Resolve pre-order source PDF path when serving PDFs

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -155,18 +155,19 @@ class PreOrdersController extends Controller
 
     public function pdf(PreOrder $preOrder): StreamedResponse
     {
-        $disk = config('filesystems.default');
-        $inputPath = $this->resolveInputPath((string) config('pre_orders.input_path', 'pre-orders/input'));
-        $relativePath = trim($inputPath . '/' . ltrim($preOrder->source_pdf, '/'), '/');
+        $sourcePdfPath = $this->resolveSourcePdfPath($preOrder);
 
-        if (!Storage::disk($disk)->exists($relativePath)) {
+        if ($sourcePdfPath === null) {
             abort(404, 'PDF introuvable.');
         }
 
-        return Storage::disk($disk)->response(
-            $relativePath,
-            $preOrder->source_pdf,
-            ['Content-Type' => 'application/pdf']
+        return Storage::disk(config('filesystems.default'))->response(
+            $sourcePdfPath,
+            basename($sourcePdfPath),
+            [
+                'Content-Type' => 'application/pdf',
+                'Content-Disposition' => 'inline; filename="' . basename($sourcePdfPath) . '"',
+            ]
         );
     }
 

--- a/tests/Feature/PreOrdersPdfAccessTest.php
+++ b/tests/Feature/PreOrdersPdfAccessTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Workflow\PreOrder;
+use App\Models\Workflow\PreOrderImport;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PreOrdersPdfAccessTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware();
+
+        Config::set('filesystems.default', 'local');
+        Config::set('pre_orders.input_path', 'pre-orders/input');
+        Config::set('pre_orders.output_path', 'output');
+        Config::set('pre_orders.done_path', 'output/done');
+
+        Storage::fake('local');
+    }
+
+    public function test_it_streams_pdf_from_done_path_for_pre_order_pdf_route(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        Storage::disk('local')->put('output/done/dc_metal_2600034108_20260218_160251_600462.pdf', '%PDF-1.4 fake');
+
+        $import = PreOrderImport::create([
+            'file_name' => 'batch.csv',
+            'checksum' => sha1('batch.csv'),
+            'imported_at' => Carbon::now(),
+        ]);
+
+        $preOrder = PreOrder::create([
+            'pre_order_import_id' => $import->id,
+            'source_pdf' => 'dc_metal_2600034108_20260218_160251_600462.pdf',
+            'status' => PreOrder::STATUS_PENDING,
+        ]);
+
+        $this->get(route('pre-orders.pdf', $preOrder))
+            ->assertOk()
+            ->assertHeader('content-type', 'application/pdf');
+    }
+
+    public function test_it_uses_basename_when_source_pdf_contains_nested_path(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        Storage::disk('local')->put('output/done/dc_metal_2600034098_20260218_160251_599572.pdf', '%PDF-1.4 fake');
+
+        $import = PreOrderImport::create([
+            'file_name' => 'batch.csv',
+            'checksum' => sha1('batch.csv-2'),
+            'imported_at' => Carbon::now(),
+        ]);
+
+        $preOrder = PreOrder::create([
+            'pre_order_import_id' => $import->id,
+            'source_pdf' => 'nested/folder/dc_metal_2600034098_20260218_160251_599572.pdf',
+            'status' => PreOrder::STATUS_PENDING,
+        ]);
+
+        $this->get(route('pre-orders.pdf', $preOrder))
+            ->assertOk()
+            ->assertHeader('content-type', 'application/pdf');
+    }
+}


### PR DESCRIPTION
### Motivation
- The `pre-orders.pdf` route only checked the configured input folder which made previously moved/renamed PDFs or `source_pdf` values containing path segments unreachable from the listing or detail views.

### Description
- Updated `PreOrdersController::pdf()` to use the existing `resolveSourcePdfPath()` helper so the same fallback logic (`input`, `output`, `output/done`) is used to locate the PDF.
- Serve the PDF with a safe `basename` and an `inline` `Content-Disposition` header to ensure the file opens correctly even when `source_pdf` contains nested paths.
- Added `tests/Feature/PreOrdersPdfAccessTest.php` with two feature tests that verify streaming a PDF from `output/done` and handling a `source_pdf` value that contains nested directories.

### Testing
- Ran PHP lint on modified files with `php -l app/Http/Controllers/Workflow/PreOrdersController.php` and `php -l tests/Feature/PreOrdersPdfAccessTest.php`, both succeeded.
- Attempted `php artisan test tests/Feature/PreOrdersPdfAccessTest.php tests/Feature/PreOrdersUploadTest.php` but the command failed in this environment because `vendor/autoload.php` is missing and dependencies are not installed.
- The new feature tests are added and expected to pass in CI once project dependencies are available and the test suite is executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b280cc8700832d95b66812a4acdb56)