### PR TITLE
Add spreadsheet order/context APIs and new WEM spreadsheet formulas; update help UI and tests

### DIFF
--- a/app/Http/Controllers/SpreadsheetDataController.php
+++ b/app/Http/Controllers/SpreadsheetDataController.php
@@ -121,6 +121,88 @@ class SpreadsheetDataController extends Controller
         ]);
     }
 
+
+    public function lateOrders(): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $orders = Orders::with('companie')
+            ->whereNotIn('statu', [3, 4, 5])
+            ->whereDate('created_at', '<', now()->subDays(30))
+            ->latest()
+            ->limit(200)
+            ->get()
+            ->map(function (Orders $order) {
+                $createdAt = $order->created_at;
+
+                return [
+                    'id' => $order->id,
+                    'reference' => $order->code,
+                    'customer' => optional($order->companie)->label,
+                    'total' => (float) ($order->total_price ?? 0),
+                    'status' => $order->statu,
+                    'days_open' => $createdAt ? $createdAt->diffInDays(now()) : null,
+                    'created_at' => optional($createdAt)?->toDateTimeString(),
+                ];
+            });
+
+        return response()->json($orders->values());
+    }
+
+    public function ordersSummary(Request $request): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $month = $request->get('month', now()->format('Y-m'));
+        try {
+            $start = Carbon::createFromFormat('Y-m', $month)->startOfMonth();
+        } catch (\Throwable $exception) {
+            $start = now()->startOfMonth();
+            $month = $start->format('Y-m');
+        }
+        $end = $start->copy()->endOfMonth();
+
+        $ordersQuery = Orders::query();
+        $openOrdersQuery = Orders::query()->whereNotIn('statu', [3, 4, 5]);
+
+        $totalOrders = (clone $ordersQuery)->count();
+        $openOrders = (clone $openOrdersQuery)->count();
+        $lateOrders = (clone $openOrdersQuery)->whereDate('created_at', '<', now()->subDays(30))->count();
+        $openAmount = (float) ((clone $openOrdersQuery)->sum('total_price') ?? 0);
+
+        $invoices = Invoices::whereBetween('created_at', [$start, $end])->get();
+        $totalHt = (float) $invoices->sum(fn (Invoices $invoice) => (float) $invoice->total_price);
+
+        return response()->json([
+            'month' => $month,
+            'total_orders' => $totalOrders,
+            'open_orders' => $openOrders,
+            'late_orders' => $lateOrders,
+            'open_orders_total_ht' => round($openAmount, 2),
+            'month_revenue_ht' => round($totalHt, 2),
+            'month_revenue_count' => $invoices->count(),
+        ]);
+    }
+
+    public function context(): JsonResponse
+    {
+        if ($response = $this->guard()) {
+            return $response;
+        }
+
+        $now = now();
+
+        return response()->json([
+            'today' => $now->format('Y-m-d'),
+            'current_month' => $now->format('Y-m'),
+            'current_year' => (int) $now->format('Y'),
+        ]);
+    }
+
     public function customers(): JsonResponse
     {
         if ($response = $this->guard()) {

--- a/resources/js/plugins/WemFormulaPlugin.js
+++ b/resources/js/plugins/WemFormulaPlugin.js
@@ -41,7 +41,7 @@ export class WemFormulaPlugin {
     }
 
     async _prefetch() {
-        for (const path of ['/orders?status=open', '/production/kpis']) {
+        for (const path of ['/orders?status=open', '/production/kpis', '/orders/summary', '/orders/late', '/context']) {
             try {
                 const res = await fetch(`${this.dataApiBase}${path}`, {
                     headers: { Accept: 'application/json' },
@@ -93,6 +93,57 @@ export class WemFormulaPlugin {
                     calculate() {
                         const data = self.fetchSync('/production/kpis');
                         return NumberValueObject.create(Number(data?.late_orders || 0));
+                    },
+                },
+                {
+                    name: 'WEM_LISTE_COMMANDES_RETARD',
+                    calculate() {
+                        const data = self.fetchSync('/orders/late');
+                        const refs = Array.isArray(data)
+                            ? data.map((order) => order?.reference).filter(Boolean)
+                            : [];
+                        return StringValueObject.create(refs.join(', '));
+                    },
+                },
+                {
+                    name: 'WEM_LISTE_COMMANDES',
+                    calculate(status) {
+                        const requestedStatus = status?.getValue?.()?.toString()?.trim() || 'all';
+                        const allowed = ['all', 'open', 'closed'];
+                        const normalizedStatus = allowed.includes(requestedStatus) ? requestedStatus : 'all';
+                        const data = self.fetchSync(`/orders?status=${encodeURIComponent(normalizedStatus)}`);
+                        const refs = Array.isArray(data)
+                            ? data.map((order) => order?.reference).filter(Boolean)
+                            : [];
+                        return StringValueObject.create(refs.join(', '));
+                    },
+                },
+                {
+                    name: 'WEM_CA_COMMANDES_OUVERTES',
+                    calculate() {
+                        const data = self.fetchSync('/orders/summary');
+                        return NumberValueObject.create(Number(data?.open_orders_total_ht || 0));
+                    },
+                },
+                {
+                    name: 'WEM_MOIS_COURANT',
+                    calculate() {
+                        const data = self.fetchSync('/context');
+                        return StringValueObject.create((data?.current_month || '').toString());
+                    },
+                },
+                {
+                    name: 'WEM_AUJOURDHUI',
+                    calculate() {
+                        const data = self.fetchSync('/context');
+                        return StringValueObject.create((data?.today || '').toString());
+                    },
+                },
+                {
+                    name: 'WEM_ANNEE_COURANTE',
+                    calculate() {
+                        const data = self.fetchSync('/context');
+                        return NumberValueObject.create(Number(data?.current_year || 0));
                     },
                 },
             ];

--- a/resources/views/spreadsheet/editor.blade.php
+++ b/resources/views/spreadsheet/editor.blade.php
@@ -37,7 +37,7 @@
                         <code>=IF(A1&gt;0;"OK";"KO")</code>) ainsi que les formules métier WEM ci-dessous.
                     </p>
 
-                    <h6 class="mt-3">Formules WEM disponibles</h6>
+                    <h6 class="mt-3">Commandes WEM disponibles</h6>
                     <div class="table-responsive">
                         <table class="table table-sm table-striped">
                             <thead>
@@ -49,29 +49,74 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>WEM.STOCK(reference)</code></td>
+                                    <td><code>WEM_STOCK(reference)</code></td>
                                     <td>Retourne le stock actuel d'une référence article.</td>
-                                    <td><code>=WEM.STOCK("REF-001")</code></td>
+                                    <td><code>=WEM_STOCK("TL-AC-2000x1000-EP1")</code></td>
                                 </tr>
                                 <tr>
-                                    <td><code>WEM.COMMANDES_EN_COURS()</code></td>
+                                    <td><code>WEM_COMMANDES_EN_COURS()</code></td>
                                     <td>Retourne le nombre de commandes ouvertes.</td>
-                                    <td><code>=WEM.COMMANDES_EN_COURS()</code></td>
+                                    <td><code>=WEM_COMMANDES_EN_COURS()</code></td>
                                 </tr>
                                 <tr>
-                                    <td><code>WEM.CA_MOIS(mois)</code></td>
-                                    <td>Retourne le chiffre d'affaires HT du mois (format <code>YYYY-MM</code>).</td>
-                                    <td><code>=WEM.CA_MOIS("2026-03")</code></td>
-                                </tr>
-                                <tr>
-                                    <td><code>WEM.DELAI_MOYEN()</code></td>
-                                    <td>Retourne le délai moyen de production en jours.</td>
-                                    <td><code>=WEM.DELAI_MOYEN()</code></td>
-                                </tr>
-                                <tr>
-                                    <td><code>WEM.COMMANDES_RETARD()</code></td>
+                                    <td><code>WEM_COMMANDES_RETARD()</code></td>
                                     <td>Retourne le nombre de commandes en retard.</td>
-                                    <td><code>=WEM.COMMANDES_RETARD()</code></td>
+                                    <td><code>=WEM_COMMANDES_RETARD()</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_LISTE_COMMANDES_RETARD()</code></td>
+                                    <td>Retourne la liste des références de commandes en retard (texte).</td>
+                                    <td><code>=WEM_LISTE_COMMANDES_RETARD()</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_LISTE_COMMANDES([status])</code></td>
+                                    <td>Retourne la liste des références de commandes (status: <code>all</code>, <code>open</code>, <code>closed</code>).</td>
+                                    <td><code>=WEM_LISTE_COMMANDES("open")</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_CA_COMMANDES_OUVERTES()</code></td>
+                                    <td>Retourne le CA HT total des commandes ouvertes.</td>
+                                    <td><code>=WEM_CA_COMMANDES_OUVERTES()</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_CA_MOIS(mois)</code></td>
+                                    <td>Retourne le chiffre d'affaires HT du mois (format <code>YYYY-MM</code>).</td>
+                                    <td><code>=WEM_CA_MOIS("2026-03")</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_DELAI_MOYEN()</code></td>
+                                    <td>Retourne le délai moyen de production en jours.</td>
+                                    <td><code>=WEM_DELAI_MOYEN()</code></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <h6 class="mt-4">Variables pratiques WEM</h6>
+                    <div class="table-responsive">
+                        <table class="table table-sm table-striped mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Variable</th>
+                                    <th>Description</th>
+                                    <th>Exemple</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>WEM_MOIS_COURANT()</code></td>
+                                    <td>Retourne le mois courant au format <code>YYYY-MM</code>.</td>
+                                    <td><code>=WEM_CA_MOIS(WEM_MOIS_COURANT())</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_AUJOURDHUI()</code></td>
+                                    <td>Retourne la date du jour au format <code>YYYY-MM-DD</code>.</td>
+                                    <td><code>=WEM_AUJOURDHUI()</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>WEM_ANNEE_COURANTE()</code></td>
+                                    <td>Retourne l'année en cours (format numérique).</td>
+                                    <td><code>=WEM_ANNEE_COURANTE()</code></td>
                                 </tr>
                             </tbody>
                         </table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -791,6 +791,9 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/orders', [SpreadsheetDataController::class, 'orders'])->name('orders');
         Route::get('/revenue', [SpreadsheetDataController::class, 'revenue'])->name('revenue');
         Route::get('/production/kpis', [SpreadsheetDataController::class, 'productionKpis'])->name('productionKpis');
+        Route::get('/orders/late', [SpreadsheetDataController::class, 'lateOrders'])->name('lateOrders');
+        Route::get('/orders/summary', [SpreadsheetDataController::class, 'ordersSummary'])->name('ordersSummary');
+        Route::get('/context', [SpreadsheetDataController::class, 'context'])->name('context');
         Route::get('/customers', [SpreadsheetDataController::class, 'customers'])->name('customers');
         Route::get('/products', [SpreadsheetDataController::class, 'products'])->name('products');
     });

--- a/tests/Feature/SpreadsheetTest.php
+++ b/tests/Feature/SpreadsheetTest.php
@@ -90,8 +90,17 @@ class SpreadsheetTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('Aide formules');
-        $response->assertSee('WEM.STOCK(reference)');
-        $response->assertSee('WEM.COMMANDES_EN_COURS()');
+        $response->assertSee('WEM_STOCK(reference)');
+        $response->assertSee('WEM_COMMANDES_EN_COURS()');
+        $response->assertSee('WEM_COMMANDES_RETARD()');
+        $response->assertSee('WEM_LISTE_COMMANDES_RETARD()');
+        $response->assertSee('WEM_LISTE_COMMANDES([status])');
+        $response->assertSee('WEM_CA_COMMANDES_OUVERTES()');
+        $response->assertSee('WEM_CA_MOIS(mois)');
+        $response->assertSee('WEM_DELAI_MOYEN()');
+        $response->assertSee('WEM_MOIS_COURANT()');
+        $response->assertSee('WEM_AUJOURDHUI()');
+        $response->assertSee('WEM_ANNEE_COURANTE()');
     }
 
     public function test_stock_data_endpoint_returns_json(): void
@@ -107,6 +116,52 @@ class SpreadsheetTest extends TestCase
             'quantity',
             'unit',
             'updated_at',
+        ]);
+    }
+
+
+    public function test_late_orders_data_endpoint_returns_json(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/api/spreadsheet/data/orders/late');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_orders_summary_data_endpoint_returns_json(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/api/spreadsheet/data/orders/summary');
+
+        $response->assertStatus(200)->assertJsonStructure([
+            'month',
+            'total_orders',
+            'open_orders',
+            'late_orders',
+            'open_orders_total_ht',
+            'month_revenue_ht',
+            'month_revenue_count',
+        ]);
+    }
+
+    public function test_context_data_endpoint_returns_json(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson('/api/spreadsheet/data/context');
+
+        $response->assertStatus(200)->assertJsonStructure([
+            'today',
+            'current_month',
+            'current_year',
         ]);
     }
 


### PR DESCRIPTION
### Motivation

- Provide additional spreadsheet data for orders and temporal context to support new WEM formulas and dashboard usage.
- Allow prefetching and synchronous access to orders summary, late orders and context from the spreadsheet formula plugin.

### Description

- Added three new API endpoints in `SpreadsheetDataController`: `lateOrders()`, `ordersSummary(Request $request)` and `context()` and registered routes under `api/spreadsheet/data` (`/orders/late`, `/orders/summary`, `/context`).
- Extended the JS formula plugin `resources/js/plugins/WemFormulaPlugin.js` to prefetch the new endpoints and registered new formulas: `WEM_LISTE_COMMANDES_RETARD`, `WEM_LISTE_COMMANDES`, `WEM_CA_COMMANDES_OUVERTES`, `WEM_MOIS_COURANT`, `WEM_AUJOURDHUI`, and `WEM_ANNEE_COURANTE`, and adjusted naming to use underscore-style formula identifiers (e.g. `WEM_STOCK`).
- Updated the spreadsheet help modal view `resources/views/spreadsheet/editor.blade.php` to reflect the new formula names, add the new commands/variables and reorganize the help content.
- Added route entries in `routes/web.php` for the new API endpoints.
- Updated `tests/Feature/SpreadsheetTest.php` to assert the updated help modal content and added feature tests for the new endpoints (`/api/spreadsheet/data/orders/late`, `/api/spreadsheet/data/orders/summary`, `/api/spreadsheet/data/context`).

### Testing

- Ran the spreadsheet feature tests via `php artisan test` (focused on `SpreadsheetTest`) which exercise the help modal assertions and the new endpoints, and they passed.
- Verified the JSON shape for `orders/summary` and `context` via the new test assertions which succeeded.
- Confirmed the existing `stock` endpoint test still passes after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d4a25290832db11b647bbe8edec8)