### PR TITLE
Conditional purchases widgets and current-month delivery notes on dashboard

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -79,6 +79,11 @@ class HomeController extends Controller
             ? Carbon::parse($latestCustomerCreatedAt)->diffForHumans()
             : __('general_content.not_available_trans_key');
 
+        $data['current_month_delivery_notes_count'] = DB::table('deliverys')
+            ->whereYear('created_at', '=', $CurentYear)
+            ->whereMonth('created_at', '=', $CurentMonth)
+            ->count();
+
         $Announcement = Announcements::latest()->first();
 
         //Estimated Budgets data for chart

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -953,6 +953,7 @@ return [
     
     //DELIVERY
     'delivery_notes_trans_key'                 => 'Delivery notes',
+    'current_month_trans_key'                  => 'Current month',
     'deliverys_notes_request_trans_key'        => 'Deliverys notes request',
     'deliverys_notes_list_trans_key'           => 'Deliverys notes list',
     'name_of_deliverys_notes_trans_key'        => 'Name of Delivery note',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -953,6 +953,7 @@ return [
     
     //DELIVERY
     'delivery_notes_trans_key'                 => 'Bons de livraisons',
+    'current_month_trans_key'                  => 'Mois en cours',
     'deliverys_notes_request_trans_key'        => 'Attente de bons de livraison',
     'deliverys_notes_list_trans_key'           => 'Liste des bons de livraisons',
     'name_of_deliverys_notes_trans_key'        => 'Nom du bon de livraison',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -124,12 +124,21 @@
     </div>
     <!-- ./col -->
     <div class="col-lg-2 col-md-2">
-      <x-adminlte-small-box title="{{ $data['suppliers_count'] }}"
-                            text="{{ __('general_content.suppliers_trans_key') }}" 
-                            icon="far fa-building"
-                            theme="success" 
-                            url="{{ route('companies', ['type' => 'supplier']) }}" 
-                            url-text="{{ __('general_content.view_details_trans_key') }}"/>
+      @can('purchases-menu')
+        <x-adminlte-small-box title="{{ $data['suppliers_count'] }}"
+                              text="{{ __('general_content.suppliers_trans_key') }}" 
+                              icon="far fa-building"
+                              theme="success" 
+                              url="{{ route('companies', ['type' => 'supplier']) }}" 
+                              url-text="{{ __('general_content.view_details_trans_key') }}"/>
+      @else
+        <x-adminlte-small-box title="{{ $data['current_month_delivery_notes_count'] }}"
+                              text="{{ __('general_content.delivery_notes_trans_key') }} - {{ __('general_content.current_month_trans_key') }}" 
+                              icon="fas fa-truck"
+                              theme="success"
+                              url="{{ route('deliverys') }}" 
+                              url-text="{{ __('general_content.view_details_trans_key') }}"/>
+      @endcan
     </div>
     <!-- ./col -->
     <div class="col-lg-2 col-md-2">
@@ -617,31 +626,33 @@
                                 @endif
                               @endfor ]
         },
-        {
-          label               : @json(__('general_content.chart_purchase_revenues_trans_key')),
-          borderColor         : 'rgba(21, 83, 79,0.5)',
-          pointRadius          : 5,
-          pointColor          : '#d9534f',
-          pointStrokeColor    : 'rgba(21, 83, 79,1)',
-          pointHighlightFill  : '#fff',
-          pointHighlightStroke: 'rgba(21, 83, 79,1)',
-          data                : [
-                              @php ($j = 1)
-                              @for($iM =1;$iM<=12;$iM++)
-                                @foreach ($data['purchaseMonthlyRecap'] as $key => $item)
+        @can('purchases-menu')
+          {
+            label               : @json(__('general_content.chart_purchase_revenues_trans_key')),
+            borderColor         : 'rgba(21, 83, 79,0.5)',
+            pointRadius          : 5,
+            pointColor          : '#d9534f',
+            pointStrokeColor    : 'rgba(21, 83, 79,1)',
+            pointHighlightFill  : '#fff',
+            pointHighlightStroke: 'rgba(21, 83, 79,1)',
+            data                : [
                                 @php ($j = 1)
-                                  @if($iM  == $item->month) 
-                                  "-{{ $item->purchaseSum }}",
-                                    @php ($j = 2)
-                                    @break
-                                  @endif
-                                @endforeach
-                                @if($j == 1) 
-                                  0,
+                                @for($iM =1;$iM<=12;$iM++)
+                                  @foreach ($data['purchaseMonthlyRecap'] as $key => $item)
                                   @php ($j = 1)
-                                @endif
-                              @endfor ]
-        },
+                                    @if($iM  == $item->month) 
+                                    "-{{ $item->purchaseSum }}",
+                                      @php ($j = 2)
+                                      @break
+                                    @endif
+                                  @endforeach
+                                  @if($j == 1) 
+                                    0,
+                                    @php ($j = 1)
+                                  @endif
+                                @endfor ]
+          },
+        @endcan
         {
           label               : @json(__('general_content.chart_order_targets_trans_key')),
           borderColor         : 'rgba(40, 167, 69, 1)',


### PR DESCRIPTION
### Motivation
- Provide a relevant dashboard view for users without purchase permissions by surfacing current-month delivery notes instead of purchase-related widgets.
- Avoid displaying purchase charts and supplier shortcuts to users who lack the `purchases-menu` permission.

### Description
- Add `current_month_delivery_notes_count` to `HomeController` by counting `deliverys` for the current year and month. 
- Render a delivery notes small box on the dashboard when the user does not have the `purchases-menu` permission and keep the suppliers box for users with the permission by wrapping sections in `@can('purchases-menu')` checks in `dashboard.blade.php`.
- Wrap the purchase revenues dataset in the dashboard chart with the same `@can('purchases-menu')` guard so the purchase series is only shown to authorized users.
- Add the translation key `current_month_trans_key` in both `resources/lang/en/general_content.php` and `resources/lang/fr/general_content.php`.

### Testing
- Ran the existing automated test suite with `phpunit`, and the test run completed successfully with all tests passing. 
- Performed static checks and view rendering locally to confirm that the conditional blocks compile without Blade errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2eafa95e8832d86d404879cbd8887)