### PR TITLE
Add reset_period and DB-backed counters for document code generation

### DIFF
--- a/app/Http/Requests/Admin/StoreDocumentCodeTemplateRequest.php
+++ b/app/Http/Requests/Admin/StoreDocumentCodeTemplateRequest.php
@@ -24,6 +24,7 @@ class StoreDocumentCodeTemplateRequest extends FormRequest
         return [
             'document_type' => 'required|string|max:255|unique:document_code_templates,document_type',
             'template' => 'required|string|max:255',
+            'reset_period' => 'required|in:none,daily,weekly,monthly',
         ];
     }
 }

--- a/app/Http/Requests/Admin/UpdateDocumentCodeTemplateRequest.php
+++ b/app/Http/Requests/Admin/UpdateDocumentCodeTemplateRequest.php
@@ -23,6 +23,7 @@ class UpdateDocumentCodeTemplateRequest extends FormRequest
     {
         return [
             'template' => 'required|string|max:255',
+            'reset_period' => 'required|in:none,daily,weekly,monthly',
         ];
     }
 }

--- a/app/Models/DocumentCodeTemplate.php
+++ b/app/Models/DocumentCodeTemplate.php
@@ -7,17 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class DocumentCodeTemplate extends Model
 {
     // Allow mass assignment for these columns
-    protected $fillable = ['document_type', 'template'];
+    protected $fillable = ['document_type', 'template', 'reset_period'];
     
     /**
      *Allows to retrieve a default template if none is found
      */
-    public static function getTemplateForDocument(string $documentType): string
+    public static function getTemplateForDocument(string $documentType): ?self
     {
         // Search the database for a template matching the document type
-        $template = self::where('document_type', $documentType)->first();
-
-        // If no template is found, we return a default template
-        return $template ? $template->template : '{type}-{id}';
+        return self::where('document_type', $documentType)->first();
     }
 }

--- a/app/Services/DocumentCodeGenerator.php
+++ b/app/Services/DocumentCodeGenerator.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\DocumentCodeTemplate;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class DocumentCodeGenerator
 {
@@ -24,10 +25,11 @@ class DocumentCodeGenerator
     public function generateDocumentCode(string $documentType, int $lastId = null)
     {
         // Retrieve the code template for the given document type
-        $template = DocumentCodeTemplate::getTemplateForDocument($documentType);
+        $templateModel = DocumentCodeTemplate::getTemplateForDocument($documentType);
+        $template = $templateModel?->template ?? $this->defaultTemplate;
+        $resetPeriod = $templateModel?->reset_period ?? 'none';
 
-        // If no last ID, start at 0
-        $id = $lastId ? $lastId + 1 : 0;
+        $id = $this->resolveNextSequence($documentType, $resetPeriod, $lastId);
 
         // Replace placeholders with dynamic values
         $code = str_replace('{year}', Carbon::now()->format('Y'), $template);
@@ -37,5 +39,63 @@ class DocumentCodeGenerator
         $code = str_replace('{type}', strtoupper($documentType), $code);
 
         return $code;
+    }
+
+    protected function resolveNextSequence(string $documentType, string $resetPeriod, ?int $lastId): int
+    {
+        if (!in_array($resetPeriod, ['daily', 'weekly', 'monthly', 'none'], true)) {
+            $resetPeriod = 'none';
+        }
+
+        $periodKey = $this->buildPeriodKey($resetPeriod);
+
+        return DB::transaction(function () use ($documentType, $periodKey, $lastId, $resetPeriod) {
+            $counter = DB::table('document_code_counters')
+                ->where('document_type', $documentType)
+                ->where('period_key', $periodKey)
+                ->lockForUpdate()
+                ->first();
+
+            if (!$counter) {
+                $initialValue = 1;
+
+                if ($resetPeriod === 'none' && $lastId !== null) {
+                    $initialValue = $lastId + 1;
+                }
+
+                DB::table('document_code_counters')->insert([
+                    'document_type' => $documentType,
+                    'period_key' => $periodKey,
+                    'current_value' => $initialValue,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                return $initialValue;
+            }
+
+            $nextValue = (int) $counter->current_value + 1;
+
+            DB::table('document_code_counters')
+                ->where('id', $counter->id)
+                ->update([
+                    'current_value' => $nextValue,
+                    'updated_at' => now(),
+                ]);
+
+            return $nextValue;
+        });
+    }
+
+    protected function buildPeriodKey(string $resetPeriod): string
+    {
+        $now = Carbon::now();
+
+        return match ($resetPeriod) {
+            'daily' => $now->format('Y-m-d'),
+            'weekly' => sprintf('%s-W%02d', $now->isoWeekYear, $now->isoWeek),
+            'monthly' => $now->format('Y-m'),
+            default => 'global',
+        };
     }
 }

--- a/database/migrations/2026_03_13_000001_add_reset_period_and_counters_for_document_codes.php
+++ b/database/migrations/2026_03_13_000001_add_reset_period_and_counters_for_document_codes.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('document_code_templates', function (Blueprint $table) {
+            $table->string('reset_period')->default('none')->after('template');
+        });
+
+        Schema::create('document_code_counters', function (Blueprint $table) {
+            $table->id();
+            $table->string('document_type');
+            $table->string('period_key');
+            $table->unsignedBigInteger('current_value')->default(0);
+            $table->timestamps();
+
+            $table->unique(['document_type', 'period_key'], 'doc_code_counter_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('document_code_counters');
+
+        Schema::table('document_code_templates', function (Blueprint $table) {
+            $table->dropColumn('reset_period');
+        });
+    }
+};

--- a/resources/views/admin/factory-index.blade.php
+++ b/resources/views/admin/factory-index.blade.php
@@ -734,6 +734,7 @@
                                         <tr>
                                             <th>{{ __('general_content.entity_type_trans_key') }}</th>
                                             <th>{{ __('general_content.template_trans_key') }}</th>
+                                            <th>Reset</th>
                                             <th></th>
                                         </tr>
                                     </thead>
@@ -742,6 +743,7 @@
                                             <tr>
                                                 <td>{{ $template->document_type }}</td>
                                                 <td>{{ $template->template }}</td>
+                                                <td>{{ $template->reset_period ?? 'none' }}</td>
                                                 <td class=" py-0 align-middle">
                                                     <!-- Button Modal -->
                                                     <x-ButtonTextEdit :modalTarget="'Template' . $template->id" />
@@ -759,6 +761,15 @@
                                                                         <input type="text" class="form-control" id="template" name="template" placeholder="{type}-{year}-{day}-{id}" value="{{ $template->template }}" required>
                                                                     </div>
                                                                 </div>
+                                                                <div class="form-group">
+                                                                    <label for="reset_period_{{ $template->id }}">Reset :</label>
+                                                                    <select class="form-control" id="reset_period_{{ $template->id }}" name="reset_period" required>
+                                                                        <option value="none" {{ ($template->reset_period ?? 'none') === 'none' ? 'selected' : '' }}>None</option>
+                                                                        <option value="daily" {{ ($template->reset_period ?? 'none') === 'daily' ? 'selected' : '' }}>Daily</option>
+                                                                        <option value="weekly" {{ ($template->reset_period ?? 'none') === 'weekly' ? 'selected' : '' }}>Weekly</option>
+                                                                        <option value="monthly" {{ ($template->reset_period ?? 'none') === 'monthly' ? 'selected' : '' }}>Monthly</option>
+                                                                    </select>
+                                                                </div>
                                                             </div>
                                                             <div class="card-footer">
                                                                 <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="info" icon="fas fa-lg fa-save"/>
@@ -775,6 +786,7 @@
                                         <tr>
                                             <th>{{ __('general_content.entity_type_trans_key') }}</th>
                                             <th>{{ __('general_content.template_trans_key') }}</th>
+                                            <th>Reset</th>
                                             <th></th>
                                         </tr>
                                     </tfoot>
@@ -819,6 +831,20 @@
                                             <span class="input-group-text"><i class="fas fa-code"></i></span>
                                         </div>
                                         <input type="text" class="form-control" id="template" name="template" placeholder="{type}-{year}-{day}-{id}" required>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="reset_period">Reset :</label>
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text"><i class="fas fa-redo"></i></span>
+                                        </div>
+                                        <select class="form-control" id="reset_period" name="reset_period" required>
+                                            <option value="none">None</option>
+                                            <option value="daily">Daily</option>
+                                            <option value="weekly">Weekly</option>
+                                            <option value="monthly">Monthly</option>
+                                        </select>
                                     </div>
                                 </div>
             


### PR DESCRIPTION
### Motivation
- Introduce configurable reset behavior for document sequences so codes can reset on a daily, weekly, monthly, or never basis.

### Description
- Add a `reset_period` column to `document_code_templates` and create a new `document_code_counters` table via a migration to persist sequence counters.
- Include `reset_period` validation in `StoreDocumentCodeTemplateRequest` and `UpdateDocumentCodeTemplateRequest` and allow mass-assignment by adding it to the model's `$fillable` on `DocumentCodeTemplate`.
- Update `DocumentCodeGenerator` to load the template model, derive the `reset_period`, and calculate the next sequence with a transactional, locked counter using the new helper methods `resolveNextSequence` and `buildPeriodKey`.
- Update the admin UI in `factory-index.blade.php` to display and edit the `reset_period` for templates, and adjust `DocumentCodeTemplate::getTemplateForDocument` to return the model instance (or null).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4777cc850832d8dd25ae44aa741e4)