### PR TITLE
Fix Univer spreadsheet plugin registration to prevent DI runtime error

### DIFF
--- a/resources/js/spreadsheet.js
+++ b/resources/js/spreadsheet.js
@@ -1,20 +1,14 @@
 import '@univerjs/ui/lib/index.css';
 import { Univer, LocaleType, merge } from '@univerjs/core';
-import * as UniverSheets from '@univerjs/sheets';
-import * as UniverSheetsUI from '@univerjs/sheets-ui';
-import * as UniverSheetsFormula from '@univerjs/sheets-formula';
+import { UniverSheetsPlugin } from '@univerjs/sheets';
+import { UniverSheetsUIPlugin } from '@univerjs/sheets-ui';
+import { UniverSheetsFormulaPlugin } from '@univerjs/sheets-formula';
 import { WemFormulaPlugin } from './plugins/WemFormulaPlugin';
 
 const config = window.WEM_SPREADSHEET;
 
 if (config && document.getElementById('univer-container')) {
-    const firstAvailable = (...candidates) => candidates.find(Boolean);
-
-    const registerPluginIfAvailable = (univer, plugin, options = undefined) => {
-        if (!plugin) {
-            return;
-        }
-
+    const registerPlugin = (univer, plugin, options = undefined) => {
         if (options === undefined) {
             univer.registerPlugin(plugin);
             return;
@@ -23,32 +17,14 @@ if (config && document.getElementById('univer-container')) {
         univer.registerPlugin(plugin, options);
     };
 
-    const sheetsPlugin = firstAvailable(
-        UniverSheets.UniverSheetsPlugin,
-        UniverSheets.default,
-        UniverSheets.plugin
-    );
-    const sheetsUIPlugin = firstAvailable(
-        UniverSheetsUI.UniverSheetsUIPlugin,
-        UniverSheetsUI.default,
-        UniverSheetsUI.plugin
-    );
-    const formulaPlugin =
-        firstAvailable(
-            UniverSheetsFormula.UniverFormulaEnginePlugin,
-            UniverSheetsFormula.UniverSheetsFormulaPlugin,
-            UniverSheetsFormula.default,
-            UniverSheetsFormula.plugin
-        );
-
     const univer = new Univer({
         locale: LocaleType.FR_FR,
         locales: {},
     });
 
-    registerPluginIfAvailable(univer, sheetsPlugin);
-    registerPluginIfAvailable(univer, formulaPlugin);
-    registerPluginIfAvailable(univer, sheetsUIPlugin, {
+    registerPlugin(univer, UniverSheetsPlugin);
+    registerPlugin(univer, UniverSheetsFormulaPlugin);
+    registerPlugin(univer, UniverSheetsUIPlugin, {
         container: 'univer-container',
     });
 


### PR DESCRIPTION
### Motivation
- The spreadsheet page crashed with `Cannot read properties of undefined (reading 'Symbol($$DEPENDENCIES)')`, which indicates an invalid/undefined plugin object was being registered into Univer's DI container.  
- The existing fallback resolution (`firstAvailable`) and namespace imports could pass undefined or the wrong shape into the injector causing runtime dependency resolution failures.

### Description
- Replace wildcard/namespace imports with direct named plugin imports: `UniverSheetsPlugin`, `UniverSheetsFormulaPlugin`, and `UniverSheetsUIPlugin` in `resources/js/spreadsheet.js`.  
- Remove the `firstAvailable` fallback resolution and the `registerPluginIfAvailable` pattern and introduce a single `registerPlugin` helper that always registers a provided plugin.  
- Always register the three known plugin classes (`UniverSheetsPlugin`, `UniverSheetsFormulaPlugin`, `UniverSheetsUIPlugin`) in the expected order before calling `univer.createUnit('UNIVER_SHEET', ...)`, preventing undefined plugin registration.

### Testing
- Attempted an asset build with `npm run development`, but the build could not be validated here because `mix` resolved to Elixir's `mix` tool in this environment and the JS bundling step failed.  
- No automated unit tests were present for this initialization path in the repository, so no additional automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b902b970832d990e714a40331124)