### PR TITLE
Filter company tabs by user permissions

### DIFF
--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -14,11 +14,21 @@
       <li class="nav-item"><a class="nav-link" href="#Company" data-toggle="tab">{{ __('general_content.detail_trans_key') }}</a></li>
       <li class="nav-item"><a class="nav-link" href="#Adresses" data-toggle="tab">{{ __('general_content.adress_trans_key') }} ({{ $Companie->getAddressesCountAttribute() }})</a></li>
       <li class="nav-item"><a class="nav-link" href="#Contact" data-toggle="tab">{{ __('general_content.contacts_trans_key') }} ({{ $Companie->getContactsCountAttribute() }})</a></li>
+      @can('leads-menu')
       <li class="nav-item"><a class="nav-link" href="#lead" data-toggle="tab">{{ __('general_content.leads_trans_key') }} ({{ $Companie->getLeadsCountAttribute() }})</a></li>
+      @endcan
+      @can('quotes-menu')
       <li class="nav-item"><a class="nav-link" href="#quote" data-toggle="tab">{{ __('general_content.quotes_list_trans_key') }} ({{ $Companie->getQuotesCountAttribute() }})</a></li>
+      @endcan
+      @can('orders-menu')
       <li class="nav-item"><a class="nav-link" href="#order" data-toggle="tab">{{ __('general_content.orders_list_trans_key') }} ({{ $Companie->getOrdersCountAttribute() }})</a></li>
+      @endcan
+      @can('deliverys-menu')
       <li class="nav-item"><a class="nav-link" href="#delivery" data-toggle="tab">{{ __('general_content.deliverys_notes_list_trans_key') }} ({{ $Companie->getDeliverysCountAttribute() }})</a></li>
+      @endcan
+      @can('invoices-menu')
       <li class="nav-item"><a class="nav-link" href="#invoice" data-toggle="tab">{{ __('general_content.invoices_list_trans_key') }} ({{ $Companie->getInvoicesCountAttribute() }})</a></li>
+      @endcan
       @can('purchases-menu')
       <li class="nav-item"><a class="nav-link" href="#purchase" data-toggle="tab">{{ __('general_content.purchase_list_trans_key') }} ({{ $Companie->getPurchasesCountAttribute() }})</a></li>
       @endcan
@@ -888,21 +898,31 @@
         <!-- /.row -->
         </div> 
       </div>
+      @can('leads-menu')
       <div class="tab-pane" id="lead">
         @livewire('leads-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @endcan
+      @can('quotes-menu')
       <div class="tab-pane" id="quote">
         @livewire('quotes-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @endcan
+      @can('orders-menu')
       <div class="tab-pane" id="order">
         @livewire('orders-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @endcan
+      @can('deliverys-menu')
       <div class="tab-pane" id="delivery">
         @livewire('deliverys-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @endcan
+      @can('invoices-menu')
       <div class="tab-pane" id="invoice">
         @livewire('invoices-index' , ['idCompanie' => $Companie->id ])
       </div>
+      @endcan
       @can('purchases-menu')
       <div class="tab-pane" id="purchase">
         @livewire('purchases-index' , ['idCompanie' => $Companie->id ])


### PR DESCRIPTION
### Motivation
- Ensure the company detail page only shows business-related tabs (Leads, Quotes, Orders, Delivery notes, Invoices) to users who have the corresponding permissions so unauthorized sections are not exposed.

### Description
- Wrap tab navigation items in `@can('...')` directives for `leads-menu`, `quotes-menu`, `orders-menu`, `deliverys-menu`, and `invoices-menu` in `resources/views/companies/companies-show.blade.php`.
- Wrap the corresponding tab panes (Livewire components) with the same `@can` directives to keep visible content consistent with the navigation.
- Only `resources/views/companies/companies-show.blade.php` was modified.

### Testing
- Attempted `php artisan test --filter=CompanyApiTest` which failed because dependencies are not installed (`vendor/autoload.php` missing), so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b402f88e08832d97a6971b59f7e80d)