### PR TITLE
Guard order-line stock color by permission check

### DIFF
--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -92,7 +92,7 @@
                                 </div>
                             </td>
                             <td>{{ $OrderLine->code }}</td>
-                            <td   @if($OrderLine->product_id )  class="bg-{{ $OrderLine->Product->getColorStockStatu() }} color-palette" @endif>
+                            <td @if($OrderLine->product_id && auth()->user()->can('stock-lot-serial-management')) class="bg-{{ $OrderLine->Product->getColorStockStatu() }} color-palette" @endif>
                                 @if($OrderLine->product_id ) <x-ButtonTextView route="{{ route('products.show', ['id' => $OrderLine->product_id])}}" />@endif
                             </td>
                             <td>{{ $OrderLine->label }}</td>


### PR DESCRIPTION
### Motivation
- Prevent the stock-status background color from being shown on order lines for users who do not have the `stock-lot-serial-management` permission.

### Description
- Updated `resources/views/livewire/order-lines.blade.php` to require `auth()->user()->can('stock-lot-serial-management')` in the conditional that adds `class="bg-{{ $OrderLine->Product->getColorStockStatu() }} color-palette"`, while leaving the product link rendering unchanged.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4363ddc08832d8fd1d952ee500225)