### PR TITLE
Format guest public pages prices to 2 decimals

### DIFF
--- a/resources/views/guest/guest-order-info.blade.php
+++ b/resources/views/guest/guest-order-info.blade.php
@@ -157,7 +157,7 @@
                                                 </div>
                                             </td>
                                             <td>{{ $DocumentLine->qty }} {{ $DocumentLine->Unit['label'] }}</td>
-                                            <td class="text-end">{{ $DocumentLine->selling_price }}  {{ $Factory->curency }}</td>
+                                            <td class="text-end">{{ number_format((float) $DocumentLine->selling_price, 2, '.', '') }} {{ $Factory->curency }}</td>
                                             <td>{{ $DocumentLine->discount }} %</td>
                                             <td>{{ $DocumentLine->VAT['rate'] }} %</td>
                                             <td>
@@ -201,12 +201,12 @@
                                         </tr>
                                         <tr>
                                             <td colspan="3">{{ __('general_content.sub_total_trans_key') }}</td>
-                                            <td colspan="2" class="text-end">{{ $subPrice }} {{ $Factory->curency }}</td>
+                                            <td colspan="2" class="text-end">{{ number_format((float) $subPrice, 2, '.', '') }} {{ $Factory->curency }}</td>
                                         </tr>
                                         @forelse($vatPrice as $key => $value)
                                         <tr>
-                                            <td colspan="3">{{ __('general_content.tax_trans_key') }} <?= $vatPrice[$key][0] ?> %</td> 
-                                            <td colspan="2" class="text-end"><?= $vatPrice[$key][1] ?> {{ $Factory->curency }}</td>
+                                            <td colspan="3">{{ __('general_content.tax_trans_key') }} <?= number_format((float) $vatPrice[$key][0], 2, '.', '') ?> %</td> 
+                                            <td colspan="2" class="text-end"><?= number_format((float) $vatPrice[$key][1], 2, '.', '') ?> {{ $Factory->curency }}</td>
                                         </tr>
                                         @empty
                                         <tr>
@@ -216,7 +216,7 @@
                                         @endforelse
                                         <tr class="fw-bold">
                                             <td colspan="3">{{ __('general_content.total_trans_key') }}</td>
-                                            <td colspan="2" class="text-end">{{ $totalPrices }} {{ $Factory->curency }}</td>
+                                            <td colspan="2" class="text-end">{{ number_format((float) $totalPrices, 2, '.', '') }} {{ $Factory->curency }}</td>
                                         </tr>
                                     </tfoot>
                                 </table>

--- a/resources/views/guest/guest-quote-info.blade.php
+++ b/resources/views/guest/guest-quote-info.blade.php
@@ -141,7 +141,7 @@
                                                 </div>
                                             </td>
                                             <td>{{ $DocumentLine->qty }} {{ $DocumentLine->Unit['label'] }}</td>
-                                            <td class="text-end">{{ $DocumentLine->selling_price }}  {{ $Factory->curency }}</td>
+                                            <td class="text-end">{{ number_format((float) $DocumentLine->selling_price, 2, '.', '') }} {{ $Factory->curency }}</td>
                                             <td>{{ $DocumentLine->discount }} %</td>
                                             <td>{{ $DocumentLine->VAT['rate'] }} %</td>
                                         </tr>
@@ -156,12 +156,12 @@
                                         </tr>
                                         <tr>
                                             <td colspan="3">{{ __('general_content.sub_total_trans_key') }}</td>
-                                            <td colspan="2" class="text-end">{{ $subPrice }} {{ $Factory->curency }}</td>
+                                            <td colspan="2" class="text-end">{{ number_format((float) $subPrice, 2, '.', '') }} {{ $Factory->curency }}</td>
                                         </tr>
                                         @forelse($vatPrice as $key => $value)
                                         <tr>
-                                            <td colspan="3">{{ __('general_content.tax_trans_key') }} <?= $vatPrice[$key][0] ?> %</td> 
-                                            <td colspan="2" class="text-end"><?= $vatPrice[$key][1] ?> {{ $Factory->curency }}</td>
+                                            <td colspan="3">{{ __('general_content.tax_trans_key') }} <?= number_format((float) $vatPrice[$key][0], 2, '.', '') ?> %</td> 
+                                            <td colspan="2" class="text-end"><?= number_format((float) $vatPrice[$key][1], 2, '.', '') ?> {{ $Factory->curency }}</td>
                                         </tr>
                                         @empty
                                         <tr>
@@ -171,7 +171,7 @@
                                         @endforelse
                                         <tr class="fw-bold">
                                             <td colspan="3">{{ __('general_content.total_trans_key') }}</td>
-                                            <td colspan="2" class="text-end">{{ $totalPrices }} {{ $Factory->curency }}</td>
+                                            <td colspan="2" class="text-end">{{ number_format((float) $totalPrices, 2, '.', '') }} {{ $Factory->curency }}</td>
                                         </tr>
                                     </tfoot>
                                 </table>


### PR DESCRIPTION
### Motivation
- Public guest pages (order and quote public links) must display monetary values with two decimal places for consistent presentation and readability.

### Description
- Update `resources/views/guest/guest-order-info.blade.php` and `resources/views/guest/guest-quote-info.blade.php` to render `selling_price`, `subPrice`, VAT row values and `totalPrices` using `number_format((float) ..., 2, '.', '')` while keeping the currency label unchanged.

### Testing
- Ran `php -l resources/views/guest/guest-order-info.blade.php` and `php -l resources/views/guest/guest-quote-info.blade.php` and both returned no syntax errors (success).
- Executed an automated Playwright script to capture the guest order page which produced a screenshot artifact but the page returned a `Not Found` response so full visual verification against a running app could not be completed (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29fcefe60832d9b5b3bb121506f14)