### PR TITLE
Add bulk product creation action for selected order lines

### DIFF
--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -1038,13 +1038,20 @@ class OrderLine extends Component
     // Helper method to check if lines exist
     private function linesExist()
     {
-        $i = 0;
-        foreach ($this->data as $key => $item) {
-            if (array_key_exists("order_line_id", $this->data[$key]) && $this->data[$key]['order_line_id'] != false) {
-                $i++;
-            }
-        }
-        return $i > 0;
+        return !empty($this->getSelectedLineIds());
+    }
+
+    private function getSelectedLineIds(): array
+    {
+        return collect($this->data)
+            ->filter(function ($item) {
+                return !empty($item['order_line_id']);
+            })
+            ->keys()
+            ->map(function ($lineId) {
+                return (int) $lineId;
+            })
+            ->all();
     }
 
     // Helper method to create serial numbers
@@ -1104,7 +1111,9 @@ class OrderLine extends Component
 
     public function storeDelevery($orderId)
     {
-        if (!$this->linesExist()) {
+        $selectedLineIds = $this->getSelectedLineIds();
+
+        if (empty($selectedLineIds)) {
             $errors = $this->getErrorBag();
             $errors->add('errors', 'no lines selected');
             return;
@@ -1124,7 +1133,7 @@ class OrderLine extends Component
         $DeliveryCreated = $this->deliveryService->createDelivery($deliveryCode, $deliveryCode, $OrderData->companies_id, $OrderData->companies_addresses_id, $OrderData->companies_contacts_id, $user->id);
 
         if ($DeliveryCreated) {
-            foreach ($this->data as $key => $item) {
+            foreach ($selectedLineIds as $key) {
                 $OrderLineData = OrderLines::find($key);
                 $this->deliveryLineService->createDeliveryLine($DeliveryCreated, $key, $this->deleveryOrdre, $OrderLineData->delivered_remaining_qty);
 
@@ -1148,7 +1157,9 @@ class OrderLine extends Component
 
     public function storeInvoice($orderId)
     {
-        if (!$this->linesExist()) {
+        $selectedLineIds = $this->getSelectedLineIds();
+
+        if (empty($selectedLineIds)) {
             $errors = $this->getErrorBag();
             $errors->add('errors', 'no lines selected');
             return;
@@ -1168,7 +1179,7 @@ class OrderLine extends Component
         $InvoiceCreated = $this->invoiceService->createInvoice($invoiceCode, $invoiceCode, $OrderData->companies_id, $OrderData->companies_addresses_id, $OrderData->companies_contacts_id, $user->id);
 
         if ($InvoiceCreated) {
-            foreach ($this->data as $key => $item) {
+            foreach ($selectedLineIds as $key) {
                 $OrderLineData = OrderLines::find($key);
                 $this->invoiceLineService->createInvoiceLine($InvoiceCreated, $key, null, $this->invoiceOrdre, $OrderLineData->invoiced_remaining_qty, $OrderLineData->accounting_vats_id);
 
@@ -1190,5 +1201,22 @@ class OrderLine extends Component
         } else {
             return redirect()->back()->with('error', 'Something went wrong');
         }
+    }
+
+    public function createProductsFromSelectedLines(): void
+    {
+        $selectedLineIds = $this->getSelectedLineIds();
+
+        if (empty($selectedLineIds)) {
+            $errors = $this->getErrorBag();
+            $errors->add('errors', 'no lines selected');
+            return;
+        }
+
+        foreach ($selectedLineIds as $lineId) {
+            $this->createProduct($lineId);
+        }
+
+        session()->flash('success', __('general_content.create_products_from_selected_lines_success_trans_key'));
     }
 }

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -467,6 +467,8 @@ return [
     'delete_line_trans_key'             => 'حذف السطر',
     'break_down_task_trans_key'         => 'تفكيك مهمة المادة',
     'create_product_trans_key'          => 'إنشاء منتج من هذا السطر',
+    'create_products_from_selected_lines_trans_key'    => 'إنشاء المنتجات من السطور المحددة',
+    'create_products_from_selected_lines_success_trans_key' => 'تم إنشاء المنتجات للسطور المحددة',
 
     //LABEL
     'customer_info_trans_key'        => 'معلومات العميل',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -526,6 +526,8 @@ return [
     'delete_line_trans_key'                    => 'Delete line',
     'break_down_task_trans_key'                => 'Break down the article task',
     'create_product_trans_key'                 => 'Create item from this line',
+    'create_products_from_selected_lines_trans_key'    => 'Create items from selected lines',
+    'create_products_from_selected_lines_success_trans_key' => 'Items created for selected lines',
 
     //LABEL
     'customer_info_trans_key'                  => 'Customer information',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -466,6 +466,8 @@ return [
     'delete_line_trans_key'                    => 'Eliminar línea',
     'break_down_task_trans_key'                => 'Desglosar la tarea del artículo',
     'create_product_trans_key'                 => 'Crear artículo a partir de esta línea',
+    'create_products_from_selected_lines_trans_key'    => 'Crear artículos de las líneas seleccionadas',
+    'create_products_from_selected_lines_success_trans_key' => 'Artículos creados para las líneas seleccionadas',
 
     //LABEL
     'customer_info_trans_key'                  => 'Información del cliente',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -526,6 +526,8 @@ return [
     'delete_line_trans_key'                    => 'Effacer la ligne',
     'break_down_task_trans_key'                => 'Décomposer les taches de l\'article',
     'create_product_trans_key'                 => 'Créer article à partir de cette ligne',
+    'create_products_from_selected_lines_trans_key'    => 'Créer les articles des lignes sélectionnées',
+    'create_products_from_selected_lines_success_trans_key' => 'Articles créés pour les lignes sélectionnées',
 
     //LABEL
     'customer_info_trans_key'                  => 'Information client',

--- a/resources/lang/zh-CN/general_content.php
+++ b/resources/lang/zh-CN/general_content.php
@@ -516,6 +516,8 @@ return [
     'delete_line_trans_key'                    => '删除行',
     'break_down_task_trans_key'                => '分解该物料的任务',
     'create_product_trans_key'                 => '由此行创建产品',
+    'create_products_from_selected_lines_trans_key'    => '从所选行创建产品',
+    'create_products_from_selected_lines_success_trans_key' => '已为所选行创建产品',
 
     //LABEL
     'customer_info_trans_key'                  => '客户信息',

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -684,14 +684,19 @@
                                 @endcan
                                 <div>
                                     @if($OrderStatu != 6)
-                                        <a class="btn btn-primary btn-sm" wire:click="storeDelevery({{ $OrderId }})" href="#">
+                                        <a class="btn btn-success btn-sm mb-1" wire:click="createProductsFromSelectedLines" href="#">
+                                            <i class="fas fa-barcode"></i>
+                                            {{ __('general_content.create_products_from_selected_lines_trans_key') }}
+                                        </a>
+
+                                        <a class="btn btn-primary btn-sm mb-1" wire:click="storeDelevery({{ $OrderId }})" href="#">
                                             <i class="fas fa-folder"></i>
                                             {{ __('general_content.new_delivery_note_trans_key') }}
                                         </a>
                                         
                                         or
 
-                                        <a class="btn btn-primary btn-sm" wire:click="storeInvoice({{ $OrderId }})" href="#">
+                                        <a class="btn btn-primary btn-sm mb-1" wire:click="storeInvoice({{ $OrderId }})" href="#">
                                             <i class="fas fa-folder"></i>
                                             {{ __('general_content.new_invoice_trans_key') }}
                                         </a>


### PR DESCRIPTION
### Motivation
- Provide a bulk action to create products from multiple order lines selected with the existing checkboxes so users can create items in batch from the order lines view. 
- Reuse existing selection UI (checkboxes + select-all) to avoid adding new selection controls. 

### Description
- Added `getSelectedLineIds()` helper to `app/Livewire/OrderLine.php` and replaced older iteration logic with this helper. 
- Added `createProductsFromSelectedLines()` Livewire action that calls existing `createProduct()` for each selected line and flashes a success message. 
- Updated `storeDelevery()` and `storeInvoice()` to process only selected line ids returned by `getSelectedLineIds()`. 
- Added a new button in `resources/views/livewire/order-lines.blade.php` to trigger the bulk creation action and added translation keys in `resources/lang/{fr,en,es,ar,zh-CN}/general_content.php` for the button label and success message. 

### Testing
- Ran `php -l` syntax checks on `app/Livewire/OrderLine.php` and updated `resources/lang/*/general_content.php` files and they all reported no syntax errors. 
- Verified the modified view `resources/views/livewire/order-lines.blade.php` contains the new button and references the translation key. 
- Attempt to run `php artisan serve` failed in this environment due to missing dependencies (`vendor/autoload.php`), so full runtime/interactive validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f5f399f4832d89331100aaa89701)