### PR TITLE
Accept Univer `snapshot` payload in spreadsheet save endpoint to fix autosave 422

### DIFF
--- a/app/Http/Controllers/SpreadsheetController.php
+++ b/app/Http/Controllers/SpreadsheetController.php
@@ -91,13 +91,24 @@ class SpreadsheetController extends Controller
         abort_unless($spreadsheet->created_by === auth()->id(), 403);
 
         $validated = $request->validate([
-            'sheets' => ['required', 'array'],
+            'sheets' => ['nullable', 'array'],
             'sheets.*.id' => ['nullable', 'integer'],
             'sheets.*.name' => ['nullable', 'string', 'max:255'],
             'sheets.*.data' => ['nullable', 'array'],
+            'snapshot' => ['nullable', 'array'],
+            'snapshot.sheets' => ['nullable', 'array'],
         ]);
 
-        foreach ($validated['sheets'] as $index => $sheetData) {
+        $sheetsPayload = $validated['sheets'] ?? $this->extractSheetsFromSnapshot($validated['snapshot'] ?? null);
+
+        if (empty($sheetsPayload)) {
+            return response()->json([
+                'message' => 'Aucune feuille à sauvegarder.',
+                'errors' => ['sheets' => ['Le tableur ne contient aucune feuille valide.']],
+            ], 422);
+        }
+
+        foreach ($sheetsPayload as $index => $sheetData) {
             $payload = [
                 'name' => $sheetData['name'] ?? ('Sheet' . ($index + 1)),
                 'order' => $index,
@@ -113,5 +124,32 @@ class SpreadsheetController extends Controller
         }
 
         return response()->json(['success' => true]);
+    }
+
+    private function extractSheetsFromSnapshot(?array $snapshot): array
+    {
+        if (empty($snapshot['sheets']) || !is_array($snapshot['sheets'])) {
+            return [];
+        }
+
+        $sheetOrder = is_array($snapshot['sheetOrder'] ?? null)
+            ? $snapshot['sheetOrder']
+            : array_keys($snapshot['sheets']);
+
+        $sheets = [];
+        foreach ($sheetOrder as $sheetKey) {
+            $sheetData = $snapshot['sheets'][$sheetKey] ?? null;
+
+            if (!is_array($sheetData)) {
+                continue;
+            }
+
+            $sheets[] = [
+                'name' => $sheetData['name'] ?? null,
+                'data' => $sheetData,
+            ];
+        }
+
+        return $sheets;
     }
 }


### PR DESCRIPTION
### Motivation
- The frontend autosave sends a Univer `snapshot` structure while the backend expected an explicit `sheets` array, causing repeated `422 Unprocessable Content` errors on the spreadsheet editor page. 
- The endpoint should be tolerant of both legacy `sheets` payloads and the `snapshot` shaped data emitted by the editor. 
- Provide a clearer error response when no valid sheets are present instead of failing silently.

### Description
- Relaxed validation in `SpreadsheetController::save` to allow `sheets` to be `nullable` and to accept a `snapshot` array (`snapshot.sheets`).
- Added a private helper `extractSheetsFromSnapshot` to convert a Univer `snapshot` into an ordered `sheets` payload using `snapshot.sheetOrder` or the keys of `snapshot.sheets`.
- Reused the existing save loop to persist each sheet from either the supplied `sheets` or the converted `snapshot` data. 
- Return a JSON `422` response with a helpful message when no valid sheets can be extracted.

### Testing
- Ran `php -l app/Http/Controllers/SpreadsheetController.php` which reported no syntax errors. 
- Attempted `php artisan test --filter=Spreadsheet --stop-on-failure` but it failed in this environment due to missing dependencies (`vendor/autoload.php` not present). 
- Verified the updated file `app/Http/Controllers/SpreadsheetController.php` was updated and the new logic compiles under static PHP linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c7897f08832d8535dcdfa5a67962)