### PR TITLE
Add article matching flow on pre-order detail lines

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -9,10 +9,12 @@ use App\Models\Accounting\AccountingPaymentMethod;
 use App\Models\Accounting\AccountingVat;
 use App\Models\Companies\Companies;
 use App\Models\Methods\MethodsUnits;
+use App\Models\Products\Products;
 use App\Models\Workflow\OrderLineDetails;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\Orders;
 use App\Models\Workflow\PreOrder;
+use App\Models\Workflow\PreOrderLine;
 use App\Services\DocumentCodeGenerator;
 use App\Services\InvoiceReportInterpreter;
 use App\Models\User;
@@ -174,7 +176,7 @@ class PreOrdersController extends Controller
 
     public function show(PreOrder $preOrder)
     {
-        $preOrder->load('lines', 'convertedOrder');
+        $preOrder->load('lines.suggestedProduct', 'lines.linkedProduct', 'convertedOrder');
 
         $sourcePdfUrl = $this->resolveSourcePdfPath($preOrder)
             ? route('pre-orders.source-pdf', $preOrder)
@@ -210,6 +212,52 @@ class PreOrdersController extends Controller
                 'Content-Disposition' => 'inline; filename="' . basename($sourcePdfPath) . '"',
             ]
         );
+    }
+
+
+    public function matchArticles(PreOrder $preOrder)
+    {
+        $preOrder->load('lines');
+
+        foreach ($preOrder->lines as $line) {
+            $reference = trim((string) $line->reference);
+
+            if ($reference === '') {
+                $line->update([
+                    'suggested_product_id' => null,
+                    'matching_unit_price' => null,
+                ]);
+
+                continue;
+            }
+
+            $product = Products::query()
+                ->where('code', $reference)
+                ->first();
+
+            $line->update([
+                'suggested_product_id' => $product?->id,
+                'matching_unit_price' => $product?->selling_price,
+            ]);
+        }
+
+        return redirect()->route('pre-orders.show', $preOrder)->with('success', 'Matching des articles terminé.');
+    }
+
+    public function acceptMatching(PreOrder $preOrder, PreOrderLine $line)
+    {
+        abort_unless((int) $line->pre_order_id === (int) $preOrder->id, 404);
+
+        if (! $line->suggested_product_id) {
+            return redirect()->route('pre-orders.show', $preOrder)->withErrors('Aucun article suggéré sur cette ligne.');
+        }
+
+        $line->update([
+            'linked_product_id' => $line->suggested_product_id,
+            'matching_confirmed_at' => now(),
+        ]);
+
+        return redirect()->route('pre-orders.show', $preOrder)->with('success', 'Matching accepté pour la ligne ' . $line->row_index . '.');
     }
 
     public function convert(Request $request, PreOrder $preOrder)
@@ -263,16 +311,19 @@ class PreOrdersController extends Controller
             ]);
 
             foreach ($preOrder->lines as $index => $line) {
+                $matchedProduct = $line->linkedProduct;
+
                 $orderLine = OrderLines::create([
                     'orders_id' => $order->id,
                     'ordre' => $index + 1,
-                    'code' => $line->reference,
-                    'label' => $line->product ?: $line->reference,
+                    'code' => $matchedProduct?->code ?: $line->reference,
+                    'product_id' => $line->linked_product_id,
+                    'label' => $matchedProduct?->label ?: ($line->product ?: $line->reference),
                     'qty' => max((int) $line->quantity, 1),
                     'delivered_remaining_qty' => max((int) $line->quantity, 1),
                     'invoiced_remaining_qty' => max((int) $line->quantity, 1),
                     'methods_units_id' => $data['methods_units_id'],
-                    'selling_price' => $line->unit_price,
+                    'selling_price' => $line->matching_unit_price ?? $line->unit_price,
                     'discount' => $data['discount'] ?? 0,
                     'accounting_vats_id' => $data['accounting_vats_id'],
                     'delivery_date' => $data['delivery_date'] ?? null,

--- a/app/Models/Workflow/PreOrderLine.php
+++ b/app/Models/Workflow/PreOrderLine.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Workflow;
 
+use App\Models\Products\Products;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Number;
@@ -18,6 +19,14 @@ class PreOrderLine extends Model
         'quantity',
         'unit_price',
         'total_price',
+        'suggested_product_id',
+        'linked_product_id',
+        'matching_unit_price',
+        'matching_confirmed_at',
+    ];
+
+    protected $casts = [
+        'matching_confirmed_at' => 'datetime',
     ];
 
     public function getEffectiveTotalPriceAttribute(): float
@@ -54,5 +63,27 @@ class PreOrderLine extends Model
     public function preOrder()
     {
         return $this->belongsTo(PreOrder::class);
+    }
+
+    public function suggestedProduct()
+    {
+        return $this->belongsTo(Products::class, 'suggested_product_id');
+    }
+
+    public function linkedProduct()
+    {
+        return $this->belongsTo(Products::class, 'linked_product_id');
+    }
+
+    public function getFormattedMatchingUnitPriceAttribute(): ?string
+    {
+        if ($this->matching_unit_price === null) {
+            return null;
+        }
+
+        $factory = app('Factory');
+        $currency = $factory->curency ?? 'EUR';
+
+        return Number::currency((float) $this->matching_unit_price, $currency, config('app.locale'));
     }
 }

--- a/database/migrations/2026_03_12_000003_add_matching_fields_to_pre_order_lines_table.php
+++ b/database/migrations/2026_03_12_000003_add_matching_fields_to_pre_order_lines_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('pre_order_lines', function (Blueprint $table) {
+            $table->unsignedBigInteger('suggested_product_id')->nullable()->after('total_price');
+            $table->unsignedBigInteger('linked_product_id')->nullable()->after('suggested_product_id');
+            $table->decimal('matching_unit_price', 12, 3)->nullable()->after('linked_product_id');
+            $table->timestamp('matching_confirmed_at')->nullable()->after('matching_unit_price');
+
+            $table->foreign('suggested_product_id')->references('id')->on('products')->nullOnDelete();
+            $table->foreign('linked_product_id')->references('id')->on('products')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pre_order_lines', function (Blueprint $table) {
+            $table->dropForeign(['suggested_product_id']);
+            $table->dropForeign(['linked_product_id']);
+            $table->dropColumn(['suggested_product_id', 'linked_product_id', 'matching_unit_price', 'matching_confirmed_at']);
+        });
+    }
+};

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -29,6 +29,13 @@
     <div class="row">
         <div class="col-lg-8">
             <x-adminlte-card title="Lignes importées" theme="primary" maximizable>
+                <form method="POST" action="{{ route('pre-orders.matching', $preOrder) }}" class="mb-3">
+                    @csrf
+                    <button type="submit" class="btn btn-primary btn-sm">
+                        <i class="fas fa-link mr-1"></i> Matching article
+                    </button>
+                </form>
+
                 <div class="table-responsive p-0">
                     <table class="table table-sm table-hover">
                         <thead>
@@ -39,6 +46,9 @@
                                 <th>Quantité</th>
                                 <th>PU</th>
                                 <th>Total</th>
+                                <th>Article matché</th>
+                                <th>PU article</th>
+                                <th>Validation</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -50,6 +60,28 @@
                                     <td>{{ $line->quantity }}</td>
                                     <td>{{ $line->formatted_selling_price }}</td>
                                     <td>{{ $line->formatted_total_price }}</td>
+                                    <td>
+                                        @if($line->linkedProduct)
+                                            <span class="badge badge-success">{{ $line->linkedProduct->code }} - {{ $line->linkedProduct->label }}</span>
+                                        @elseif($line->suggestedProduct)
+                                            <span class="badge badge-warning">{{ $line->suggestedProduct->code }} - {{ $line->suggestedProduct->label }}</span>
+                                        @else
+                                            <span class="text-muted">Aucun</span>
+                                        @endif
+                                    </td>
+                                    <td>{{ $line->formatted_matching_unit_price ?? '-' }}</td>
+                                    <td>
+                                        @if($line->linked_product_id)
+                                            <span class="badge badge-success">Validé</span>
+                                        @elseif($line->suggested_product_id)
+                                            <form method="POST" action="{{ route('pre-orders.accept-matching', [$preOrder, $line]) }}">
+                                                @csrf
+                                                <button type="submit" class="btn btn-xs btn-success">Accepter</button>
+                                            </form>
+                                        @else
+                                            <span class="text-muted">-</span>
+                                        @endif
+                                    </td>
                                 </tr>
                             @endforeach
                         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -185,6 +185,8 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/pdf/{preOrder}', 'App\Http\Controllers\Workflow\PreOrdersController@pdf')->name('pre-orders.pdf');
         Route::get('/{preOrder}', 'App\Http\Controllers\Workflow\PreOrdersController@show')->name('pre-orders.show');
         Route::get('/{preOrder}/source-pdf', 'App\Http\Controllers\Workflow\PreOrdersController@sourcePdf')->name('pre-orders.source-pdf');
+        Route::post('/{preOrder}/matching', 'App\Http\Controllers\Workflow\PreOrdersController@matchArticles')->name('pre-orders.matching');
+        Route::post('/{preOrder}/lines/{line}/accept-matching', 'App\Http\Controllers\Workflow\PreOrdersController@acceptMatching')->name('pre-orders.accept-matching');
         Route::post('/{preOrder}/convert', 'App\Http\Controllers\Workflow\PreOrdersController@convert')->name('pre-orders.convert');
     });
 


### PR DESCRIPTION
### Motivation
- Allow operators to link pre-order line `reference` values to internal `products` so each imported line can be matched to an existing product, show the product's theoretical unit price and let the user accept the match per-line before final conversion. 
- Persist matching metadata on `pre_order_lines` so confirmed links and matched prices are used when creating the final `order_lines`.

### Description
- Add migration `2026_03_12_000003_add_matching_fields_to_pre_order_lines_table.php` to add `suggested_product_id`, `linked_product_id`, `matching_unit_price` and `matching_confirmed_at` to `pre_order_lines` and foreign keys to `products`.
- Update `PreOrderLine` model to include new fields in `$fillable`, add casts, relations `suggestedProduct()` and `linkedProduct()` and a `getFormattedMatchingUnitPriceAttribute()` helper.
- Add controller actions `matchArticles(PreOrder $preOrder)` and `acceptMatching(PreOrder $preOrder, PreOrderLine $line)` to `PreOrdersController`, preload `lines.suggestedProduct`/`lines.linkedProduct` in `show`, and use confirmed `linked_product_id` / `matching_unit_price` when creating `order_lines` in `convert`.
- Update view `resources/views/workflow/pre-orders-show.blade.php` to add a `Matching article` button, show suggested/linked product, theoretical unit price and a per-line `Accepter` action, and register new routes `pre-orders.matching` and `pre-orders.accept-matching` in `routes/web.php`.

### Testing
- Run syntax checks with `php -l` on the modified files (`PreOrdersController.php`, `PreOrderLine.php`, `pre-orders-show.blade.php`, migration) which all succeeded. 
- Attempted `php artisan route:list --name=pre-orders` failed in the environment because `vendor/autoload.php` is missing (dependencies not installed). 
- Rendered a UI snapshot using a Playwright headless script which completed and produced `artifacts/preorder-matching.png` demonstrating the new button and table columns.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b7d9b084832dbda9648a19139bec)