### PR TITLE
Blocage temporaire par IP après échecs répétés de connexion

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -11,6 +11,9 @@ use Illuminate\Validation\ValidationException;
 
 class LoginRequest extends FormRequest
 {
+    private const LOGIN_ATTEMPTS_LIMIT = 5;
+    private const IP_ATTEMPTS_LIMIT = 10;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -47,6 +50,7 @@ class LoginRequest extends FormRequest
 
         if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
+            RateLimiter::hit($this->ipThrottleKey());
 
             throw ValidationException::withMessages([
                 'email' => __('auth.failed'),
@@ -65,7 +69,19 @@ class LoginRequest extends FormRequest
      */
     public function ensureIsNotRateLimited()
     {
-        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+        if (RateLimiter::tooManyAttempts($this->ipThrottleKey(), self::IP_ATTEMPTS_LIMIT)) {
+            event(new Lockout($this));
+
+            $seconds = RateLimiter::availableIn($this->ipThrottleKey());
+
+            throw ValidationException::withMessages([
+                'email' => __('Trop de tentatives de connexion depuis cette adresse IP. Réessayez dans :minutes minute(s).', [
+                    'minutes' => ceil($seconds / 60),
+                ]),
+            ]);
+        }
+
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), self::LOGIN_ATTEMPTS_LIMIT)) {
             return;
         }
 
@@ -89,5 +105,15 @@ class LoginRequest extends FormRequest
     public function throttleKey()
     {
         return Str::lower($this->input('email')).'|'.$this->ip();
+    }
+
+    /**
+     * Get the rate limiting key used for IP lockouts.
+     *
+     * @return string
+     */
+    public function ipThrottleKey()
+    {
+        return 'ip|'.$this->ip();
     }
 }

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Tests\TestCase;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class AuthenticationTest extends TestCase
@@ -43,5 +44,26 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertGuest();
+    }
+
+    public function test_ip_is_temporarily_blocked_after_repeated_failed_logins()
+    {
+        $user = User::factory()->create();
+
+        for ($attempt = 0; $attempt < 10; $attempt++) {
+            $this->post('/login', [
+                'email' => $user->email,
+                'password' => 'wrong-password',
+            ]);
+        }
+
+        $response = $this->from('/login')->post('/login', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHasErrors('email');
+        $this->assertTrue(RateLimiter::tooManyAttempts('ip|127.0.0.1', 10));
     }
 }


### PR DESCRIPTION
### Motivation

- Empêcher les attaques par force brute émanant d'une même adresse IP en ajoutant un verrouillage temporaire côté IP en plus du throttling existant par compte.
- Conserver le comportement actuel par `email|ip` pour les verrouillages au niveau du compte tout en appliquant une limite plus stricte au niveau IP.

### Description

- Ajout de constantes `LOGIN_ATTEMPTS_LIMIT = 5` et `IP_ATTEMPTS_LIMIT = 10` dans `app/Http/Requests/Auth/LoginRequest.php` pour séparer les limites par compte et par IP.
- Lors d'un échec d'authentification, on incrémente maintenant les deux compteurs : `throttleKey()` existant et le nouveau `ipThrottleKey()`; la méthode `ipThrottleKey()` retourne `ip|<adresse>`.
- La méthode `ensureIsNotRateLimited()` vérifie d'abord le compteur IP et renvoie un message d'erreur dédié si l'IP est bloquée, puis conserve la logique de verrouillage par compte en cas de dépassement.
- Ajout d'un test feature `test_ip_is_temporarily_blocked_after_repeated_failed_logins()` dans `tests/Feature/AuthenticationTest.php` qui simule 10 échecs et vérifie le blocage IP et la présence d'erreur de session; l'import `RateLimiter` a été ajouté au test.

### Testing

- `php -l app/Http/Requests/Auth/LoginRequest.php` a été exécuté et a renvoyé « No syntax errors detected ». 
- `php -l tests/Feature/AuthenticationTest.php` a été exécuté et a renvoyé « No syntax errors detected ». 
- `php artisan test --filter=AuthenticationTest` n'a pas pu être exécuté dans cet environnement car `vendor/autoload.php` est absent, empêchant l'exécution des tests automatisés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b47ae24940832d9c119ac40032354a)