### PR TITLE
Add ShouldQueue to event listeners in app/Listeners

### DIFF
--- a/app/Listeners/CheckOrderDeliveredStatus.php
+++ b/app/Listeners/CheckOrderDeliveredStatus.php
@@ -8,7 +8,7 @@ use App\Models\Workflow\OrderLines;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class CheckOrderDeliveredStatus
+class CheckOrderDeliveredStatus implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/CheckOrderLineTaskStatus.php
+++ b/app/Listeners/CheckOrderLineTaskStatus.php
@@ -9,7 +9,7 @@ use App\Models\Workflow\OrderLines;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class CheckOrderLineTaskStatus
+class CheckOrderLineTaskStatus implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/SendWelcomeEmail.php
+++ b/app/Listeners/SendWelcomeEmail.php
@@ -2,11 +2,12 @@
 
 namespace App\Listeners;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Mail\WelcomeMail;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Mail;
 
-class SendWelcomeEmail
+class SendWelcomeEmail implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/UpdateCompanyStatus.php
+++ b/app/Listeners/UpdateCompanyStatus.php
@@ -7,7 +7,7 @@ use App\Models\Companies\Companies;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UpdateCompanyStatus
+class UpdateCompanyStatus implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/UpdateCompanyStatusForOrder.php
+++ b/app/Listeners/UpdateCompanyStatusForOrder.php
@@ -7,7 +7,7 @@ use App\Models\Companies\Companies;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UpdateCompanyStatusForOrder
+class UpdateCompanyStatusForOrder implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/UpdateDeliveryStatus.php
+++ b/app/Listeners/UpdateDeliveryStatus.php
@@ -8,7 +8,7 @@ use App\Models\Workflow\DeliveryLines;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UpdateDeliveryStatus
+class UpdateDeliveryStatus implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/UpdateOpportunityStatus.php
+++ b/app/Listeners/UpdateOpportunityStatus.php
@@ -8,7 +8,7 @@ use App\Models\Workflow\Opportunities;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UpdateOpportunityStatus
+class UpdateOpportunityStatus implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/UpdatePurchaseStatus.php
+++ b/app/Listeners/UpdatePurchaseStatus.php
@@ -9,7 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Models\Purchases\PurchaseReceiptLines;
 
-class UpdatePurchaseStatus
+class UpdatePurchaseStatus implements ShouldQueue
 {
     /**
      * Create the event listener.

--- a/app/Listeners/UpdatePurchasesQuotationStatus.php
+++ b/app/Listeners/UpdatePurchasesQuotationStatus.php
@@ -2,11 +2,12 @@
 
 namespace App\Listeners;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Events\PurchaseCreated;
 use App\Models\Purchases\PurchasesQuotation;
 use App\Models\Purchases\PurchaseQuotationLines;
 
-class UpdatePurchasesQuotationStatus
+class UpdatePurchasesQuotationStatus implements ShouldQueue
 {
     /**
      * Create the event listener.


### PR DESCRIPTION
### Motivation
- Ensure event listeners are queued by default so their work runs asynchronously and does not block request handling.
- Apply this consistently across all listener classes in `app/Listeners/` that did not already implement `ShouldQueue`.

### Description
- Added `implements ShouldQueue` to the listener classes in `app/Listeners/` that lacked it, without altering any business logic.
- Added the missing import `use Illuminate\Contracts\Queue\ShouldQueue;` where it was absent.
- Files modified: `app/Listeners/CheckOrderDeliveredStatus.php`, `app/Listeners/CheckOrderLineTaskStatus.php`, `app/Listeners/SendWelcomeEmail.php`, `app/Listeners/UpdateCompanyStatus.php`, `app/Listeners/UpdateCompanyStatusForOrder.php`, `app/Listeners/UpdateDeliveryStatus.php`, `app/Listeners/UpdateOpportunityStatus.php`, `app/Listeners/UpdatePurchaseStatus.php`, and `app/Listeners/UpdatePurchasesQuotationStatus.php`.

### Testing
- Ran `php -l` syntax checks on each modified file and all files reported `No syntax errors detected`.
- Verified the set of modified files contains 9 entries and that no other code or logic was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68204f684832d822e3e88dc0f49de)