### PR TITLE
Fix type mismatch when loading quote line product custom fields

### DIFF
--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -281,8 +281,10 @@ class QuoteLine extends Component
     private function loadProductCustomFields($quoteLines): void
     {
         foreach ($quoteLines as $line) {
+            $productId = is_numeric($line->product_id) ? (int) $line->product_id : null;
+
             $this->productCustomFields[$line->id] = $this->customFieldService
-                ->getProductCustomFieldsForQuoteLine($line->product_id, $line->id);
+                ->getProductCustomFieldsForQuoteLine($productId, $line->id);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a runtime type error where `CustomFieldService::getProductCustomFieldsForQuoteLine()` (signature `(?int $productId, int $quoteLineId)`) could receive a string from quote line data, causing an "Argument #1 must be of type ?int, string given" error.

### Description
- In `app/Livewire/QuoteLine.php` updated `loadProductCustomFields()` to normalize `product_id` using `is_numeric()` and cast it to `int` or use `null` when non-numeric, then pass the normalized `$productId` to `getProductCustomFieldsForQuoteLine()`.

### Testing
- Ran `php -l app/Livewire/QuoteLine.php` and the file reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b426a01b7c832d857a6c1d6b722c4d)