### PR TITLE
Hide purchase tabs when user lacks purchases-menu permission

### DIFF
--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -19,7 +19,9 @@
       <li class="nav-item"><a class="nav-link" href="#order" data-toggle="tab">{{ __('general_content.orders_list_trans_key') }} ({{ $Companie->getOrdersCountAttribute() }})</a></li>
       <li class="nav-item"><a class="nav-link" href="#delivery" data-toggle="tab">{{ __('general_content.deliverys_notes_list_trans_key') }} ({{ $Companie->getDeliverysCountAttribute() }})</a></li>
       <li class="nav-item"><a class="nav-link" href="#invoice" data-toggle="tab">{{ __('general_content.invoices_list_trans_key') }} ({{ $Companie->getInvoicesCountAttribute() }})</a></li>
+      @can('purchases-menu')
       <li class="nav-item"><a class="nav-link" href="#purchase" data-toggle="tab">{{ __('general_content.purchase_list_trans_key') }} ({{ $Companie->getPurchasesCountAttribute() }})</a></li>
+      @endcan
       
       @if($Companie->statu_supplier == 2 )
       <li class="nav-item"><a class="nav-link" href="#evaluation" data-toggle="tab">{{ __('general_content.supplier_evaluations_trans_key') }}</a></li>
@@ -901,9 +903,11 @@
       <div class="tab-pane" id="invoice">
         @livewire('invoices-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @can('purchases-menu')
       <div class="tab-pane" id="purchase">
         @livewire('purchases-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @endcan
       <div class="tab-pane" id="evaluation">
         @php
           $newEvaluationLabel = trans('general_content.new_supplier_evaluation_trans_key');

--- a/resources/views/products/products-show.blade.php
+++ b/resources/views/products/products-show.blade.php
@@ -28,7 +28,9 @@
           @endif
           <li class="nav-item"><a class="nav-link" href="#quote" data-toggle="tab"><i class="fas fa-file-invoice"></i> {{ __('general_content.quotes_list_trans_key') }}</a></li>
           <li class="nav-item"><a class="nav-link" href="#order" data-toggle="tab"><i class="fas fa-shopping-cart"></i> {{ __('general_content.orders_list_trans_key') }}</a></li>
+          @can('purchases-menu')
           <li class="nav-item"><a class="nav-link" href="#purchase" data-toggle="tab"><i class="fas fa-cart-arrow-down"></i> {{ __('general_content.purchase_list_trans_key') }}</a></li>
+          @endcan
           @can('stock-lot-serial-management')
           <li class="nav-item"><a class="nav-link" href="#serialNumber" data-toggle="tab"><i class="fas fa-barcode"></i> {{ __('general_content.serial_numbers_trans_key') }}</a></li>
           @endcan
@@ -697,9 +699,11 @@
         <div class="tab-pane" id="order">
           @livewire('orders-lines-index' , ['product_id' => $Product->id ])
         </div>
+        @can('purchases-menu')
         <div class="tab-pane" id="purchase">
           @livewire('purchases-lines-index' , ['search_product_id' => $Product->id, 'purchase_id' => null, 'OrderStatu' => 0 ])
         </div>
+        @endcan
         @can('stock-lot-serial-management')
         <div class="tab-pane" id="serialNumber">
           @livewire('serial-numbers-index' , ['product_id' => $Product->id ])


### PR DESCRIPTION
### Motivation
- Prevent users without the `purchases-menu` permission from seeing purchase-related UI on Company and Product detail pages to avoid unauthorized access to purchase lists.

### Description
- Wrap the purchase tab entry and its content pane with `@can('purchases-menu')` in `resources/views/companies/companies-show.blade.php` so the tab and its `@livewire('purchases-index')` pane are only shown to authorized users.
- Wrap the purchase tab entry and its content pane with `@can('purchases-menu')` in `resources/views/products/products-show.blade.php` so the tab and its `@livewire('purchases-lines-index')` pane are only shown to authorized users.
- No backend routes or controllers were modified; this is a view-level permission gating change.

### Testing
- Ran `php -l resources/views/companies/companies-show.blade.php` and it returned no syntax errors.
- Ran `php -l resources/views/products/products-show.blade.php` and it returned no syntax errors.
- Captured a headless UI screenshot via Playwright to validate the purchase tab is hidden for an unauthorized view and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e36294b0832db30dcc41680b37e1)