### PR TITLE
Fix spreadsheet crash by resolving Univer plugins defensively

### DIFF
--- a/resources/js/spreadsheet.js
+++ b/resources/js/spreadsheet.js
@@ -1,13 +1,15 @@
 import '@univerjs/ui/lib/index.css';
 import { Univer, LocaleType, merge } from '@univerjs/core';
-import { UniverSheetsPlugin } from '@univerjs/sheets';
-import { UniverSheetsUIPlugin } from '@univerjs/sheets-ui';
+import * as UniverSheets from '@univerjs/sheets';
+import * as UniverSheetsUI from '@univerjs/sheets-ui';
 import * as UniverSheetsFormula from '@univerjs/sheets-formula';
 import { WemFormulaPlugin } from './plugins/WemFormulaPlugin';
 
 const config = window.WEM_SPREADSHEET;
 
 if (config && document.getElementById('univer-container')) {
+    const firstAvailable = (...candidates) => candidates.find(Boolean);
+
     const registerPluginIfAvailable = (univer, plugin, options = undefined) => {
         if (!plugin) {
             return;
@@ -21,17 +23,32 @@ if (config && document.getElementById('univer-container')) {
         univer.registerPlugin(plugin, options);
     };
 
+    const sheetsPlugin = firstAvailable(
+        UniverSheets.UniverSheetsPlugin,
+        UniverSheets.default,
+        UniverSheets.plugin
+    );
+    const sheetsUIPlugin = firstAvailable(
+        UniverSheetsUI.UniverSheetsUIPlugin,
+        UniverSheetsUI.default,
+        UniverSheetsUI.plugin
+    );
     const formulaPlugin =
-        UniverSheetsFormula.UniverFormulaEnginePlugin || UniverSheetsFormula.UniverSheetsFormulaPlugin;
+        firstAvailable(
+            UniverSheetsFormula.UniverFormulaEnginePlugin,
+            UniverSheetsFormula.UniverSheetsFormulaPlugin,
+            UniverSheetsFormula.default,
+            UniverSheetsFormula.plugin
+        );
 
     const univer = new Univer({
         locale: LocaleType.FR_FR,
         locales: {},
     });
 
-    registerPluginIfAvailable(univer, UniverSheetsPlugin);
+    registerPluginIfAvailable(univer, sheetsPlugin);
     registerPluginIfAvailable(univer, formulaPlugin);
-    registerPluginIfAvailable(univer, UniverSheetsUIPlugin, {
+    registerPluginIfAvailable(univer, sheetsUIPlugin, {
         container: 'univer-container',
     });
 


### PR DESCRIPTION
### Motivation
- A runtime crash (`Uncaught TypeError: Cannot read properties of undefined (reading 'Symbol($$DEPENDENCIES)')`) indicated the DI container attempted to instantiate an undefined plugin class during spreadsheet initialization.
- The project must handle different module export shapes from `@univerjs/*` packages (named exports, `default`, or alternate `plugin` properties) to avoid registering `undefined` plugins.

### Description
- Replaced direct named imports with namespace imports in `resources/js/spreadsheet.js` and added a `firstAvailable(...)` helper to pick the first defined export shape. 
- Resolved the sheets, sheets UI, and formula plugin constructors from multiple candidates (`named`, `default`, or `plugin`) before registering them. 
- Switched plugin registration calls to use the resolved `sheetsPlugin`, `formulaPlugin`, and `sheetsUIPlugin` variables while keeping workbook creation and save logic unchanged. 
- Modified file: `resources/js/spreadsheet.js`.

### Testing
- Ran `php artisan test --filter=SpreadsheetTest`, which failed in this environment due to missing PHP dependencies (`vendor/autoload.php` not found), so automated PHP tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b7e0e45c832da9be329cf723b95d)