### PR TITLE
Fix TaskManage context product ID return typing

### DIFF
--- a/app/Livewire/TaskManage.php
+++ b/app/Livewire/TaskManage.php
@@ -705,12 +705,21 @@ class TaskManage extends Component
     private function determineContextProductId(): ?int
     {
         return match ($this->idType) {
-            'products_id' => $this->idLine,
-            'quote_lines_id' => QuoteLines::whereKey($this->idLine)->value('product_id'),
-            'order_lines_id' => OrderLines::whereKey($this->idLine)->value('product_id'),
-            'sub_assembly_id' => SubAssembly::whereKey($this->idLine)->value('products_id'),
+            'products_id' => $this->castToNullableInt($this->idLine),
+            'quote_lines_id' => $this->castToNullableInt(QuoteLines::whereKey($this->idLine)->value('product_id')),
+            'order_lines_id' => $this->castToNullableInt(OrderLines::whereKey($this->idLine)->value('product_id')),
+            'sub_assembly_id' => $this->castToNullableInt(SubAssembly::whereKey($this->idLine)->value('products_id')),
             default => null,
         };
+    }
+
+    private function castToNullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
     }
 
     private function loadToolsForProduct(?int $productId): void


### PR DESCRIPTION
### Motivation
- Prevent a runtime type error where `TaskManage::determineContextProductId()` could return string values instead of the declared `?int` by normalizing values returned from Livewire state and DB lookups.

### Description
- Update `determineContextProductId()` to cast all branches to `?int` by calling a new helper `castToNullableInt()` so every match arm returns a nullable integer.
- Add private helper `castToNullableInt(mixed $value): ?int` which converts `null`/empty string to `null` and otherwise casts the value to `int`.

### Testing
- Ran `php -l app/Livewire/TaskManage.php` to validate PHP syntax, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b435929e94832db85e03b83cc5477d)