### PR TITLE
Add bulk "Valider toutes les lignes" action for pre-order matching

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -260,6 +260,24 @@ class PreOrdersController extends Controller
         return redirect()->route('pre-orders.show', $preOrder)->with('success', 'Matching accepté pour la ligne ' . $line->row_index . '.');
     }
 
+    public function acceptAllMatching(PreOrder $preOrder)
+    {
+        $updatedCount = PreOrderLine::query()
+            ->where('pre_order_id', $preOrder->id)
+            ->whereNotNull('suggested_product_id')
+            ->whereNull('linked_product_id')
+            ->update([
+                'linked_product_id' => DB::raw('suggested_product_id'),
+                'matching_confirmed_at' => now(),
+            ]);
+
+        if ($updatedCount === 0) {
+            return redirect()->route('pre-orders.show', $preOrder)->withErrors('Aucune ligne à valider.');
+        }
+
+        return redirect()->route('pre-orders.show', $preOrder)->with('success', $updatedCount . ' ligne(s) validée(s) automatiquement.');
+    }
+
     public function convert(Request $request, PreOrder $preOrder)
     {
         if ($preOrder->status === PreOrder::STATUS_CONVERTED) {

--- a/resources/views/workflow/pre-orders-show.blade.php
+++ b/resources/views/workflow/pre-orders-show.blade.php
@@ -29,12 +29,25 @@
     <div class="row">
         <div class="col-lg-8">
             <x-adminlte-card title="Lignes importées" theme="primary" maximizable>
-                <form method="POST" action="{{ route('pre-orders.matching', $preOrder) }}" class="mb-3">
-                    @csrf
-                    <button type="submit" class="btn btn-primary btn-sm">
-                        <i class="fas fa-link mr-1"></i> Matching article
-                    </button>
-                </form>
+                @php
+                    $hasPendingMatching = $preOrder->lines->contains(fn ($line) => $line->suggested_product_id && ! $line->linked_product_id);
+                @endphp
+
+                <div class="d-flex mb-3">
+                    <form method="POST" action="{{ route('pre-orders.matching', $preOrder) }}" class="mr-2">
+                        @csrf
+                        <button type="submit" class="btn btn-primary btn-sm">
+                            <i class="fas fa-link mr-1"></i> Matching article
+                        </button>
+                    </form>
+
+                    <form method="POST" action="{{ route('pre-orders.accept-all-matching', $preOrder) }}">
+                        @csrf
+                        <button type="submit" class="btn btn-success btn-sm" @disabled(! $hasPendingMatching)>
+                            <i class="fas fa-check-double mr-1"></i> Valider toutes les lignes
+                        </button>
+                    </form>
+                </div>
 
                 <div class="table-responsive p-0">
                     <table class="table table-sm table-hover">

--- a/routes/web.php
+++ b/routes/web.php
@@ -187,6 +187,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/{preOrder}/source-pdf', 'App\Http\Controllers\Workflow\PreOrdersController@sourcePdf')->name('pre-orders.source-pdf');
         Route::post('/{preOrder}/matching', 'App\Http\Controllers\Workflow\PreOrdersController@matchArticles')->name('pre-orders.matching');
         Route::post('/{preOrder}/lines/{line}/accept-matching', 'App\Http\Controllers\Workflow\PreOrdersController@acceptMatching')->name('pre-orders.accept-matching');
+        Route::post('/{preOrder}/accept-all-matching', 'App\Http\Controllers\Workflow\PreOrdersController@acceptAllMatching')->name('pre-orders.accept-all-matching');
         Route::post('/{preOrder}/convert', 'App\Http\Controllers\Workflow\PreOrdersController@convert')->name('pre-orders.convert');
     });
 


### PR DESCRIPTION
### Motivation
- Permettre de valider en une seule action toutes les lignes d'une pré-commande pour lesquelles un article a été suggéré, afin d'éviter d'accepter manuellement ligne par ligne.

### Description
- Ajout d'une nouvelle route `pre-orders.accept-all-matching` pour déclencher l'action de validation en masse.
- Implémentation de `acceptAllMatching` dans `PreOrdersController` qui exécute une mise à jour en une requête sur `PreOrderLine` pour `linked_product_id = suggested_product_id` et positionne `matching_confirmed_at`.
- Mise à jour de la vue `resources/views/workflow/pre-orders-show.blade.php` pour afficher un bouton `Valider toutes les lignes` à côté de `Matching article` et le désactiver lorsqu'il n'y a aucune ligne en attente.
- Les retours utilisateur sont gérés via des messages flash de succès ou d'erreur selon le nombre de lignes traitées.

### Testing
- Lint PHP: `php -l app/Http/Controllers/Workflow/PreOrdersController.php`, `php -l resources/views/workflow/pre-orders-show.blade.php` et `php -l routes/web.php` ont réussi sans erreurs de syntaxe.
- `php artisan route:list` n'a pas pu être exécuté ici car `vendor/autoload.php` est absent dans l'environnement de build, donc les vérifications d'exécution Laravel n'ont pas été réalisées.
- Tentative d'un test UI par Playwright (capture d'écran) a échoué à cause d'un crash du binaire headless Chromium dans cet environnement (SIGSEGV).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e485881c832da5b7564de41d77d0)