### PR TITLE
feat(auth): make login mode selector configurable via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,9 @@ VAT_VALIDATION_ENABLED=false
 # Use 'web' as the primary authentication driver for Laravel. Aslo use ldap for the secondary driver.
 # This means that the application will use the LDAP server to handle user authentication.
 AUTH_DRIVER=web
+# Show mode selector (Desktop/Workshop) on the login page.
+# Set to false to hide it and default to Desktop mode.
+LOGIN_MODE_SELECTOR_ENABLED=true
 LDAP_HOST=ldap.example.com
 LDAP_USERNAME="cn=admin,dc=example,dc=com"
 LDAP_PASSWORD=supersecretpassword

--- a/config/auth.php
+++ b/config/auth.php
@@ -128,4 +128,16 @@ return [
 
     'password_timeout' => 10800,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Login View Options
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether the mode selector is displayed on
+    | the login screen.
+    |
+    */
+
+    'login_mode_selector_enabled' => env('LOGIN_MODE_SELECTOR_ENABLED', true),
+
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -82,18 +82,22 @@
         </div>
 
         {{-- Mode field --}}
-        <div class="input-group mb-3">
-            <select name="modeView" id="modeView" class="form-control">
-                <option value="desktop">Desktop</option>
-                <option value="workshop">Workshop (Beta)</option>
-            </select>
+        @if(config('auth.login_mode_selector_enabled'))
+            <div class="input-group mb-3">
+                <select name="modeView" id="modeView" class="form-control">
+                    <option value="desktop">Desktop</option>
+                    <option value="workshop">Workshop (Beta)</option>
+                </select>
 
-            <div class="input-group-append">
-                <div class="input-group-text">
-                    <span class="fa fa-window-maximize {{ config('adminlte.classes_auth_icon', '') }}"></span>
+                <div class="input-group-append">
+                    <div class="input-group-text">
+                        <span class="fa fa-window-maximize {{ config('adminlte.classes_auth_icon', '') }}"></span>
+                    </div>
                 </div>
             </div>
-        </div>
+        @else
+            <input type="hidden" name="modeView" value="desktop">
+        @endif
 
         {{-- Login field --}}
         <div class="row">


### PR DESCRIPTION
### Motivation
- Allow deployments to disable the Desktop/Workshop selector on the login page from configuration so the login UI can be simplified or locked to `desktop` mode for specific environments.

### Description
- Added `login_mode_selector_enabled` to `config/auth.php` backed by the environment variable `LOGIN_MODE_SELECTOR_ENABLED` with a default of `true`.
- Updated `resources/views/auth/login.blade.php` to conditionally render the mode `<select>` only when `config('auth.login_mode_selector_enabled')` is true and otherwise submit a hidden `modeView=desktop` to preserve redirection behavior.
- Documented the new `LOGIN_MODE_SELECTOR_ENABLED` key in `.env.example` with explanatory comments.

### Testing
- Ran `php -l config/auth.php` and it returned no syntax errors (success).
- Attempted `php artisan test --filter=AuthenticatedSessionController --stop-on-failure` but it could not run due to a missing `vendor/autoload.php` in this environment (tests could not be executed).
- A headless browser script navigated to `/login` and produced a screenshot artifact `artifacts/login-mode-selector.png` showing the login page with the selector (verification artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d9fb4a90832db9f2c9e7f9c0ae9b)