### PR TITLE
Use whereColumn for receipt/invoiced qty comparisons

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -84,8 +84,8 @@ class AppServiceProvider extends ServiceProvider
                                                                                     ->orWhere('type', '=', '7');
                                                                             })->get();*/
 
-            $PurchasesWaintingReceiptCount = PurchaseLines::where('receipt_qty','<=', 'qty')->count();
-            $PurchasesWaintingInvoiceCount = PurchaseLines::where('invoiced_qty','<=', 'qty')->count();
+            $PurchasesWaintingReceiptCount = PurchaseLines::whereColumn('receipt_qty','<=', 'qty')->count();
+            $PurchasesWaintingInvoiceCount = PurchaseLines::whereColumn('invoiced_qty','<=', 'qty')->count();
 
             $event->menu->addBefore('orders_lines_list', [
                 'text' => 'orders_list_trans_key',

--- a/app/Services/PurchaseReceiptService.php
+++ b/app/Services/PurchaseReceiptService.php
@@ -123,7 +123,7 @@ class PurchaseReceiptService
     public function getPurchasesWaintingReceiptLines($companies_id = null, $sortField = 'id', $sortAsc = true)
     {
         return PurchaseLines::orderBy($sortField, $sortAsc ? 'asc' : 'desc')
-        ->where('receipt_qty','<=', 'qty')
+        ->whereColumn('receipt_qty','<=', 'qty')
         ->whereHas('purchase', function($q)use ($companies_id) {
             $q->where('companies_id','like', '%'. $companies_id .'%');
         })
@@ -137,7 +137,7 @@ class PurchaseReceiptService
      */
     public function getUniqueCompanyIdsWithOpenPurchaseLines(): Collection
     {
-        return PurchaseLines::where('receipt_qty','<=', 'qty')
+        return PurchaseLines::whereColumn('receipt_qty','<=', 'qty')
                             ->leftJoin('purchases', 'purchase_lines.purchases_id', '=', 'purchases.id')
                             ->pluck('purchases.companies_id')
                             ->filter()


### PR DESCRIPTION
### Motivation
- Ensure comparisons are performed between database columns (not string values) when checking received/invoiced quantities so queries behave correctly across databases.

### Description
- Replace `where('receipt_qty','<=', 'qty')` and `where('invoiced_qty','<=', 'qty')` with `whereColumn('receipt_qty','<=', 'qty')` and `whereColumn('invoiced_qty','<=', 'qty')` in `app/Services/PurchaseReceiptService.php` and `app/Providers/AppServiceProvider.php`.

### Testing
- Searched the `app/` tree with `rg -n` for the original `where(... 'receipt_qty' ...)` / `where(... 'invoiced_qty' ...)` patterns and confirmed no remaining matches; the search succeeded.
- Inspected the modified files with a diff/line listing to verify the `whereColumn` substitutions were applied; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6819b9fec832da03846cfba559477)