### PR TITLE
Filter email template document type selection by permissions

### DIFF
--- a/app/Http/Controllers/Admin/EmailTemplateController.php
+++ b/app/Http/Controllers/Admin/EmailTemplateController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use App\Models\Admin\EmailTemplate;
 
 class EmailTemplateController extends Controller
@@ -10,13 +11,17 @@ class EmailTemplateController extends Controller
     public function index()
     {
         $emailTemplates = EmailTemplate::all();
-        return view('admin/templates-index', compact('emailTemplates'));
+        $availableDocumentTypes = $this->availableDocumentTypes();
+
+        return view('admin/templates-index', compact('emailTemplates', 'availableDocumentTypes'));
     }
 
     public function store(Request $request)
     {
+        $allowedDocumentTypes = array_keys($this->availableDocumentTypes());
+
         $request->validate([
-            'document_type' => 'required|string',
+            'document_type' => ['required', 'string', Rule::in($allowedDocumentTypes)],
             'subject' => 'required|string',
             'content' => 'required|string',
         ]);
@@ -43,5 +48,34 @@ class EmailTemplateController extends Controller
         $emailTemplate->delete();
 
         return redirect()->back()->with('success', 'Modèle supprimé avec succès !');
+    }
+
+    private function availableDocumentTypes(): array
+    {
+        $documentTypes = [];
+
+        if (auth()->user()->can('quotes-menu')) {
+            $documentTypes['quote'] = 'general_content.quote_trans_key';
+        }
+
+        if (auth()->user()->can('orders-menu')) {
+            $documentTypes['order'] = 'general_content.orders_trans_key';
+        }
+
+        if (auth()->user()->can('deliverys-menu')) {
+            $documentTypes['delivery'] = 'general_content.delivery_notes_trans_key';
+        }
+
+        if (auth()->user()->can('invoices-menu')) {
+            $documentTypes['invoice'] = 'general_content.invoice_trans_key';
+            $documentTypes['creditnote'] = 'general_content.credit_note_trans_key';
+        }
+
+        if (auth()->user()->can('purchases-menu')) {
+            $documentTypes['purchase-quotation'] = 'general_content.requests_for_quotation_list_trans_key';
+            $documentTypes['purchase'] = 'general_content.purchase_order_trans_key';
+        }
+
+        return $documentTypes;
     }
 }

--- a/resources/views/admin/templates-index.blade.php
+++ b/resources/views/admin/templates-index.blade.php
@@ -64,13 +64,11 @@
                 <div class="form-group">
                     <label>{{ __('general_content.entity_type_trans_key') }} :</label>
                     <select class="form-control" name="document_type" required>
-                        <option value="quote">{{ __('general_content.quote_trans_key') }}</option>
-                        <option value="order">{{ __('general_content.orders_trans_key') }}</option>
-                        <option value="delivery">{{ __('general_content.delivery_notes_trans_key') }}</option>
-                        <option value="invoice">{{ __('general_content.invoice_trans_key') }}</option>
-                        <option value="creditnote">{{ __('general_content.credit_note_trans_key') }}</option>
-                        <option value="purchase-quotation">{{ __('general_content.requests_for_quotation_list_trans_key') }}</option>
-                        <option value="purchase">{{ __('general_content.purchase_order_trans_key') }}</option>
+                        @forelse($availableDocumentTypes as $value => $label)
+                            <option value="{{ $value }}">{{ __($label) }}</option>
+                        @empty
+                            <option value="" disabled selected>{{ __('general_content.no_data_trans_key') }}</option>
+                        @endforelse
                     </select>
                 </div>
                 <div class="form-group">
@@ -82,7 +80,7 @@
                     <textarea name="content" class="form-control summernote" required></textarea>
                 </div>
                 <div class="card-footer">
-                    <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.submit_trans_key') }}" theme="danger" icon="fas fa-lg fa-save"/>
+                    <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.submit_trans_key') }}" theme="danger" icon="fas fa-lg fa-save" :disabled="empty($availableDocumentTypes)"/>
                 </div>
             </form>
         </x-adminlte-card>


### PR DESCRIPTION
### Motivation
- The document-type dropdown for creating email templates should only show types the current user is authorized to manage so users don't see or submit options they lack rights for.
- Prevent invalid submissions by enforcing server-side checks that the chosen `document_type` is within the user-authorized set.

### Description
- Added `availableDocumentTypes()` in `app/Http/Controllers/Admin/EmailTemplateController.php` to compute allowed document types based on permissions (`quotes-menu`, `orders-menu`, `deliverys-menu`, `invoices-menu`, `purchases-menu`).
- Passed `$availableDocumentTypes` to the `admin/templates-index` view and replaced the static `<option>` list with a dynamic `@forelse($availableDocumentTypes as $value => $label)` loop in `resources/views/admin/templates-index.blade.php`.
- Added backend validation using `Illuminate\Validation\Rule::in(...)` to ensure submitted `document_type` is one of the allowed values before creating the template.
- Disabled the form submit button when no document types are available for the current user to avoid presenting an unusable form.

Files changed: `app/Http/Controllers/Admin/EmailTemplateController.php`, `resources/views/admin/templates-index.blade.php`.

### Testing
- Checked PHP syntax with `php -l app/Http/Controllers/Admin/EmailTemplateController.php` and `php -l resources/views/admin/templates-index.blade.php`, both reported no syntax errors.
- Rendered the email templates page and captured a UI screenshot to verify the dropdown and button state: `browser:/tmp/codex_browser_invocations/f6cb0aa3a3fc1f5f/artifacts/artifacts/email-template-rights.png`.
- No automated unit tests were modified; the above validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b447986d4c832d8b07d637bc50fcb9)