### PR TITLE
Cache menu SQL counters in AppServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,6 +14,7 @@ use App\Observers\OrdersObserver;
 use App\Models\Workflow\DeliveryLines;
 use App\Models\Purchases\PurchaseLines;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Contracts\Events\Dispatcher;
 use App\Models\Purchases\PurchaseReceiptLines;
 use JeroenNoten\LaravelAdminLte\Events\BuildingMenu;
@@ -49,25 +50,31 @@ class AppServiceProvider extends ServiceProvider
 
         $events->listen(BuildingMenu::class, function (BuildingMenu $event) {
 
-            $OrdersNotFinishCount = Orders::whereNotIn('statu', [3, 6])->count();
+            $OrdersNotFinishCount = Cache::remember('menu_orders_not_finish', 60, function() {
+                return Orders::whereNotIn('statu', [3, 6])->count();
+            });
             
-            $DeliverysRequestsCount = OrderLines::where(
-                function($query) {
-                    return $query
-                        ->where('delivery_status', '=', '1')
-                        ->orWhere('delivery_status', '=', '2');
-                })
-                ->whereHas('order', function($q){
-                    $q->whereNotIn('statu', [5, 6])
-                        ->where('type', '=', '1');
-                })->count();
+            $DeliverysRequestsCount = Cache::remember('menu_deliverys_requests', 60, function() {
+                return OrderLines::where(
+                    function($query) {
+                        return $query
+                            ->where('delivery_status', '=', '1')
+                            ->orWhere('delivery_status', '=', '2');
+                    })
+                    ->whereHas('order', function($q){
+                        $q->whereNotIn('statu', [5, 6])
+                            ->where('type', '=', '1');
+                    })->count();
+            });
 
-            $InvoicesRequestsCount =  DeliveryLines::where(
-                                                        function($query) {
-                                                            return $query
-                                                                ->where('invoice_status', '=', '1')
-                                                                ->orWhere('invoice_status', '=', '2');
-                                                        })->count();
+            $InvoicesRequestsCount = Cache::remember('menu_invoices_requests', 60, function() {
+                return DeliveryLines::where(
+                    function($query) {
+                        return $query
+                            ->where('invoice_status', '=', '1')
+                            ->orWhere('invoice_status', '=', '2');
+                    })->count();
+            });
 
             /* not use because Status is not init on start of instal, and what is incident if statu is null on menu init ?*/ 
             //$Status = Status::select('id')->orderBy('order')->first();
@@ -84,8 +91,12 @@ class AppServiceProvider extends ServiceProvider
                                                                                     ->orWhere('type', '=', '7');
                                                                             })->get();*/
 
-            $PurchasesWaintingReceiptCount = PurchaseLines::whereColumn('receipt_qty','<=', 'qty')->count();
-            $PurchasesWaintingInvoiceCount = PurchaseLines::whereColumn('invoiced_qty','<=', 'qty')->count();
+            $PurchasesWaintingReceiptCount = Cache::remember('menu_purchases_receipt', 60, function() {
+                return PurchaseLines::whereColumn('receipt_qty','<=', 'qty')->count();
+            });
+            $PurchasesWaintingInvoiceCount = Cache::remember('menu_purchases_invoice', 60, function() {
+                return PurchaseLines::whereColumn('invoiced_qty','<=', 'qty')->count();
+            });
 
             $event->menu->addBefore('orders_lines_list', [
                 'text' => 'orders_list_trans_key',


### PR DESCRIPTION
### Motivation
- Reduce database load and speed up menu rendering by caching frequently computed menu counters.

### Description
- Added `use Illuminate\Support\Facades\Cache;` and wrapped the five menu counter queries in `Cache::remember(..., 60, function() { ... })` using the keys `menu_orders_not_finish`, `menu_deliverys_requests`, `menu_invoices_requests`, `menu_purchases_receipt`, and `menu_purchases_invoice`.

### Testing
- Ran `php -l app/Providers/AppServiceProvider.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b682473178832da64b74f23533d4e5)