### PR TITLE
Truncate long notification text in navbar dropdown

### DIFF
--- a/app/Http/Controllers/NotificationsController.php
+++ b/app/Http/Controllers/NotificationsController.php
@@ -67,7 +67,7 @@ class NotificationsController extends Controller
         $dropdownHtml = '';
         foreach ($notifications as $key => $not) {
             $icon = "<span class='notification-icon mr-2'><i class='{$not['icon']} fa-fw'></i></span>";
-            $text = "<span class='notification-text'>{$not['text']}</span>";
+            $text = "<span class='notification-text d-inline-block text-truncate' style='max-width: 220px;' title='{$not['text']}'>{$not['text']}</span>";
             $time = "<span class='notification-time text-muted text-sm'>{$not['time']}</span>";
             $content = "<div class='notification-content flex-fill'>{$text}{$time}</div>";
             $dropdownHtml .= "<a href='{$not['route']}' class='dropdown-item notification-item d-flex align-items-start'>{$icon}{$content}</a>";


### PR DESCRIPTION
### Motivation
- Prevent very long notification texts from overflowing the navbar dropdown and make them display with an ellipsis while keeping the full text accessible on hover.

### Description
- Update `app/Http/Controllers/NotificationsController.php` to wrap the notification label with `<span class='notification-text d-inline-block text-truncate' style='max-width: 220px;' title='...'>` so long texts are truncated and the full text remains in the `title` attribute.

### Testing
- Run `php -l app/Http/Controllers/NotificationsController.php` and it returned no syntax errors (success).
- Rendered the app in a headless browser and captured a screenshot to validate the dropdown truncation (playwright script executed and produced `notifications-truncate.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ec349714832d8990ba9e516fa0e0)