### PR TITLE
Afficher le logo factory et la version sur la page de login

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -45,8 +45,8 @@ return [
     |
     */
 
-    'logo' => 'v1.19',
-    'logo_img' => 'vendor/adminlte/dist/img/simple-logo.PNG',
+    'logo' => '',
+    'logo_img' => 'vendor/adminlte/dist/img/simple-logo -R.PNG',
     'logo_img_class' => 'brand-image  elevation-3',
     'logo_img_xl' => null,
     'logo_img_xl_class' => 'brand-image-xs',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -138,4 +138,7 @@
             </a>
         </p>
     @endif
+
+
+    <p class="my-2 text-muted">v1.19</p>
 @stop


### PR DESCRIPTION
### Motivation
- Remplacer le logo de l’application par le logo de l’usine et afficher la version de l’application sous la card de connexion pour rendre l’écran de login conforme à l’identité factory.

### Description
- Met à jour `config/adminlte.php` pour vider le texte `logo` et pointer `logo_img` vers `vendor/adminlte/dist/img/simple-logo -R.PNG` afin d’utiliser le logo factory.
- Ajoute dans `resources/views/auth/login.blade.php` un paragraphe ` <p class="my-2 text-muted">v1.19</p>` dans la section `auth_footer` pour afficher la version sous la card de login.

### Testing
- Lint PHP sur les fichiers modifiés avec `php -l config/adminlte.php` et `php -l resources/views/auth/login.blade.php` a réussi.
- Démarrage temporaire de l’application avec `php artisan serve` et capture visuelle de la page `/login` a été effectuée pour vérifier le rendu (screenshot généré).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b5b21230832dbdcf4028f719676c)