### PR TITLE
Ajuste l'affichage de la durée dans le dropdown de notifications

### DIFF
--- a/app/Http/Controllers/NotificationsController.php
+++ b/app/Http/Controllers/NotificationsController.php
@@ -67,9 +67,9 @@ class NotificationsController extends Controller
         $dropdownHtml = '';
         foreach ($notifications as $key => $not) {
             $icon = "<span class='notification-icon mr-2'><i class='{$not['icon']} fa-fw'></i></span>";
-            $text = "<span class='notification-text d-inline-block text-truncate' style='max-width: 220px;' title='{$not['text']}'>{$not['text']}</span>";
-            $time = "<span class='notification-time text-muted text-sm'>{$not['time']}</span>";
-            $content = "<div class='notification-content flex-fill'>{$text}{$time}</div>";
+            $text = "<span class='notification-text d-block text-truncate' style='max-width: 220px;' title='{$not['text']}'>{$not['text']}</span>";
+            $time = "<span class='notification-time text-muted text-sm d-block mt-1'>{$not['time']}</span>";
+            $content = "<div class='notification-content d-flex flex-column flex-fill'>{$text}{$time}</div>";
             $dropdownHtml .= "<a href='{$not['route']}' class='dropdown-item notification-item d-flex align-items-start'>{$icon}{$content}</a>";
 
             if ($key < count($notifications) - 1) {


### PR DESCRIPTION
### Motivation
- Rendre la durée (`il y a ...`) plus lisible en l'affichant sur une ligne séparée sous le texte principal des notifications dans le dropdown.

### Description
- Modifie `app/Http/Controllers/NotificationsController.php` pour rendre `notification-text` en `d-block`, `notification-time` en `d-block mt-1` et le conteneur en `d-flex flex-column` afin d'empiler le texte et la durée verticalement.

### Testing
- Exécution de la vérification de syntaxe PHP avec `php -l app/Http/Controllers/NotificationsController.php` (succès).
- Tentative de démarrage local via `php artisan serve` échouée à cause de l'absence du répertoire `vendor/` (dépendances non installées), donc l'application n'a pas pu être lancée pour validation visuelle complète.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b6bf1774832db7f5f45044692b3f)