### PR TITLE
Fix quote-line custom field loading when product ID is a string

### DIFF
--- a/app/Services/CustomFieldService.php
+++ b/app/Services/CustomFieldService.php
@@ -34,8 +34,12 @@ class CustomFieldService
      * previously saved for the provided quote line (entity_type = quote_line)
      * and the product's own value as a fallback.
      */
-    public function getProductCustomFieldsForQuoteLine(?int $productId, int $quoteLineId)
+    public function getProductCustomFieldsForQuoteLine(int|string|null $productId, int $quoteLineId)
     {
+        if (is_string($productId)) {
+            $productId = ctype_digit($productId) ? (int) $productId : null;
+        }
+
         if (!$productId) {
             return collect();
         }


### PR DESCRIPTION
### Motivation
- Livewire-bound product IDs may arrive as strings which caused a PHP type error in `CustomFieldService::getProductCustomFieldsForQuoteLine()` when the method required `?int` input. 
- The code needs to accept numeric string IDs and safely handle non-numeric values to avoid runtime failures. 

### Description
- Broadened the method signature to accept `int|string|null` for the ` $productId` parameter in `app/Services/CustomFieldService.php`. 
- Added normalization logic to convert numeric strings to integers via `ctype_digit` and cast before using the value in the query. 
- Non-numeric strings are treated as `null`, preserving the existing early-return behavior that yields an empty collection and prevents invalid queries. 

### Testing
- Ran `php -l app/Services/CustomFieldService.php` and the file reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42667c8a4832d84e61da74aac3a2e)