### PR TITLE
Add creation date range filter to /fr/products listing

### DIFF
--- a/app/Livewire/ProductsIndex.php
+++ b/app/Livewire/ProductsIndex.php
@@ -16,6 +16,8 @@ class ProductsIndex extends Component
     protected $paginationTheme = 'bootstrap';
     
     public $search = '';
+    public $createdAtFrom = '';
+    public $createdAtTo = '';
     public $sortField = 'label'; // default sorting field
     public $sortAsc = true; // default sort direction
     
@@ -76,6 +78,16 @@ class ProductsIndex extends Component
         $this->resetPage();
     }
 
+    public function updatingCreatedAtFrom()
+    {
+        $this->resetPage();
+    }
+
+    public function updatingCreatedAtTo()
+    {
+        $this->resetPage();
+    }
+
     public function mount() 
     {
         $this->userSelect = User::select('id', 'name')->get();
@@ -83,7 +95,15 @@ class ProductsIndex extends Component
 
     public function render()
     {
-        $Products = Products::where('label','like', '%'.$this->search.'%')->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->paginate(15);
+        $Products = Products::where('label', 'like', '%'.$this->search.'%')
+            ->when($this->createdAtFrom, function ($query) {
+                $query->whereDate('created_at', '>=', $this->createdAtFrom);
+            })
+            ->when($this->createdAtTo, function ($query) {
+                $query->whereDate('created_at', '<=', $this->createdAtTo);
+            })
+            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+            ->paginate(15);
         $userSelect = User::select('id', 'name')->get();
         $ServicesSelect = MethodsServices::select('id', 'label')->orderBy('ordre')->get();
         $UnitsSelect = MethodsUnits::select('id', 'label', 'type')->orderBy('label')->get();

--- a/resources/views/livewire/products-index.blade.php
+++ b/resources/views/livewire/products-index.blade.php
@@ -316,9 +316,28 @@
     <div class="card">
         <div class="card-body">
             <div class="row">
-                <div class="col-md-10">
+                <div class="col-md-8">
                     @include('include.search-card')
                 </div>
+                <div class="col-md-2">
+                    <div class="input-group mb-3">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text"><i class="fas fa-calendar-alt fa-fw"></i></span>
+                        </div>
+                        <input type="date" class="form-control" wire:model.live="createdAtFrom" aria-label="Date de création du" title="Date de création du">
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="input-group mb-3">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text"><i class="fas fa-calendar-alt fa-fw"></i></span>
+                        </div>
+                        <input type="date" class="form-control" wire:model.live="createdAtTo" aria-label="Date de création au" title="Date de création au">
+                    </div>
+                </div>
+            </div>
+            <div class="row mb-2">
+                <div class="col-md-10"></div>
                 <div class="col-md-2">
                     <button type="button" class="btn btn-success float-sm-right" data-toggle="modal" data-target="#ModalProduct">
                         {{ __('general_content.new_product_trans_key') }}


### PR DESCRIPTION
### Motivation
- Provide a simple way to filter products list by creation date range on the `/fr/products` index so users can narrow results by `created_at`.

### Description
- Added two Livewire state properties `createdAtFrom` and `createdAtTo` to `ProductsIndex` and added `updatingCreatedAtFrom()` / `updatingCreatedAtTo()` to reset pagination when filters change.
- Updated the products query in `render()` to apply optional `whereDate('created_at', '>=', ...)` and `whereDate('created_at', '<=', ...)` using `when()`.
- Added two `type="date"` inputs in `resources/views/livewire/products-index.blade.php` bound to `createdAtFrom` and `createdAtTo` and adjusted layout to keep the create-product button visible.

### Testing
- Linted PHP files with `php -l app/Livewire/ProductsIndex.php` and `php -l resources/views/livewire/products-index.blade.php`, both returned no syntax errors (success).
- Attempted to run the app with `php artisan serve`, which failed in this environment due to missing `vendor/autoload.php`, so full runtime verification could not be performed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ff103430832d914df21b02020b1e)