### PR TITLE
Fix missing company logo in delivery and invoice PDFs

### DIFF
--- a/resources/views/print/pdf-delivery.blade.php
+++ b/resources/views/print/pdf-delivery.blade.php
@@ -46,6 +46,9 @@
             <table width="100%; border: none; ">
                 <tr>
                     <td align="left" style="width: 50%; background-color: {{ $Factory->pdf_header_font_color }}">
+                        @if($image)
+                            <img src="data:image/png;base64,{{ $image }}" alt="Logo" style="height: 120px;"/>
+                        @endif
                     </td>
                     <td colspan="2" align="center" style="width: 400%; background-color: {{ $Factory->pdf_header_font_color }}">
                         <h2>{{ $typeDocumentName }}</h2>

--- a/resources/views/print/pdf-invoice.blade.php
+++ b/resources/views/print/pdf-invoice.blade.php
@@ -44,6 +44,9 @@
             <table width="100%; border: none; ">
                 <tr>
                     <td align="left" style="width: 50%; background-color: {{ $Factory->pdf_header_font_color }}">
+                        @if($image)
+                            <img src="data:image/png;base64,{{ $image }}" alt="Logo" style="height: 120px;"/>
+                        @endif
                     </td>
                     <td colspan="2" align="center" style="width: 400%; background-color: {{ $Factory->pdf_header_font_color }}">
                         <h2>{{ $typeDocumentName }}</h2>


### PR DESCRIPTION
### Motivation
- Delivery and invoice PDF templates were not displaying the company logo in the header even though the `$image` variable is provided, resulting in unbranded PDFs.

### Description
- Inserted a conditional logo block `@if($image) <img src="data:image/png;base64,{{ $image }}" alt="Logo" style="height: 120px;"/> @endif` into the header of `resources/views/print/pdf-delivery.blade.php` and `resources/views/print/pdf-invoice.blade.php` to render the factory logo when available.

### Testing
- Ran `git diff --check` to ensure no whitespace/conflict issues and reviewed the template diffs to confirm the logo markup was correctly inserted, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fa6ea174832daeac79167b6a2503)