### PR TITLE
feat: add Spreadsheet module with Univer-based editor and data APIs

### DIFF
--- a/app/Http/Controllers/SpreadsheetController.php
+++ b/app/Http/Controllers/SpreadsheetController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Spreadsheet;
+use Illuminate\Http\Request;
+
+class SpreadsheetController extends Controller
+{
+    public function index()
+    {
+        // TODO: add role-based permission
+        $spreadsheets = Spreadsheet::with('creator')
+            ->where('created_by', auth()->id())
+            ->latest()
+            ->paginate(15);
+
+        return view('spreadsheet.index', compact('spreadsheets'));
+    }
+
+    public function create()
+    {
+        // TODO: add role-based permission
+        return view('spreadsheet.create');
+    }
+
+    public function store(Request $request)
+    {
+        // TODO: add role-based permission
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $spreadsheet = Spreadsheet::create([
+            'name' => $validated['name'],
+            'description' => $validated['description'] ?? null,
+            'created_by' => auth()->id(),
+        ]);
+
+        $spreadsheet->sheets()->create([
+            'name' => 'Sheet1',
+            'order' => 0,
+            'data' => null,
+        ]);
+
+        return redirect()->route('spreadsheet.edit', $spreadsheet)
+            ->with('success', 'Tableur créé avec succès.');
+    }
+
+    public function edit(Spreadsheet $spreadsheet)
+    {
+        // TODO: add role-based permission
+        abort_unless($spreadsheet->created_by === auth()->id(), 403);
+
+        $spreadsheet->load('sheets');
+
+        return view('spreadsheet.editor', compact('spreadsheet'));
+    }
+
+    public function update(Request $request, Spreadsheet $spreadsheet)
+    {
+        // TODO: add role-based permission
+        abort_unless($spreadsheet->created_by === auth()->id(), 403);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $spreadsheet->update($validated);
+
+        return redirect()->route('spreadsheet.edit', $spreadsheet)
+            ->with('success', 'Tableur mis à jour.');
+    }
+
+    public function destroy(Spreadsheet $spreadsheet)
+    {
+        // TODO: add role-based permission
+        abort_unless($spreadsheet->created_by === auth()->id(), 403);
+
+        $spreadsheet->delete();
+
+        return redirect()->route('spreadsheet.index')
+            ->with('success', 'Tableur supprimé.');
+    }
+
+    public function save(Request $request, Spreadsheet $spreadsheet)
+    {
+        // TODO: add role-based permission
+        abort_unless($spreadsheet->created_by === auth()->id(), 403);
+
+        $validated = $request->validate([
+            'sheets' => ['required', 'array'],
+            'sheets.*.id' => ['nullable', 'integer'],
+            'sheets.*.name' => ['nullable', 'string', 'max:255'],
+            'sheets.*.data' => ['nullable', 'array'],
+        ]);
+
+        foreach ($validated['sheets'] as $index => $sheetData) {
+            $payload = [
+                'name' => $sheetData['name'] ?? ('Sheet' . ($index + 1)),
+                'order' => $index,
+                'data' => $sheetData['data'] ?? null,
+            ];
+
+            if (!empty($sheetData['id'])) {
+                $spreadsheet->sheets()->where('id', $sheetData['id'])->update($payload);
+                continue;
+            }
+
+            $spreadsheet->sheets()->create($payload);
+        }
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/app/Http/Controllers/SpreadsheetDataController.php
+++ b/app/Http/Controllers/SpreadsheetDataController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Planning\Task;
+use App\Models\Products\Products;
+use App\Models\Workflow\Invoices;
+use App\Models\Workflow\Orders;
+use App\Models\Companies\Companies;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class SpreadsheetDataController extends Controller
+{
+    protected function guard(): ?JsonResponse
+    {
+        if (!auth()->check()) {
+            return response()->json(['message' => 'Non autorisé'], 403);
+        }
+
+        return null;
+    }
+
+    public function stock(string $reference): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $product = Products::where('code', $reference)->first();
+        $quantity = $product ? (float) $product->getTotalStockMove() : 0;
+
+        return response()->json([
+            'reference' => $reference,
+            'quantity' => $quantity,
+            'unit' => optional($product?->Unit)->label,
+            'updated_at' => $product?->updated_at?->toDateTimeString(),
+        ]);
+    }
+
+    public function orders(Request $request): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $status = $request->get('status', 'all');
+        $query = Orders::with('companie')->latest();
+
+        if ($status === 'open') {
+            $query->whereNotIn('statu', [3, 4, 5]);
+        } elseif ($status === 'closed') {
+            $query->whereIn('statu', [3, 4, 5]);
+        }
+
+        $orders = $query->limit(100)->get()->map(function (Orders $order) {
+            return [
+                'id' => $order->id,
+                'reference' => $order->code,
+                'customer' => optional($order->companie)->label,
+                'total' => (float) ($order->total_price ?? 0),
+                'status' => $order->statu,
+                'created_at' => optional($order->created_at)?->toDateTimeString(),
+            ];
+        });
+
+        return response()->json($orders->values());
+    }
+
+    public function revenue(Request $request): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $month = $request->get('month', now()->format('Y-m'));
+        try {
+            $start = Carbon::createFromFormat('Y-m', $month)->startOfMonth();
+        } catch (\Throwable $exception) {
+            $start = now()->startOfMonth();
+            $month = $start->format('Y-m');
+        }
+        $end = $start->copy()->endOfMonth();
+
+        $invoices = Invoices::whereBetween('created_at', [$start, $end])->get();
+        $totalHt = $invoices->sum(fn (Invoices $invoice) => (float) $invoice->total_price);
+
+        return response()->json([
+            'month' => $month,
+            'total_ht' => round($totalHt, 2),
+            'total_ttc' => round($totalHt * 1.2, 2),
+            'count' => $invoices->count(),
+        ]);
+    }
+
+    public function productionKpis(): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $tasks = Task::query();
+        $inProgress = (clone $tasks)->whereNotIn('status_id', [3, 4])->count();
+        $completedThisMonth = (clone $tasks)->whereIn('status_id', [3, 4])->whereMonth('updated_at', now()->month)->whereYear('updated_at', now()->year)->count();
+        $lateOrders = Orders::whereNotIn('statu', [3, 4, 5])->whereDate('created_at', '<', now()->subDays(30))->count();
+        $avgLeadTimeDays = (float) round(
+            (clone $tasks)
+                ->whereNotNull('start_date')
+                ->whereNotNull('end_date')
+                ->selectRaw('AVG(DATEDIFF(end_date, start_date)) as avg_days')
+                ->value('avg_days') ?? 0,
+            2
+        );
+
+        return response()->json([
+            'avg_lead_time_days' => $avgLeadTimeDays,
+            'orders_in_progress' => $inProgress,
+            'orders_completed_this_month' => $completedThisMonth,
+            'late_orders' => $lateOrders,
+        ]);
+    }
+
+    public function customers(): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $customers = Companies::query()
+            ->where('statu_customer', 1)
+            ->select(['id', 'label as name', 'city'])
+            ->limit(200)
+            ->get();
+
+        return response()->json($customers);
+    }
+
+    public function products(): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $products = Products::query()
+            ->with('Stock_location_product')
+            ->limit(200)
+            ->get()
+            ->map(function (Products $product) {
+                return [
+                    'id' => $product->id,
+                    'reference' => $product->code,
+                    'name' => $product->label,
+                    'stock_qty' => (float) $product->getTotalStockMove(),
+                ];
+            });
+
+        return response()->json($products->values());
+    }
+}

--- a/app/Models/Spreadsheet.php
+++ b/app/Models/Spreadsheet.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Spreadsheet extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'created_by',
+    ];
+
+    public function sheets()
+    {
+        return $this->hasMany(SpreadsheetSheet::class)->orderBy('order');
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/SpreadsheetSheet.php
+++ b/app/Models/SpreadsheetSheet.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class SpreadsheetSheet extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'spreadsheet_id',
+        'name',
+        'order',
+        'data',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+    ];
+
+    public function spreadsheet()
+    {
+        return $this->belongsTo(Spreadsheet::class);
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -741,6 +741,13 @@ return [
                 ],
             ],
         ],
+
+        [
+            'text' => 'Tableurs',
+            'icon' => 'nav-icon fas fa-table',
+            'url'  => 'spreadsheet',
+            'active' => ['spreadsheet*'],
+        ],
         [
             'text' => 'Reports',
             'icon' => 'fas fa-chart-pie',

--- a/database/migrations/2026_03_14_000001_create_spreadsheets_table.php
+++ b/database/migrations/2026_03_14_000001_create_spreadsheets_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('spreadsheets', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->foreignId('created_by')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('spreadsheets');
+    }
+};

--- a/database/migrations/2026_03_14_000002_create_spreadsheet_sheets_table.php
+++ b/database/migrations/2026_03_14_000002_create_spreadsheet_sheets_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('spreadsheet_sheets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('spreadsheet_id')->constrained()->onDelete('cascade');
+            $table->string('name')->default('Sheet1');
+            $table->integer('order')->default(0);
+            $table->longText('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('spreadsheet_sheets');
+    }
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
         "socket.io-client": "^4.8.0",
         "three": "^0.157.0",
         "vue-resizable": "^2.1.7",
-        "vuedraggable": "^4.1.0"
+        "vuedraggable": "^4.1.0",
+        "@univerjs/core": "^0.5",
+        "@univerjs/sheets": "^0.5",
+        "@univerjs/sheets-formula": "^0.5",
+        "@univerjs/ui": "^0.5",
+        "@univerjs/sheets-ui": "^0.5"
     }
 }

--- a/resources/js/plugins/WemFormulaPlugin.js
+++ b/resources/js/plugins/WemFormulaPlugin.js
@@ -1,0 +1,81 @@
+const CACHE_TTL_MS = 30000;
+
+export class WemFormulaPlugin {
+    constructor({ dataApiBase = '/api/spreadsheet/data' } = {}) {
+        this.dataApiBase = dataApiBase;
+        this.cache = new Map();
+    }
+
+    getCache(key) {
+        const item = this.cache.get(key);
+        if (!item) return null;
+
+        if (Date.now() - item.at > CACHE_TTL_MS) {
+            this.cache.delete(key);
+            return null;
+        }
+
+        return item.value;
+    }
+
+    setCache(key, value) {
+        this.cache.set(key, { value, at: Date.now() });
+        return value;
+    }
+
+    async fetchJson(path) {
+        const key = path;
+        const cached = this.getCache(key);
+        if (cached !== null) {
+            return cached;
+        }
+
+        const response = await fetch(`${this.dataApiBase}${path}`, {
+            headers: {
+                Accept: 'application/json',
+            },
+            credentials: 'same-origin',
+        });
+
+        const data = await response.json();
+
+        return this.setCache(key, data);
+    }
+
+    async stock(reference) {
+        const data = await this.fetchJson(`/stock/${encodeURIComponent(reference)}`);
+        return Number(data.quantity || 0);
+    }
+
+    async commandesEnCours() {
+        const data = await this.fetchJson('/orders?status=open');
+        return Array.isArray(data) ? data.length : 0;
+    }
+
+    async caMois(month) {
+        const data = await this.fetchJson(`/revenue?month=${encodeURIComponent(month)}`);
+        return Number(data.total_ht || 0);
+    }
+
+    async delaiMoyen() {
+        const data = await this.fetchJson('/production/kpis');
+        return Number(data.avg_lead_time_days || 0);
+    }
+
+    async commandesRetard() {
+        const data = await this.fetchJson('/production/kpis');
+        return Number(data.late_orders || 0);
+    }
+
+    register(univerApi) {
+        if (!univerApi || typeof univerApi.registerFunction !== 'function') {
+            return;
+        }
+
+        univerApi.registerFunction('WEM.STOCK', async (reference) => this.stock(reference));
+        univerApi.registerFunction('WEM.COMMANDES_EN_COURS', async () => this.commandesEnCours());
+        univerApi.registerFunction('WEM.CA_MOIS', async (month) => this.caMois(month));
+        univerApi.registerFunction('WEM.DELAI_MOYEN', async () => this.delaiMoyen());
+        univerApi.registerFunction('WEM.COMMANDES_RETARD', async () => this.commandesRetard());
+    }
+}

--- a/resources/js/spreadsheet.js
+++ b/resources/js/spreadsheet.js
@@ -1,0 +1,92 @@
+import '@univerjs/ui/lib/index.css';
+import { Univer, LocaleType, merge } from '@univerjs/core';
+import { UniverSheetsPlugin } from '@univerjs/sheets';
+import { UniverSheetsUIPlugin } from '@univerjs/sheets-ui';
+import { UniverFormulaEnginePlugin } from '@univerjs/sheets-formula';
+import { WemFormulaPlugin } from './plugins/WemFormulaPlugin';
+
+const config = window.WEM_SPREADSHEET;
+
+if (config && document.getElementById('univer-container')) {
+    const univer = new Univer({
+        locale: LocaleType.FR_FR,
+        locales: {},
+    });
+
+    univer.registerPlugin(UniverSheetsPlugin);
+    univer.registerPlugin(UniverFormulaEnginePlugin);
+    univer.registerPlugin(UniverSheetsUIPlugin, {
+        container: 'univer-container',
+    });
+
+    const workbookData = {
+        id: `spreadsheet-${config.id}`,
+        name: config.name,
+        sheetOrder: config.sheets.map((sheet, index) => sheet?.data?.id || `sheet-${index + 1}`),
+        sheets: config.sheets.reduce((carry, sheet, index) => {
+            const sheetId = sheet?.data?.id || `sheet-${index + 1}`;
+            carry[sheetId] = merge(
+                {
+                    id: sheetId,
+                    name: sheet.name || `Sheet${index + 1}`,
+                    cellData: {},
+                },
+                sheet.data || {}
+            );
+
+            return carry;
+        }, {}),
+    };
+
+    univer.createUnit('UNIVER_SHEET', workbookData);
+
+    const wemFormulaPlugin = new WemFormulaPlugin({ dataApiBase: config.dataApiBase });
+    wemFormulaPlugin.register(univer);
+
+    const saveStatus = document.getElementById('save-status');
+    let saveTimer = null;
+
+    const setStatus = (text) => {
+        if (saveStatus) {
+            saveStatus.textContent = text;
+        }
+    };
+
+    const saveWorkbook = async () => {
+        setStatus('Enregistrement…');
+
+        const workbook = univer.getActiveWorkbook();
+        const snapshot = workbook ? workbook.save() : null;
+
+        const payloadSheets = (config.sheets || []).map((sheet, index) => ({
+            id: sheet.id,
+            name: sheet.name || `Sheet${index + 1}`,
+            data: snapshot,
+        }));
+
+        await fetch(config.saveUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': config.csrfToken,
+                Accept: 'application/json',
+            },
+            body: JSON.stringify({ sheets: payloadSheets }),
+        });
+
+        setStatus('Enregistré ✓');
+    };
+
+    const debounceSave = () => {
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+            saveWorkbook().catch(() => setStatus('Erreur de sauvegarde'));
+        }, 2000);
+    };
+
+    const commandService = univer.__getInjector().get('commandService', null);
+    if (commandService && typeof commandService.onCommandExecuted === 'function') {
+        commandService.onCommandExecuted(() => debounceSave());
+    }
+}

--- a/resources/views/spreadsheet/create.blade.php
+++ b/resources/views/spreadsheet/create.blade.php
@@ -1,0 +1,34 @@
+@extends('adminlte::page')
+
+@section('title', 'Nouveau tableur')
+
+@section('content_header')
+    <h1>Nouveau tableur</h1>
+@stop
+
+@section('content')
+    <x-adminlte-card theme="light" theme-mode="outline">
+        <form method="POST" action="{{ route('spreadsheet.store') }}">
+            @csrf
+
+            <div class="form-group">
+                <label for="name">Nom</label>
+                <input type="text" id="name" name="name" class="form-control @error('name') is-invalid @enderror" value="{{ old('name') }}" required>
+                @error('name')
+                    <span class="invalid-feedback">{{ $message }}</span>
+                @enderror
+            </div>
+
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea id="description" name="description" class="form-control @error('description') is-invalid @enderror" rows="4">{{ old('description') }}</textarea>
+                @error('description')
+                    <span class="invalid-feedback">{{ $message }}</span>
+                @enderror
+            </div>
+
+            <button type="submit" class="btn btn-primary">Créer</button>
+            <a href="{{ route('spreadsheet.index') }}" class="btn btn-default">Annuler</a>
+        </form>
+    </x-adminlte-card>
+@stop

--- a/resources/views/spreadsheet/editor.blade.php
+++ b/resources/views/spreadsheet/editor.blade.php
@@ -1,0 +1,26 @@
+@extends('adminlte::page')
+
+@section('title', 'Éditeur de tableur')
+
+@section('content_header')
+    <div class="d-flex justify-content-between align-items-center">
+        <h1>{{ $spreadsheet->name }}</h1>
+        <span id="save-status" class="text-muted">Prêt</span>
+    </div>
+@stop
+
+@section('content')
+    <div id="univer-container" style="height: calc(100vh - 60px);"></div>
+
+    <script>
+        window.WEM_SPREADSHEET = {
+            id: {{ $spreadsheet->id }},
+            name: @json($spreadsheet->name),
+            saveUrl: "{{ route('spreadsheet.save', $spreadsheet) }}",
+            dataApiBase: "/api/spreadsheet/data",
+            csrfToken: "{{ csrf_token() }}",
+            sheets: @json($spreadsheet->sheets->map(fn($s) => ['id' => $s->id, 'name' => $s->name, 'data' => $s->data]))
+        };
+    </script>
+    <script src="{{ mix('js/spreadsheet.js') }}"></script>
+@stop

--- a/resources/views/spreadsheet/index.blade.php
+++ b/resources/views/spreadsheet/index.blade.php
@@ -1,0 +1,54 @@
+@extends('adminlte::page')
+
+@section('title', 'Tableurs')
+
+@section('content_header')
+    <div class="d-flex justify-content-between align-items-center">
+        <h1>Tableurs</h1>
+        <a href="{{ route('spreadsheet.create') }}" class="btn btn-primary">Nouveau tableur</a>
+    </div>
+@stop
+
+@section('content')
+    <x-adminlte-card theme="light" theme-mode="outline">
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Nom</th>
+                        <th>Description</th>
+                        <th>Créé par</th>
+                        <th>Mis à jour</th>
+                        <th class="text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($spreadsheets as $spreadsheet)
+                        <tr>
+                            <td>{{ $spreadsheet->name }}</td>
+                            <td>{{ $spreadsheet->description }}</td>
+                            <td>{{ $spreadsheet->creator->name ?? '-' }}</td>
+                            <td>{{ optional($spreadsheet->updated_at)->format('d/m/Y H:i') }}</td>
+                            <td class="text-right">
+                                <a href="{{ route('spreadsheet.edit', $spreadsheet) }}" class="btn btn-sm btn-info">Éditer</a>
+                                <form action="{{ route('spreadsheet.destroy', $spreadsheet) }}" method="POST" class="d-inline-block" onsubmit="return confirm('Supprimer ce tableur ?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-danger">Supprimer</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="text-center text-muted">Aucun tableur disponible.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div class="mt-3">
+            {{ $spreadsheets->links() }}
+        </div>
+    </x-adminlte-card>
+@stop

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\ExportSalesOrderController;
 use App\Http\Controllers\Api\Collaboration\WhiteboardController as ApiWhiteboardController;
 use App\Http\Controllers\Api\Collaboration\WhiteboardSnapshotController;
 use App\Http\Controllers\Api\Collaboration\WhiteboardFileController;
+use App\Http\Controllers\SpreadsheetDataController;
 
 /*
 |--------------------------------------------------------------------------
@@ -39,6 +40,16 @@ Route::middleware('auth:api')->group(function () {
         ->names('api.energy-consumptions');
 
     Route::get('/exports/sales-orders', ExportSalesOrderController::class);
+
+
+    Route::prefix('spreadsheet/data')->name('spreadsheet.data.')->group(function () {
+        Route::get('/stock/{reference}', [SpreadsheetDataController::class, 'stock'])->name('stock');
+        Route::get('/orders', [SpreadsheetDataController::class, 'orders'])->name('orders');
+        Route::get('/revenue', [SpreadsheetDataController::class, 'revenue'])->name('revenue');
+        Route::get('/production/kpis', [SpreadsheetDataController::class, 'productionKpis'])->name('productionKpis');
+        Route::get('/customers', [SpreadsheetDataController::class, 'customers'])->name('customers');
+        Route::get('/products', [SpreadsheetDataController::class, 'products'])->name('products');
+    });
 
     Route::prefix('collaboration/whiteboards')->name('api.collaboration.whiteboards.')->group(function () {
         Route::get('/', [ApiWhiteboardController::class, 'index'])->name('index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 use App\Http\Controllers\ProductionTraceController;
 use App\Http\Controllers\EnergyConsumptionController;
 use App\Http\Controllers\DocumentController;
+use App\Http\Controllers\SpreadsheetController;
 
 /*
 |--------------------------------------------------------------------------
@@ -62,6 +63,17 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     Route::get('/documents', [DocumentController::class, 'index'])
         ->middleware(['auth', 'check.factory'])
         ->name('documents.index');
+
+    Route::group(['prefix' => 'spreadsheet', 'middleware' => ['auth', 'check.factory']], function () {
+        // TODO: add role-based permission
+        Route::get('/', [SpreadsheetController::class, 'index'])->name('spreadsheet.index');
+        Route::get('/create', [SpreadsheetController::class, 'create'])->name('spreadsheet.create');
+        Route::post('/', [SpreadsheetController::class, 'store'])->name('spreadsheet.store');
+        Route::get('/{spreadsheet}/edit', [SpreadsheetController::class, 'edit'])->name('spreadsheet.edit');
+        Route::put('/{spreadsheet}', [SpreadsheetController::class, 'update'])->name('spreadsheet.update');
+        Route::delete('/{spreadsheet}', [SpreadsheetController::class, 'destroy'])->name('spreadsheet.destroy');
+        Route::post('/{spreadsheet}/save', [SpreadsheetController::class, 'save'])->name('spreadsheet.save');
+    });
 
     Route::group(['prefix' => 'workshop', 'middleware' => ['auth', 'check.factory']], function () {
         Route::get('/', 'App\Http\Controllers\Workshop\WorkshopController@index')->middleware(['auth', 'check.factory'])->name('workshop');

--- a/tests/Feature/SpreadsheetTest.php
+++ b/tests/Feature/SpreadsheetTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Tests\TestCase;
+use App\Models\Spreadsheet;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class SpreadsheetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_list_spreadsheets(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+        Spreadsheet::create([
+            'name' => 'Pilotage',
+            'description' => 'Tableur de test',
+            'created_by' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('spreadsheet.index'));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_user_can_create_spreadsheet(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('spreadsheet.store'), [
+            'name' => 'Suivi production',
+            'description' => 'Description',
+        ]);
+
+        $this->assertDatabaseHas('spreadsheets', [
+            'name' => 'Suivi production',
+            'created_by' => $user->id,
+        ]);
+
+        $spreadsheet = Spreadsheet::first();
+        $response->assertRedirect(route('spreadsheet.edit', $spreadsheet));
+    }
+
+    public function test_user_can_save_spreadsheet_data(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+        $spreadsheet = Spreadsheet::create([
+            'name' => 'KPI',
+            'created_by' => $user->id,
+        ]);
+
+        $sheet = $spreadsheet->sheets()->create([
+            'name' => 'Sheet1',
+            'order' => 0,
+            'data' => null,
+        ]);
+
+        $response = $this->actingAs($user)->postJson(route('spreadsheet.save', $spreadsheet), [
+            'sheets' => [
+                [
+                    'id' => $sheet->id,
+                    'name' => 'Sheet1',
+                    'data' => ['cellData' => ['0' => ['0' => ['v' => 10]]]],
+                ],
+            ],
+        ]);
+
+        $response->assertOk()->assertJson(['success' => true]);
+    }
+
+    public function test_stock_data_endpoint_returns_json(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/api/spreadsheet/data/stock/TEST');
+
+        $response->assertStatus(200)->assertJsonStructure([
+            'reference',
+            'quantity',
+            'unit',
+            'updated_at',
+        ]);
+    }
+
+    public function test_unauthenticated_user_cannot_access(): void
+    {
+        $response = $this->get(route('spreadsheet.index'));
+
+        $response->assertStatus(302);
+        $this->assertStringContainsString('/login', $response->headers->get('Location'));
+    }
+}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -12,5 +12,6 @@ const mix = require('laravel-mix');
  */
 
 mix.js('resources/js/app.js', 'public/js')
+    .js('resources/js/spreadsheet.js', 'public/js')
     .vue()
     .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
### Motivation
- Provide a spreadsheet module in WEM to create, edit and persist multi-sheet workbooks and expose WEM live data via custom formulas. 
- Integrate a dedicated editor using the Univer library and a small server-side API to serve stock/orders/revenue/production/customers/products for formulas.

### Description
- Add DB migrations `database/migrations/2026_03_14_000001_create_spreadsheets_table.php` and `2026_03_14_000002_create_spreadsheet_sheets_table.php` for `spreadsheets` and `spreadsheet_sheets` with JSON `data` per sheet. 
- Add Eloquent models `app/Models/Spreadsheet.php` and `app/Models/SpreadsheetSheet.php` with relationships and `data` casting. 
- Implement `SpreadsheetController` with `index`, `create`, `store`, `edit`, `update`, `destroy` and AJAX `save` to persist Univer snapshots. 
- Implement `SpreadsheetDataController` exposing authenticated JSON endpoints: `stock`, `orders`, `revenue`, `productionKpis`, `customers`, `products`. 
- Register web routes (under auth) and API read-only routes (`/api/spreadsheet/data/*`) and add AdminLTE menu entry `Tableurs`. 
- Add Blade views `resources/views/spreadsheet/index.blade.php`, `create.blade.php`, `editor.blade.php` and frontend bootstrap at `resources/js/spreadsheet.js` plus `resources/js/plugins/WemFormulaPlugin.js` implementing WEM formulas with 30s cache and 2s debounced autosave. 
- Update `webpack.mix.js` to build a separate `resources/js/spreadsheet.js` bundle and add Univer packages to `package.json` dependencies (installation may be restricted by environment). 
- Add feature tests at `tests/Feature/SpreadsheetTest.php` covering listing, creation, save endpoint, stock API and unauthenticated redirect.

### Testing
- Ran PHP syntax checks with `php -l` on newly added PHP files; results: no syntax errors. 
- Added `tests/Feature/SpreadsheetTest.php` (feature tests present) but `php artisan test --filter=SpreadsheetTest` could not run in this environment due to missing vendor autoload (`vendor/autoload.php`), so tests were not executed here. 
- Attempted `npm install` for Univer packages but it failed with registry `403 Forbidden`, so frontend dependencies were added to `package.json` but not installed in CI here. 
- Performed a headless page snapshot attempt (Playwright) to validate editor route rendering; screenshot artifact was generated but the application in this environment did not serve a full app (no running webserver). 

Files of interest: `app/Http/Controllers/SpreadsheetController.php`, `app/Http/Controllers/SpreadsheetDataController.php`, `app/Models/Spreadsheet.php`, `app/Models/SpreadsheetSheet.php`, `resources/js/spreadsheet.js`, `resources/js/plugins/WemFormulaPlugin.js`, `resources/views/spreadsheet/*`, `routes/web.php`, `routes/api.php`, `database/migrations/*`, `tests/Feature/SpreadsheetTest.php`, `webpack.mix.js`, `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b587f22864832dac303e93fd54d98c)