### PR TITLE
Hide stock status badge colors for users without stock permission

### DIFF
--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -123,9 +123,10 @@
                             </td>
                             <td>
                                 @if($OrderLine->order->type == 2)
-                                    @if(1 == $OrderLine->delivery_status )  <span class="badge badge-info">{{ __('general_content.not_delivered_trans_key') }}</span>@endif
-                                    @if(2 == $OrderLine->delivery_status )  <span class="badge badge-warning">{{ __('general_content.partly_stored_trans_key') }}</span>@endif
-                                    @if(3 == $OrderLine->delivery_status )  <span class="badge badge-success">{{ __('general_content.stock_trans_key') }}</span>@endif
+                                    @php($stockBadgeClass = auth()->user()->can('stock-lot-serial-management') ? 'badge' : '')
+                                    @if(1 == $OrderLine->delivery_status )  <span class="{{ trim($stockBadgeClass . ' badge-info') }}">{{ __('general_content.not_delivered_trans_key') }}</span>@endif
+                                    @if(2 == $OrderLine->delivery_status )  <span class="{{ trim($stockBadgeClass . ' badge-warning') }}">{{ __('general_content.partly_stored_trans_key') }}</span>@endif
+                                    @if(3 == $OrderLine->delivery_status )  <span class="{{ trim($stockBadgeClass . ' badge-success') }}">{{ __('general_content.stock_trans_key') }}</span>@endif
                                 @else
                                     @if(1 == $OrderLine->delivery_status )  <span class="badge badge-info">{{ __('general_content.not_delivered_trans_key') }}</span>@endif
                                     @if(2 == $OrderLine->delivery_status )  

--- a/resources/views/livewire/orders-lines-index.blade.php
+++ b/resources/views/livewire/orders-lines-index.blade.php
@@ -72,9 +72,10 @@
                             </td>
                             <td>
                                 @if($OrderLine->order->type == 2)
-                                    @if(1 == $OrderLine->delivery_status )  <span class="badge badge-info">{{ __('general_content.not_delivered_trans_key') }}</span>@endif
-                                    @if(2 == $OrderLine->delivery_status )  <span class="badge badge-warning">{{ __('general_content.partly_stored_trans_key') }}</span>@endif
-                                    @if(3 == $OrderLine->delivery_status )  <span class="badge badge-success">{{ __('general_content.stock_trans_key') }}</span>@endif
+                                    @php($stockBadgeClass = auth()->user()->can('stock-lot-serial-management') ? 'badge' : '')
+                                    @if(1 == $OrderLine->delivery_status )  <span class="{{ trim($stockBadgeClass . ' badge-info') }}">{{ __('general_content.not_delivered_trans_key') }}</span>@endif
+                                    @if(2 == $OrderLine->delivery_status )  <span class="{{ trim($stockBadgeClass . ' badge-warning') }}">{{ __('general_content.partly_stored_trans_key') }}</span>@endif
+                                    @if(3 == $OrderLine->delivery_status )  <span class="{{ trim($stockBadgeClass . ' badge-success') }}">{{ __('general_content.stock_trans_key') }}</span>@endif
                                 @else
                                     @if(1 == $OrderLine->delivery_status )  <span class="badge badge-info">{{ __('general_content.not_delivered_trans_key') }}</span>@endif
                                     @if(2 == $OrderLine->delivery_status )  


### PR DESCRIPTION
### Motivation
- Prevent showing color-coded stock status badges on order lines for users who do not have the stock management permission, while keeping the status text visible.

### Description
- Added a conditional `$stockBadgeClass = auth()->user()->can('stock-lot-serial-management') ? 'badge' : ''` and applied it to the delivery status badge class concatenation for `order->type == 2` cases in two Livewire views.
- Updated `resources/views/livewire/order-lines.blade.php` to use the conditional class when rendering delivery status for stock-type orders.
- Applied the same change to `resources/views/livewire/orders-lines-index.blade.php` to keep UI behavior consistent across list views.

### Testing
- Ran `php -l resources/views/livewire/orders-lines-index.blade.php` which reported no syntax errors.
- Ran `php -l resources/views/livewire/order-lines.blade.php` which reported no syntax errors.
- Executed an automated Playwright script to capture a screenshot of the modified page, producing an artifact (`artifacts/order-lines-stock-status.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f537ec74832d8b6fc310ca20cf0c)