### PR TITLE
fix(stock): hide task/purchase/order links when permission is missing

### DIFF
--- a/resources/views/livewire/stock-detail.blade.php
+++ b/resources/views/livewire/stock-detail.blade.php
@@ -38,20 +38,32 @@
                     <td>{{ $StockDetails->qty }}</td>
                     <td>
                         @if($StockDetails->order_line_id)
-                        <x-OrderButton id="{{ $StockDetails->OrderLine->order['id'] }}" code="{{ $StockDetails->OrderLine->order['code'] }}"  />
+                            @can('orders-menu')
+                                <x-OrderButton id="{{ $StockDetails->OrderLine->order['id'] }}" code="{{ $StockDetails->OrderLine->order['code'] }}"  />
+                            @else
+                                {{ $StockDetails->OrderLine->order['code'] }}
+                            @endcan
                         @endif
                         </td>
                         <td>
                         @if($StockDetails->task_id)
-                        <a href="{{ route('production.task.statu.id', ['id' => $StockDetails->task_id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a>
+                            @can('scheduling-menu')
+                                <a href="{{ route('production.task.statu.id', ['id' => $StockDetails->task_id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a>
+                            @else
+                                #{{ $StockDetails->task_id }}
+                            @endcan
                         @endif
                         </td>
                         <td>
                         @if($StockDetails->purchase_receipt_line_id)
-                        <a class="btn btn-primary btn-sm" href="{{ route('purchase.receipts.show', ['id' => $StockDetails->purchaseReceiptLines->purchase_receipt_id])}}">
-                            <i class="fas fa-folder"></i>
-                            {{ $StockDetails->purchaseReceiptLines->purchaseReceipt->code }}
-                        </a>
+                            @can('purchases-menu')
+                                <a class="btn btn-primary btn-sm" href="{{ route('purchase.receipts.show', ['id' => $StockDetails->purchaseReceiptLines->purchase_receipt_id])}}">
+                                    <i class="fas fa-folder"></i>
+                                    {{ $StockDetails->purchaseReceiptLines->purchaseReceipt->code }}
+                                </a>
+                            @else
+                                {{ $StockDetails->purchaseReceiptLines->purchaseReceipt->code }}
+                            @endcan
                         @endif
                     </td>
                     <td>

--- a/resources/views/products/StockLocationProduct-show.blade.php
+++ b/resources/views/products/StockLocationProduct-show.blade.php
@@ -64,20 +64,32 @@
                   <td>{{ $StockMove->tracability }}</td>
                   <td>
                   @if($StockMove->order_line_id)
-                    <x-OrderButton id="{{ $StockMove->OrderLine->order['id'] }}" code="{{ $StockMove->OrderLine->order['code'] }}"  />
+                    @can('orders-menu')
+                      <x-OrderButton id="{{ $StockMove->OrderLine->order['id'] }}" code="{{ $StockMove->OrderLine->order['code'] }}"  />
+                    @else
+                      {{ $StockMove->OrderLine->order['code'] }}
+                    @endcan
                   @endif
                   </td>
                   <td>
                   @if($StockMove->task_id)
-                    <a href="{{ route('production.task.statu.id', ['id' => $StockMove->task_id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a>
+                    @can('scheduling-menu')
+                      <a href="{{ route('production.task.statu.id', ['id' => $StockMove->task_id]) }}" class="btn btn-sm btn-success">{{__('general_content.view_trans_key') }} </a>
+                    @else
+                      #{{ $StockMove->task_id }}
+                    @endcan
                   @endif
                   </td>
                   <td>
                   @if($StockMove->purchase_receipt_line_id)
-                    <a class="btn btn-primary btn-sm" href="{{ route('purchase.receipts.show', ['id' => $StockMove->purchaseReceiptLines->purchase_receipt_id])}}">
-                      <i class="fas fa-folder"></i>
+                    @can('purchases-menu')
+                      <a class="btn btn-primary btn-sm" href="{{ route('purchase.receipts.show', ['id' => $StockMove->purchaseReceiptLines->purchase_receipt_id])}}">
+                        <i class="fas fa-folder"></i>
+                        {{ $StockMove->purchaseReceiptLines->purchaseReceipt->code }}
+                      </a>
+                    @else
                       {{ $StockMove->purchaseReceiptLines->purchaseReceipt->code }}
-                    </a>
+                    @endcan
                   @endif
                   </td>
                   <td>


### PR DESCRIPTION
### Motivation
- Empêcher l'affichage de liens cliquables vers les tâches, commandes et réceptions d'achat lorsque l'utilisateur n'a pas les droits correspondants afin d'éviter une navigation non autorisée.
- Conserver l'information contextuelle visible (code de commande, identifiant de tâche, code de réception) sans rendre l'élément interactif pour les utilisateurs non autorisés.

### Description
- Misé à jour `resources/views/livewire/stock-detail.blade.php` pour envelopper le lien commande avec `@can('orders-menu')`, la référence tâche avec `@can('scheduling-menu')` et la réception achat avec `@can('purchases-menu')`, et afficher du texte simple sinon.
- Appliqué la même logique à `resources/views/products/StockLocationProduct-show.blade.php` pour les lignes de mouvements de stock (order/task/purchase receipt).
- Les éléments affichés en lecture seule sont respectivement le code de commande, `#<task_id>` pour la tâche et le code du bon de réception lorsque la permission fait défaut.

### Testing
- Vérification de syntaxe PHP/Blade avec `php -l resources/views/livewire/stock-detail.blade.php` qui a réussi.
- Vérification de syntaxe PHP/Blade avec `php -l resources/views/products/StockLocationProduct-show.blade.php` qui a réussi.
- Exécution d'un script Playwright pour générer une capture d'écran (`artifacts/stock-permission-change.png`) pour validation visuelle qui a produit la capture avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2861a930c832dabd22550490a3674)