### PR TITLE
Add dedicated migration for missing indexes on orders, lines, tasks and purchase_lines

### DIFF
--- a/database/migrations/2026_03_15_000000_add_missing_indexes_to_sales_tasks_and_purchase_tables.php
+++ b/database/migrations/2026_03_15_000000_add_missing_indexes_to_sales_tasks_and_purchase_tables.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->index('statu');
+        });
+
+        Schema::table('order_lines', function (Blueprint $table) {
+            $table->index('orders_id');
+            $table->index('delivery_status');
+            $table->index('tasks_status');
+        });
+
+        Schema::table('quote_lines', function (Blueprint $table) {
+            $table->index('quotes_id');
+            $table->index('statu');
+        });
+
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->index('order_lines_id');
+            $table->index('quote_lines_id');
+            $table->index('status_id');
+            $table->index('products_id');
+        });
+
+        Schema::table('purchase_lines', function (Blueprint $table) {
+            $table->index('receipt_qty');
+            $table->index('invoiced_qty');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropIndex(['statu']);
+        });
+
+        Schema::table('order_lines', function (Blueprint $table) {
+            $table->dropIndex(['orders_id']);
+            $table->dropIndex(['delivery_status']);
+            $table->dropIndex(['tasks_status']);
+        });
+
+        Schema::table('quote_lines', function (Blueprint $table) {
+            $table->dropIndex(['quotes_id']);
+            $table->dropIndex(['statu']);
+        });
+
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropIndex(['order_lines_id']);
+            $table->dropIndex(['quote_lines_id']);
+            $table->dropIndex(['status_id']);
+            $table->dropIndex(['products_id']);
+        });
+
+        Schema::table('purchase_lines', function (Blueprint $table) {
+            $table->dropIndex(['receipt_qty']);
+            $table->dropIndex(['invoiced_qty']);
+        });
+    }
+};


### PR DESCRIPTION
### Motivation
- Ajouter les index manquants pour améliorer les performances des requêtes sur les colonnes fréquemment filtrées sans modifier les migrations historiques déjà en production.

### Description
- Ajout d'une nouvelle migration `database/migrations/2026_03_15_000000_add_missing_indexes_to_sales_tasks_and_purchase_tables.php` qui crée uniquement les index demandés.
- Index ajoutés : `orders.statu`; `order_lines.orders_id`, `order_lines.delivery_status`, `order_lines.tasks_status`; `quote_lines.quotes_id`, `quote_lines.statu`; `tasks.order_lines_id`, `tasks.quote_lines_id`, `tasks.status_id`, `tasks.products_id`; `purchase_lines.receipt_qty`, `purchase_lines.invoiced_qty`.
- La migration inclut un `down()` complet qui supprime les mêmes index pour permettre un rollback propre.
- Aucune structure de colonne n'a été modifiée, seulement des index ont été ajoutés.

### Testing
- Exécuté `php -l database/migrations/2026_03_15_000000_add_missing_indexes_to_sales_tasks_and_purchase_tables.php` et la vérification de syntaxe PHP a réussi (pas d'erreurs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b682e70dd0832d8aa734ac3e987c5b)