### PR TITLE
Add third-party license inventory to licence page

### DIFF
--- a/resources/views/licence.blade.php
+++ b/resources/views/licence.blade.php
@@ -32,6 +32,178 @@
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
         SOFTWARE.
     </p>
+
+    <hr/>
+
+    <h3>THIRD PARTY LICENSES</h3>
+    <p><strong>WEM (Web ERP MES)</strong></p>
+    <p>
+        This product includes software developed by third parties.<br/>
+        The following libraries are used under their respective licenses.
+    </p>
+
+    <pre style="white-space: pre-wrap;">
+------------------------------------------------------------
+MIT License
+------------------------------------------------------------
+The following components are licensed under the MIT License:
+
+almasaeed2010/adminlte
+barryvdh/laravel-dompdf
+brick/math
+carbonphp/carbon-doctrine-types
+composer/ca-bundle
+composer/class-map-generator
+composer/composer
+composer/metadata-minifier
+composer/pcre
+composer/semver
+composer/spdx-licenses
+composer/xdebug-handler
+dflydev/dot-access-data
+directorytree/ldaprecord
+directorytree/ldaprecord-laravel
+doctrine/dbal
+doctrine/deprecations
+doctrine/event-manager
+doctrine/inflector
+doctrine/instantiator
+doctrine/lexer
+dominikb/composer-license-checker
+dragonbe/vies
+dragonmantank/cron-expression
+egulias/email-validator
+fakerphp/faker
+filp/whoops
+fruitcake/php-cors
+goetas-webservices/xsd2php-runtime
+graham-campbell/result-type
+guzzlehttp/guzzle
+guzzlehttp/promises
+guzzlehttp/psr7
+guzzlehttp/uri-template
+horstoeko/mimedb
+horstoeko/stringmanagement
+horstoeko/zugferd
+intervention/gif
+intervention/image
+jaybizzle/crawler-detect
+jenssegers/agent
+jeroennoten/laravel-adminlte
+jms/metadata
+jms/serializer
+justinrainbow/json-schema
+laravel/breeze
+laravel/framework
+laravel/prompts
+laravel/sail
+laravel/serializable-closure
+laravel/telescope
+laravel/tinker
+laravel/ui
+laravolt/avatar
+league/flysystem
+league/flysystem-local
+league/mime-type-detection
+league/uri
+league/uri-interfaces
+livewire/livewire
+maatwebsite/excel
+maennchen/zipstream-php
+markbaker/complex
+markbaker/matrix
+masterminds/html5
+mcamara/laravel-localization
+milon/barcode
+mobiledetect/mobiledetectlib
+monolog/monolog
+myclabs/deep-copy
+nesbot/carbon
+nunomaduro/collision
+nunomaduro/termwind
+phpoffice/phpspreadsheet
+phpstan/phpdoc-parser
+predis/predis
+protonemedia/laravel-cross-eloquent-search
+psr/cache
+psr/clock
+psr/container
+psr/event-dispatcher
+psr/http-client
+psr/http-factory
+psr/http-message
+psr/log
+psr/simple-cache
+psy/psysh
+pusher/pusher-php-server
+ralouphie/getallheaders
+ramsey/collection
+ramsey/uuid
+react/promise
+sabberworm/php-css-parser
+seld/jsonlint
+seld/phar-utils
+seld/signal-handler
+setasign/fpdf
+setasign/fpdi
+spatie/backtrace
+spatie/error-solutions
+spatie/flare-client-php
+spatie/ignition
+spatie/laravel-activitylog
+spatie/laravel-ignition
+spatie/laravel-package-tools
+spatie/laravel-permission
+staabm/side-effects-detector
+symfony/*
+thecodingmachine/safe
+voku/portable-ascii
+webklex/laravel-pdfmerger
+
+------------------------------------------------------------
+BSD-3-Clause License
+------------------------------------------------------------
+
+hamcrest/hamcrest-php
+league/commonmark
+league/config
+marc-mabe/php-enum
+mockery/mockery
+nikic/php-parser
+phpunit/*
+sebastian/*
+theseer/tokenizer
+tijsverkoyen/css-to-inline-styles
+vlucas/phpdotenv
+
+------------------------------------------------------------
+Apache License 2.0
+------------------------------------------------------------
+
+phpoption/phpoption
+
+------------------------------------------------------------
+ISC License
+------------------------------------------------------------
+
+paragonie/sodium_compat
+
+------------------------------------------------------------
+LGPL Licenses
+------------------------------------------------------------
+
+dompdf/dompdf (LGPL-2.1)
+dompdf/php-font-lib (LGPL-2.1-or-later)
+dompdf/php-svg-lib (LGPL-3.0-or-later)
+ezyang/htmlpurifier (LGPL-2.1-or-later)
+smalot/pdfparser (LGPL-3.0)
+
+------------------------------------------------------------
+
+Full license texts for the above libraries can be found in the
+vendor directories of this distribution or in the respective
+upstream repositories.
+    </pre>
 </div>
 @stop
 


### PR DESCRIPTION
### Motivation
- Provide clear attribution for third-party software used by the product by adding a dedicated licenses inventory to the existing licence page. 
- Ensure legal transparency by grouping dependencies by license type and making the information available on the `/licence` view.

### Description
- Appended a `THIRD PARTY LICENSES` section to `resources/views/licence.blade.php` that follows the existing WEM MIT license text. 
- The new section includes a short intro and a formatted `pre` block listing packages grouped under **MIT**, **BSD-3-Clause**, **Apache-2.0**, **ISC**, and **LGPL** headings. 
- No other templates, routes, or application logic were changed.

### Testing
- Attempted to run `php artisan view:cache`, which failed in this environment because `vendor/autoload.php` is missing (environmental dependency issue). 
- Ran an automated Playwright script to fetch `http://127.0.0.1:8000/licence` and capture a screenshot; the script executed and produced a screenshot artifact, but the page returned `Not Found` in this test environment. 
- Inspected the updated template file contents and diff to confirm the new block is present and correctly formatted in `resources/views/licence.blade.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40ace833c832d8a98c7a2c8063794)