### PR TITLE
Ajout permission `stock-lot-serial-management` pour contrôler stock / lots / numéros de série

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -479,16 +479,19 @@ return [
                     'text' => 'serial_numbers_trans_key',
                     'url'  => 'products/serial-numbers',
                     'icon_color' => 'info',
+                    'can'  => ['stock-lot-serial-management'],
                 ],
                 [
                     'text' => 'batches_trans_key',
                     'url'  => 'products/batches',
                     'icon_color' => 'info', // choose color consistent with design
+                    'can'  => ['stock-lot-serial-management'],
                 ],
                 [
                     'text' => 'stock_trans_key',
                     'url'  => 'products/Stock',
                     'icon_color' => 'primary',
+                    'can'  => ['stock-lot-serial-management'],
                 ],
                 /*[
                     'text' => 'inventory_trans_key',

--- a/database/seeders/PermissionTableSeeder.php
+++ b/database/seeders/PermissionTableSeeder.php
@@ -25,6 +25,7 @@ class PermissionTableSeeder  extends Seeder
                         'deliverys-menu',
                         'invoices-menu',
                         'products-menu',
+                        'stock-lot-serial-management',
                         'purchases-menu',
                         'quality-menu',
                         'settings-time-menu',

--- a/resources/views/livewire/deliverys-request.blade.php
+++ b/resources/views/livewire/deliverys-request.blade.php
@@ -92,10 +92,12 @@
                         @error('companies_contacts_id') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
                     <div class="form-group col-md-3">
+                        @can('stock-lot-serial-management')
                         <label for="RemoveFromStock">{{ __('general_content.remove_component_lines_stock_trans_key') }}</label>
                         <input type="checkbox" id="RemoveFromStock" wire:model.live="RemoveFromStock" >
                         <label for="CreateSerialNumber">{{ __('general_content.create_serial_number_trans_key') }}</label>
                         <input type="checkbox" id="CreateSerialNumber" wire:model.live="CreateSerialNumber" >
+                        @endcan
                     </div>
                     
                     <div class="form-group col-md-3"><br/>

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -672,6 +672,7 @@
                         <tr>
                             <th colspan="11"></th>
                             <th colspan="4">
+                                @can('stock-lot-serial-management')
                                 <div>
                                     <label for="RemoveFromStock">{{ __('general_content.remove_component_lines_stock_trans_key') }}</label>
                                     <input type="checkbox" id="RemoveFromStock" wire:model.live="RemoveFromStock" >
@@ -680,6 +681,7 @@
                                     <label for="CreateSerialNumber">{{ __('general_content.create_serial_number_trans_key') }}</label>
                                     <input type="checkbox" id="CreateSerialNumber" wire:model.live="CreateSerialNumber" >
                                 </div>
+                                @endcan
                                 <div>
                                     @if($OrderStatu != 6)
                                         <a class="btn btn-primary btn-sm" wire:click="storeDelevery({{ $OrderId }})" href="#">

--- a/resources/views/products/products-show.blade.php
+++ b/resources/views/products/products-show.blade.php
@@ -17,7 +17,9 @@
         <ul class="nav nav-tabs" id="productTab" role="tablist">
           <li class="nav-item"><a class="nav-link active" href="#Product" data-toggle="tab"><i class="fas fa-info-circle"></i> {{ __('general_content.product_info_trans_key') }}</a></li>
           <li class="nav-item"><a class="nav-link" href="#TechnicalInfo" data-toggle="tab"><i class="fas fa-cogs"></i> {{ __('general_content.tech_bom_trans_key') }} {{ $Product->getAllTaskCountAttribute() }}</a></li>
+          @can('stock-lot-serial-management')
           <li class="nav-item"><a class="nav-link" href="#Stock" data-toggle="tab"><i class="fas fa-boxes"></i> {{ __('general_content.stock_trans_key') }} ({{ $Product->StockLocationProductCount() }})</a></li>
+          @endcan
           @if($CustomFields->count() > 0)
           <li class="nav-item"><a class="nav-link" href="#CustomFields" data-toggle="tab"><i class="fas fa-list"></i> {{ __('general_content.custom_fields_trans_key') }}</a></li>
           @endif
@@ -27,7 +29,9 @@
           <li class="nav-item"><a class="nav-link" href="#quote" data-toggle="tab"><i class="fas fa-file-invoice"></i> {{ __('general_content.quotes_list_trans_key') }}</a></li>
           <li class="nav-item"><a class="nav-link" href="#order" data-toggle="tab"><i class="fas fa-shopping-cart"></i> {{ __('general_content.orders_list_trans_key') }}</a></li>
           <li class="nav-item"><a class="nav-link" href="#purchase" data-toggle="tab"><i class="fas fa-cart-arrow-down"></i> {{ __('general_content.purchase_list_trans_key') }}</a></li>
+          @can('stock-lot-serial-management')
           <li class="nav-item"><a class="nav-link" href="#serialNumber" data-toggle="tab"><i class="fas fa-barcode"></i> {{ __('general_content.serial_numbers_trans_key') }}</a></li>
+          @endcan
           
           @if($Product->drawing_file)
           <li class="nav-item"><a class="nav-link" href="#DrawingViewer" data-toggle="tab"> {{ __('general_content.drawing_trans_key') }}</a></li>
@@ -526,11 +530,13 @@
         <div class="tab-pane " id="TechnicalInfo">
           @livewire('task-manage', ['idType' => 'products_id', 'idPage' => $Product->id, 'idLine' => $Product->id, 'statu' => 1])
         </div>
+        @can('stock-lot-serial-management')
         <div class="tab-pane " id="Stock">
           <x-adminlte-card title="{{ __('general_content.stock_location_product_list_trans_key') }}" theme="primary" maximizable>
             @include('include.table-stock-locations-products')
           </x-adminlte-card>
         </div>
+        @endcan
         @if($CustomFields->count() > 0)
         <div class="tab-pane" id="CustomFields">
           @include('include.custom-fields-form', ['id' => $Product->id, 'type' => 'product'])
@@ -694,9 +700,11 @@
         <div class="tab-pane" id="purchase">
           @livewire('purchases-lines-index' , ['search_product_id' => $Product->id, 'purchase_id' => null, 'OrderStatu' => 0 ])
         </div>
+        @can('stock-lot-serial-management')
         <div class="tab-pane" id="serialNumber">
           @livewire('serial-numbers-index' , ['product_id' => $Product->id ])
         </div>
+        @endcan
         @if($Product->drawing_file)
         <div class="tab-pane" id="DrawingViewer">
           <object data="{{ asset('drawing/'. $Product->drawing_file) }}" type="application/pdf" width="100%" height="1000px"></object>

--- a/routes/web.php
+++ b/routes/web.php
@@ -394,16 +394,16 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/import', 'App\Http\Controllers\Admin\ImportsExportsController@importProducts')->name('products.import');
 
         // Serial numbers routes
-        Route::group(['prefix' => 'serial-numbers'], function () {
+        Route::group(['prefix' => 'serial-numbers', 'middleware' => ['permission:stock-lot-serial-management']], function () {
             Route::get('/', 'App\Http\Controllers\Products\SerialNumbersController@index')->name('products.serialNumbers');
         });
 
-        Route::group(['prefix' => 'batches'], function () {
+        Route::group(['prefix' => 'batches', 'middleware' => ['permission:stock-lot-serial-management']], function () {
             Route::get('/', 'App\Http\Controllers\Products\BatchesController@index')->name('products.batches');
         });
 
         // Stock routes
-        Route::group(['prefix' => 'Stock'], function () {
+        Route::group(['prefix' => 'Stock', 'middleware' => ['permission:stock-lot-serial-management']], function () {
             Route::get('/', 'App\Http\Controllers\Products\StockController@index')->name('products.stock');
             Route::post('/create', 'App\Http\Controllers\Products\StockController@store')->name('products.stock.store');
             Route::post('/edit/{id}', 'App\Http\Controllers\Products\StockController@update')->name('products.stock.update');
@@ -415,14 +415,14 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         });
 
         // Stock Location routes
-        Route::group(['prefix' => 'stock/location'], function () {
+        Route::group(['prefix' => 'stock/location', 'middleware' => ['permission:stock-lot-serial-management']], function () {
             Route::post('/create', 'App\Http\Controllers\Products\StockLocationController@store')->name('products.stocklocation.store');
             Route::post('/edit/{id}', 'App\Http\Controllers\Products\StockLocationController@update')->name('products.stocklocation.update');
             Route::get('/{id}', 'App\Http\Controllers\Products\StockLocationController@show')->name('products.stocklocation.show');
         });
 
         // Stock Location Products routes
-        Route::group(['prefix' => 'stock/location/product'], function () {
+        Route::group(['prefix' => 'stock/location/product', 'middleware' => ['permission:stock-lot-serial-management']], function () {
             Route::post('/create', 'App\Http\Controllers\Products\StockLocationProductsController@store')->name('products.stockline.store');
             Route::post('/create/internal-order', 'App\Http\Controllers\Products\StockLocationProductsController@storeFromInternalOrder')->name('products.stockline.store.from.internal.order');
             Route::post('/create/purchase-order', 'App\Http\Controllers\Products\StockLocationProductsController@storeFromPurchaseOrder')->name('products.stockline.store.from.purchase.order');


### PR DESCRIPTION
### Motivation
- Centraliser le contrôle d'accès aux fonctionnalités de gestion de stock, lots et numéros de série afin de pouvoir activer/désactiver l'accès dans l'UI et aux routes backend.
- Empêcher l'affichage et l'utilisation des onglets/option liés au stock quand l'utilisateur n'a pas la permission dédiée.

### Description
- Ajout de la permission `stock-lot-serial-management` dans le seeder `database/seeders/PermissionTableSeeder.php` pour pouvoir l'assigner aux rôles/utilisateurs.
- Ajout de la clé `can => ['stock-lot-serial-management']` dans le menu Produits (`config/adminlte.php`) pour conditionner l'affichage des entrées `serial-numbers`, `batches` et `Stock`.
- Protection des routes liées aux numéros de série, lots, stock, emplacements et mouvements de stock via le middleware `permission:stock-lot-serial-management` dans `routes/web.php`.
- Masquage conditionnel par Blade (`@can('stock-lot-serial-management')`) des onglets **Stock** et **Numéros de série** dans la fiche produit (`resources/views/products/products-show.blade.php`) et masquage des options `RemoveFromStock` / `CreateSerialNumber` dans les vues de livraison/commande (`resources/views/livewire/order-lines.blade.php` et `resources/views/livewire/deliverys-request.blade.php`).

### Testing
- Vérification syntaxique PHP sur les fichiers modifiés avec `php -l` (fichiers contrôlés : `PermissionTableSeeder.php`, `config/adminlte.php`, `routes/web.php`, `resources/views/products/products-show.blade.php`, `resources/views/livewire/order-lines.blade.php`, `resources/views/livewire/deliverys-request.blade.php`) — résultat : pas d'erreurs de syntaxe.
- Exécution d'un script Playwright pour charger l'application et capturer une capture d'écran de l'interface afin de valider visuellement l'impact sur le menu (capture générée avec succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e0d301ac832dbcae372d34395510)