### PR TITLE
Dashboard: remplacer la date de création par la date de livraison

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -248,7 +248,7 @@
                   @if(6 == $LastOrder->statu )  <span class="badge badge-warning">{{ __('general_content.canceled_trans_key') }}</span>@endif
                 </td>
                 <td>{{ $LastOrder->formatted_total_price }}</td>
-                <td>{{ $LastOrder->GetPrettyCreatedAttribute() }}</td>
+                <td>{{ $LastOrder->validity_date ? \Carbon\Carbon::parse($LastOrder->validity_date)->format('d/m/Y') : '—' }}</td>
               </tr>
               <!-- /.item -->
               @empty


### PR DESCRIPTION
### Motivation
- Remplacer l'affichage de la date relative de création dans le widget « Dernières commande » par la date de livraison afin d'afficher la date de livraison effective plutôt que l'âge de la commande.

### Description
- Remplacement d'une seule ligne dans `resources/views/dashboard.blade.php` pour afficher `validity_date` formatée en `d/m/Y` avec un fallback `—` lorsque la date est absente (au lieu de `GetPrettyCreatedAttribute()`).

### Testing
- Exécution de `php -l resources/views/dashboard.blade.php` (vérification syntaxique) réussie, et tentative de lancement de l'application via `php artisan serve` échouée en environnement CI/local à cause de `vendor/autoload.php` manquant.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a112dc1c832d9abef1f1706e6e75)