### PR TITLE
Replace wire:model.live with wire:model.lazy in Livewire Blade views

### DIFF
--- a/resources/views/livewire/chatlive.blade.php
+++ b/resources/views/livewire/chatlive.blade.php
@@ -66,7 +66,7 @@
     </div> 
         
     <div class="input-group">
-        <input type="text" wire:model.live="label" name="label"  id="label" placeholder="Chat ..." class="form-control">
+        <input type="text" wire:model.lazy="label" name="label"  id="label" placeholder="Chat ..." class="form-control">
         <span class="input-group-append">
             <button type="button" wire:click="storeMessage({{ $idItem }}, '{{ $Class }}')" class="btn btn-danger">{{ __('general_content.add_trans_key') }}</button>
         </span>

--- a/resources/views/livewire/companies-lines.blade.php
+++ b/resources/views/livewire/companies-lines.blade.php
@@ -21,7 +21,7 @@
                                                     <div class="input-group-prepend">
                                                         <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                                     </div>
-                                                    <input type="text" class="form-control @error('code') is-invalid @enderror"  wire:model.live="code" name="code" id="code" placeholder="AAA000">
+                                                    <input type="text" class="form-control @error('code') is-invalid @enderror"  wire:model.lazy="code" name="code" id="code" placeholder="AAA000">
                                                 </div>
                                                 @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                             </div>
@@ -31,7 +31,7 @@
                                                     <div class="input-group-prepend">
                                                         <span class="input-group-text"><i class="fas fa-user"></i></span>
                                                     </div>
-                                                    <select class="form-control" name="user_id" id="user_id"  wire:model.live="user_id">
+                                                    <select class="form-control" name="user_id" id="user_id"  wire:model.lazy="user_id">
                                                         <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                                                     @foreach ($userSelect as $item)
                                                         <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -46,7 +46,7 @@
                                                         <div class="input-group-prepend">
                                                             <span class="input-group-text"><i class="fas fa-toggle-on"></i></span>
                                                         </div>
-                                                        <select class="form-control" id="client_type" wire:click.prevent="toggleClientType()" wire:model.live="client_type">
+                                                        <select class="form-control" id="client_type" wire:click.prevent="toggleClientType()" wire:model.lazy="client_type">
                                                             <option value="1">{{ __('general_content.legal_entity_trans_key') }}</option>
                                                             <option value="2">{{ __('general_content.individual_trans_key') }}</option>
                                                         </select>
@@ -61,7 +61,7 @@
                                                     <div class="input-group-prepend">
                                                         <span class="input-group-text"><i class="fas fa-building"></i></span>
                                                     </div>
-                                                    <input type="text" class="form-control" id="civility" wire:model.live="civility" placeholder="{{ __('general_content.civility_trans_key') }}"> 
+                                                    <input type="text" class="form-control" id="civility" wire:model.lazy="civility" placeholder="{{ __('general_content.civility_trans_key') }}"> 
                                                 </div>
                                                 @error('civility') <span class="text-danger">{{ $message }}</span> @enderror
                                             </div>
@@ -71,7 +71,7 @@
                                                     <div class="input-group-prepend">
                                                         <span class="input-group-text"><i class="fas fa-building"></i></span>
                                                     </div>
-                                                    <input type="text" class="form-control" id="label" wire:model.live="label" placeholder="{{ __('general_content.first_name_trans_key') }}"> 
+                                                    <input type="text" class="form-control" id="label" wire:model.lazy="label" placeholder="{{ __('general_content.first_name_trans_key') }}"> 
                                                 </div>
                                                 @error('label') <span class="text-danger">{{ $message }}</span> @enderror
                                             </div>
@@ -81,7 +81,7 @@
                                                     <div class="input-group-prepend">
                                                         <span class="input-group-text"><i class="fas fa-building"></i></span>
                                                     </div>
-                                                    <input type="text" class="form-control" id="last_name" wire:model.live="last_name" placeholder="{{ __('general_content.contact_name_trans_key') }}">
+                                                    <input type="text" class="form-control" id="last_name" wire:model.lazy="last_name" placeholder="{{ __('general_content.contact_name_trans_key') }}">
                                                 </div>
                                                 @error('last_name') <span class="text-danger">{{ $message }}</span> @enderror
                                             </div>
@@ -92,7 +92,7 @@
                                                     <div class="input-group-prepend">
                                                         <span class="input-group-text"><i class="fas fa-building"></i></span>
                                                     </div>
-                                                    <input type="text" class="form-control @error('label') is-invalid @enderror"  wire:model.live="label" name="label"  id="label" placeholder="{{ __('general_content.name_company_trans_key') }}">
+                                                    <input type="text" class="form-control @error('label') is-invalid @enderror"  wire:model.lazy="label" name="label"  id="label" placeholder="{{ __('general_content.name_company_trans_key') }}">
                                                 </div>
                                                 @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                             </div>
@@ -103,7 +103,7 @@
                                         <div class="row">
                                             <div class="col-12">
                                                 <label>{{ __('general_content.comment_trans_key') }}</label>
-                                                <textarea class="form-control" rows="3" name="comment"   wire:model.live="comment" placeholder="..."></textarea>
+                                                <textarea class="form-control" rows="3" name="comment"   wire:model.lazy="comment" placeholder="..."></textarea>
                                                 @error('comment') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                             </div>
                                         </div>
@@ -132,7 +132,7 @@
                                             <div class="input-group-prepend">
                                                 <span class="input-group-text"><i class="fas fa-filter fa-fw"></i></span>
                                             </div>
-                                            <select class="form-control" wire:model.live="statusFilter">
+                                            <select class="form-control" wire:model.lazy="statusFilter">
                                                 <option value="all">{{ __('general_content.view_all_trans_key') }}</option>
                                                 <option value="client">{{ __('general_content.client_trans_key') }}</option>
                                                 <option value="prospect">{{ __('general_content.prospect_trans_key') }}</option>

--- a/resources/views/livewire/deliverys-request.blade.php
+++ b/resources/views/livewire/deliverys-request.blade.php
@@ -11,7 +11,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-building"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id">
+                            <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                 <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                             @forelse ($CompanieSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -28,7 +28,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                            <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                         </div>
                         @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -38,7 +38,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="label" name="label"  id="label"  placeholder="{{ __('general_content.name_of_deliverys_notes_trans_key') }}" required>
+                            <input type="text" class="form-control" wire:model.lazy="label" name="label"  id="label"  placeholder="{{ __('general_content.name_of_deliverys_notes_trans_key') }}" required>
                         </div>
                         @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -48,7 +48,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-user"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="user_id" name="user_id" id="user_id">
+                            <select class="form-control" wire:model.lazy="user_id" name="user_id" id="user_id">
                                 <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                             @foreach ($userSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -63,7 +63,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-map-marked-alt"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_addresses_id" name="companies_addresses_id" id="companies_addresses_id">
+                            <select class="form-control" wire:model.lazy="companies_addresses_id" name="companies_addresses_id" id="companies_addresses_id">
                                 <option value="">{{ __('general_content.select_address_trans_key') }}</option>
                             @forelse ($AddressSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->label }} - {{ $item->adress }}</option>
@@ -80,7 +80,7 @@
                             <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id">
+                            <select class="form-control" wire:model.lazy="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id">
                                 <option value="">{{ __('general_content.select_contact_trans_key') }}</option>
                             @forelse ($ContactSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->first_name }} - {{ $item->name }}</option>
@@ -94,9 +94,9 @@
                     <div class="form-group col-md-3">
                         @can('stock-lot-serial-management')
                         <label for="RemoveFromStock">{{ __('general_content.remove_component_lines_stock_trans_key') }}</label>
-                        <input type="checkbox" id="RemoveFromStock" wire:model.live="RemoveFromStock" >
+                        <input type="checkbox" id="RemoveFromStock" wire:model.lazy="RemoveFromStock" >
                         <label for="CreateSerialNumber">{{ __('general_content.create_serial_number_trans_key') }}</label>
-                        <input type="checkbox" id="CreateSerialNumber" wire:model.live="CreateSerialNumber" >
+                        <input type="checkbox" id="CreateSerialNumber" wire:model.lazy="CreateSerialNumber" >
                         @endcan
                     </div>
                     
@@ -134,7 +134,7 @@
                             {{__('general_content.action_trans_key') }}
                             @if($companies_id)
                                 <div class="custom-control custom-checkbox mt-2">
-                                    <input class="custom-control-input" id="selectAllLines" type="checkbox" wire:model.live="selectAll">
+                                    <input class="custom-control-input" id="selectAllLines" type="checkbox" wire:model.lazy="selectAll">
                                     <label class="custom-control-label" for="selectAllLines">
                                         {{ $selectAll ? __('general_content.deselect_all_lines_trans_key') : __('general_content.select_all_lines_trans_key') }}
                                     </label>
@@ -169,7 +169,7 @@
                         <td>{{ $DeliverysRequestsLine->delivered_remaining_qty }}</td>
                         <td>
                             <input class="form-control" 
-                            wire:model.live="data.{{ $DeliverysRequestsLine->id }}.scumQty" 
+                            wire:model.lazy="data.{{ $DeliverysRequestsLine->id }}.scumQty" 
                             id="data.{{ $DeliverysRequestsLine->id }}.scumQty"
                             name="data.{{ $DeliverysRequestsLine->id }}.scumQty" 
                             placeholder="{{ __('general_content.qty_trans_key') }}" 
@@ -184,7 +184,7 @@
                             <div class="custom-control custom-checkbox">
                                 <input class="custom-control-input" 
                                         value="{{ $DeliverysRequestsLine->id }}" 
-                                        wire:model.live="data.{{ $DeliverysRequestsLine->id }}.order_line_id" 
+                                        wire:model.lazy="data.{{ $DeliverysRequestsLine->id }}.order_line_id" 
                                         name="data.{{ $DeliverysRequestsLine->id }}.order_line_id" 
                                         id="data.{{ $DeliverysRequestsLine->id }}.order_line_id"  
                                         type="checkbox">

--- a/resources/views/livewire/estimated-budget.blade.php
+++ b/resources/views/livewire/estimated-budget.blade.php
@@ -13,7 +13,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-ruler"></i></span>
                             </div>
-                            <select class="form-control @error('year') is-invalid @enderror" name="year" id="year"  wire:model.live="year">
+                            <select class="form-control @error('year') is-invalid @enderror" name="year" id="year"  wire:model.lazy="year">
                                 <option value="" >{{ __('general_content.select_year_trans_key') }}</option>
                                 <option value="2021" >2021</option>
                                 <option value="2022" >2022</option>
@@ -34,7 +34,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount1') is-invalid @enderror" id="amount1" placeholder="{{ __('general_content.amount_trans_key') }} 1" wire:model.live="amount1">
+                            <input type="number" class="form-control @error('amount1') is-invalid @enderror" id="amount1" placeholder="{{ __('general_content.amount_trans_key') }} 1" wire:model.lazy="amount1">
                         </div>
                     </div>
                     <div class="col-2">
@@ -43,7 +43,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount2') is-invalid @enderror" id="amount2" placeholder="{{ __('general_content.amount_trans_key') }} 2" wire:model.live="amount2">
+                            <input type="number" class="form-control @error('amount2') is-invalid @enderror" id="amount2" placeholder="{{ __('general_content.amount_trans_key') }} 2" wire:model.lazy="amount2">
                         </div>
                     </div>
                     <div class="col-2">
@@ -52,7 +52,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount3') is-invalid @enderror" id="amount3" placeholder="{{ __('general_content.amount_trans_key') }} 3" wire:model.live="amount3">
+                            <input type="number" class="form-control @error('amount3') is-invalid @enderror" id="amount3" placeholder="{{ __('general_content.amount_trans_key') }} 3" wire:model.lazy="amount3">
                         </div>
                     </div>
                     <div class="col-2">
@@ -61,7 +61,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount4" placeholder="{{ __('general_content.amount_trans_key') }} 4" wire:model.live="amount4">
+                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount4" placeholder="{{ __('general_content.amount_trans_key') }} 4" wire:model.lazy="amount4">
                         </div>
                     </div>
                 </div>
@@ -76,7 +76,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount5') is-invalid @enderror" id="amount5" placeholder="{{ __('general_content.amount_trans_key') }} 5" wire:model.live="amount5">
+                            <input type="number" class="form-control @error('amount5') is-invalid @enderror" id="amount5" placeholder="{{ __('general_content.amount_trans_key') }} 5" wire:model.lazy="amount5">
                         </div>
                     </div>
                     <div class="col-2">
@@ -85,7 +85,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount6') is-invalid @enderror" id="amount6" placeholder="{{ __('general_content.amount_trans_key') }} 6" wire:model.live="amount6">
+                            <input type="number" class="form-control @error('amount6') is-invalid @enderror" id="amount6" placeholder="{{ __('general_content.amount_trans_key') }} 6" wire:model.lazy="amount6">
                         </div>
                     </div>
                     <div class="col-2">
@@ -94,7 +94,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount7') is-invalid @enderror" id="amount7" placeholder="{{ __('general_content.amount_trans_key') }} 7" wire:model.live="amount7">
+                            <input type="number" class="form-control @error('amount7') is-invalid @enderror" id="amount7" placeholder="{{ __('general_content.amount_trans_key') }} 7" wire:model.lazy="amount7">
                         </div>
                     </div>
                     <div class="col-2">
@@ -103,7 +103,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount8') is-invalid @enderror" id="amount8" placeholder="{{ __('general_content.amount_trans_key') }} 8" wire:model.live="amount8">
+                            <input type="number" class="form-control @error('amount8') is-invalid @enderror" id="amount8" placeholder="{{ __('general_content.amount_trans_key') }} 8" wire:model.lazy="amount8">
                         </div>
                     </div>
                 </div>
@@ -118,7 +118,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount9') is-invalid @enderror" id="amount9" placeholder="{{ __('general_content.amount_trans_key') }} 9" wire:model.live="amount9">
+                            <input type="number" class="form-control @error('amount9') is-invalid @enderror" id="amount9" placeholder="{{ __('general_content.amount_trans_key') }} 9" wire:model.lazy="amount9">
                         </div>
                     </div>
                     <div class="col-2">
@@ -127,7 +127,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount10" placeholder="{{ __('general_content.amount_trans_key') }} 10" wire:model.live="amount10">
+                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount10" placeholder="{{ __('general_content.amount_trans_key') }} 10" wire:model.lazy="amount10">
                         </div>
                     </div>
                     <div class="col-2">
@@ -136,7 +136,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount11') is-invalid @enderror" id="amount11" placeholder="{{ __('general_content.amount_trans_key') }} 11" wire:model.live="amount11">
+                            <input type="number" class="form-control @error('amount11') is-invalid @enderror" id="amount11" placeholder="{{ __('general_content.amount_trans_key') }} 11" wire:model.lazy="amount11">
                         </div>
                     </div>
                     <div class="col-2">
@@ -145,7 +145,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount12') is-invalid @enderror" id="amount12" placeholder="{{ __('general_content.amount_trans_key') }} 12" wire:model.live="amount12">
+                            <input type="number" class="form-control @error('amount12') is-invalid @enderror" id="amount12" placeholder="{{ __('general_content.amount_trans_key') }} 12" wire:model.lazy="amount12">
                         </div>
                     </div>
                 </div>
@@ -159,7 +159,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-ruler"></i></span>
                             </div>
-                            <select class="form-control @error('year') is-invalid @enderror" name="year" id="year"  wire:model.live="year">
+                            <select class="form-control @error('year') is-invalid @enderror" name="year" id="year"  wire:model.lazy="year">
                                 <option value="" >{{ __('general_content.select_year_trans_key') }}</option>
                                 <option value="2021" >2021</option>
                                 <option value="2022" >2022</option>
@@ -180,7 +180,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount1') is-invalid @enderror" id="amount1" placeholder="{{ __('general_content.amount_trans_key') }} 1" wire:model.live="amount1">
+                            <input type="number" class="form-control @error('amount1') is-invalid @enderror" id="amount1" placeholder="{{ __('general_content.amount_trans_key') }} 1" wire:model.lazy="amount1">
                         </div>
                     </div>
                     <div class="col-2">
@@ -189,7 +189,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount2') is-invalid @enderror" id="amount2" placeholder="{{ __('general_content.amount_trans_key') }} 2" wire:model.live="amount2">
+                            <input type="number" class="form-control @error('amount2') is-invalid @enderror" id="amount2" placeholder="{{ __('general_content.amount_trans_key') }} 2" wire:model.lazy="amount2">
                         </div>
                     </div>
                     <div class="col-2">
@@ -198,7 +198,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount3') is-invalid @enderror" id="amount3" placeholder="{{ __('general_content.amount_trans_key') }} 3" wire:model.live="amount3">
+                            <input type="number" class="form-control @error('amount3') is-invalid @enderror" id="amount3" placeholder="{{ __('general_content.amount_trans_key') }} 3" wire:model.lazy="amount3">
                         </div>
                     </div>
                     <div class="col-2">
@@ -207,7 +207,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount4" placeholder="{{ __('general_content.amount_trans_key') }} 4" wire:model.live="amount4">
+                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount4" placeholder="{{ __('general_content.amount_trans_key') }} 4" wire:model.lazy="amount4">
                         </div>
                     </div>
                 </div>
@@ -222,7 +222,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount5') is-invalid @enderror" id="amount5" placeholder="{{ __('general_content.amount_trans_key') }} 5" wire:model.live="amount5">
+                            <input type="number" class="form-control @error('amount5') is-invalid @enderror" id="amount5" placeholder="{{ __('general_content.amount_trans_key') }} 5" wire:model.lazy="amount5">
                         </div>
                     </div>
                     <div class="col-2">
@@ -231,7 +231,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount6') is-invalid @enderror" id="amount6" placeholder="{{ __('general_content.amount_trans_key') }} 6" wire:model.live="amount6">
+                            <input type="number" class="form-control @error('amount6') is-invalid @enderror" id="amount6" placeholder="{{ __('general_content.amount_trans_key') }} 6" wire:model.lazy="amount6">
                         </div>
                     </div>
                     <div class="col-2">
@@ -240,7 +240,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount7') is-invalid @enderror" id="amount7" placeholder="{{ __('general_content.amount_trans_key') }} 7" wire:model.live="amount7">
+                            <input type="number" class="form-control @error('amount7') is-invalid @enderror" id="amount7" placeholder="{{ __('general_content.amount_trans_key') }} 7" wire:model.lazy="amount7">
                         </div>
                     </div>
                     <div class="col-2">
@@ -249,7 +249,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount8') is-invalid @enderror" id="amount8" placeholder="{{ __('general_content.amount_trans_key') }} 8" wire:model.live="amount8">
+                            <input type="number" class="form-control @error('amount8') is-invalid @enderror" id="amount8" placeholder="{{ __('general_content.amount_trans_key') }} 8" wire:model.lazy="amount8">
                         </div>
                     </div>
                 </div>
@@ -263,7 +263,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount9') is-invalid @enderror" id="amount9" placeholder="{{ __('general_content.amount_trans_key') }} 9" wire:model.live="amount9">
+                            <input type="number" class="form-control @error('amount9') is-invalid @enderror" id="amount9" placeholder="{{ __('general_content.amount_trans_key') }} 9" wire:model.lazy="amount9">
                         </div>
                     </div>
                     <div class="col-2">
@@ -272,7 +272,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount10" placeholder="{{ __('general_content.amount_trans_key') }} 10" wire:model.live="amount10">
+                            <input type="number" class="form-control @error('amount4') is-invalid @enderror" id="amount10" placeholder="{{ __('general_content.amount_trans_key') }} 10" wire:model.lazy="amount10">
                         </div>
                     </div>
                     <div class="col-2">
@@ -281,7 +281,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount11') is-invalid @enderror" id="amount11" placeholder="{{ __('general_content.amount_trans_key') }} 11" wire:model.live="amount11">
+                            <input type="number" class="form-control @error('amount11') is-invalid @enderror" id="amount11" placeholder="{{ __('general_content.amount_trans_key') }} 11" wire:model.lazy="amount11">
                         </div>
                     </div>
                     <div class="col-2">
@@ -290,7 +290,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('amount12') is-invalid @enderror" id="amount12" placeholder="{{ __('general_content.amount_trans_key') }} 12" wire:model.live="amount12">
+                            <input type="number" class="form-control @error('amount12') is-invalid @enderror" id="amount12" placeholder="{{ __('general_content.amount_trans_key') }} 12" wire:model.lazy="amount12">
                         </div>
                     </div>
                 </div>

--- a/resources/views/livewire/form/customer-price-grid.blade.php
+++ b/resources/views/livewire/form/customer-price-grid.blade.php
@@ -4,7 +4,7 @@
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="card-title mb-0">{{ __('general_content.customer_price_grid_trans_key') }}</h3>
             <div class="custom-control custom-switch">
-                <input type="checkbox" class="custom-control-input" id="usePriceListSwitch-{{ $priceListToggleKey }}" wire:model.live="usePriceList" @if(!$product_id) disabled @endif>
+                <input type="checkbox" class="custom-control-input" id="usePriceListSwitch-{{ $priceListToggleKey }}" wire:model.lazy="usePriceList" @if(!$product_id) disabled @endif>
                 <label class="custom-control-label" for="usePriceListSwitch-{{ $priceListToggleKey }}">{{ __('general_content.automatic_pricing_trans_key') }}</label>
             </div>
         </div>

--- a/resources/views/livewire/form/line-create.blade.php
+++ b/resources/views/livewire/form/line-create.blade.php
@@ -5,13 +5,13 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-sort-numeric-down"></i></span>
                 </div>
-                <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.live="ordre" >
+                <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.lazy="ordre" >
             </div>
             @error('ordre') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
         <div class="form-group col-md-2">
             <x-adminlte-select name="product_id" id="product_id" label="{{ __('general_content.product_trans_key') }}" label-class="text-lightblue"
-                igroup-size="s" data-placeholder="{{ __('general_content.select_product_trans_key') }}" wire:model.live="product_id" wire:change.prevent="ChangeCodelabel()">
+                igroup-size="s" data-placeholder="{{ __('general_content.select_product_trans_key') }}" wire:model.lazy="product_id" wire:change.prevent="ChangeCodelabel()">
                 <x-slot name="prependSlot">
                     <div class="input-group-text bg-gradient-info">
                         <i class="fas fa-barcode"></i>
@@ -30,7 +30,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                 </div>
-                <input type="text" class="code form-control @error('code') is-invalid @enderror" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" wire:model.live="code">
+                <input type="text" class="code form-control @error('code') is-invalid @enderror" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" wire:model.lazy="code">
             </div>
             @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -40,7 +40,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-tags"></i></span>
                 </div>
-                <input type="text" class="form-control @error('label') is-invalid @enderror" id="label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.live="label">
+                <input type="text" class="form-control @error('label') is-invalid @enderror" id="label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.lazy="label">
             </div>
             @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -50,7 +50,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-times"></i></span>
                 </div>
-                <input type="number" class="form-control @error('qty') is-invalid @enderror" id="qty" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.live="qty">
+                <input type="number" class="form-control @error('qty') is-invalid @enderror" id="qty" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.lazy="qty">
             </div>
             @error('qty') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -60,7 +60,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">{{ $Factory->curency }}</span>
                 </div>
-                <input type="number" class="form-control @error('selling_price') is-invalid @enderror" id="selling_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" wire:model.live="selling_price" step=".001" value="0">
+                <input type="number" class="form-control @error('selling_price') is-invalid @enderror" id="selling_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" wire:model.lazy="selling_price" step=".001" value="0">
             </div>
             @error('selling_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -70,13 +70,13 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-percentage"></i></span>
                 </div>
-                <input type="number" class="form-control @error('discount') is-invalid @enderror" id="discount" placeholder="{{ __('general_content.discount_trans_key') }}" wire:model.live="discount" step=".01" value="0">
+                <input type="number" class="form-control @error('discount') is-invalid @enderror" id="discount" placeholder="{{ __('general_content.discount_trans_key') }}" wire:model.lazy="discount" step=".01" value="0">
             </div>
             @error('discount') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
         <div class="form-group col-md-2">
             <label for="delivery_date">{{ __('general_content.delivery_date_trans_key') }}</label>
-            <input type="date" class="form-control" @error('delivery_date') is-invalid @enderror name="delivery_date"  id="delivery_date" wire:model.live="delivery_date">
+            <input type="date" class="form-control" @error('delivery_date') is-invalid @enderror name="delivery_date"  id="delivery_date" wire:model.lazy="delivery_date">
             @error('delivery_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
         <div class="form-group col-md-2">

--- a/resources/views/livewire/form/line-update.blade.php
+++ b/resources/views/livewire/form/line-update.blade.php
@@ -6,13 +6,13 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-sort-numeric-down"></i></span>
                 </div>
-                <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.live="ordre">
+                <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.lazy="ordre">
             </div>
             @error('ordre') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
         <div class="form-group col-md-2">
             <x-adminlte-select2 name="product_id" id="product_id" label="{{ __('general_content.product_trans_key') }}" label-class="text-lightblue"
-                igroup-size="s" data-placeholder="{{ __('general_content.select_product_trans_key') }}" wire:model.live="product_id" wire:change.prevent="ChangeCodelabel()">
+                igroup-size="s" data-placeholder="{{ __('general_content.select_product_trans_key') }}" wire:model.lazy="product_id" wire:change.prevent="ChangeCodelabel()">
                 <x-slot name="prependSlot">
                     <div class="input-group-text bg-gradient-info">
                         <i class="fas fa-barcode"></i>
@@ -30,7 +30,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-times"></i></span>
                 </div>
-                <input type="number" class="form-control @error('qty') is-invalid @enderror" id="qty" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.live="qty">
+                <input type="number" class="form-control @error('qty') is-invalid @enderror" id="qty" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.lazy="qty">
             </div>
             @error('qty') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -40,7 +40,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">{{ $Factory->curency }}</span>
                 </div>
-                <input type="number" class="form-control @error('selling_price') is-invalid @enderror" id="selling_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" wire:model.live="selling_price" step=".001">
+                <input type="number" class="form-control @error('selling_price') is-invalid @enderror" id="selling_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" wire:model.lazy="selling_price" step=".001">
             </div>
             @error('selling_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -50,7 +50,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-percentage"></i></span>
                 </div>
-                <select class="form-control @error('accounting_vats_id') is-invalid @enderror" name="accounting_vats_id" id="accounting_vats_id"  wire:model.live="accounting_vats_id">
+                <select class="form-control @error('accounting_vats_id') is-invalid @enderror" name="accounting_vats_id" id="accounting_vats_id"  wire:model.lazy="accounting_vats_id">
                     <option value="" >{{ __('general_content.select_vat_trans_key') }}</option>
                     @foreach ($VATSelect as $item)
                         <option value="{{ $item->id }}" >{{ $item->label }}</option>
@@ -71,7 +71,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                 </div>
-                <input type="text" class="form-control @error('code') is-invalid @enderror" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" wire:model.live="code">
+                <input type="text" class="form-control @error('code') is-invalid @enderror" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" wire:model.lazy="code">
             </div>
             @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -81,7 +81,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-tags"></i></span>
                 </div>
-                <input type="text" class="form-control @error('label') is-invalid @enderror" id="label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.live="label">
+                <input type="text" class="form-control @error('label') is-invalid @enderror" id="label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.lazy="label">
             </div>
             @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
@@ -91,7 +91,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-ruler"></i></span>
                 </div>
-                <select class="form-control" name="methods_units_id" id="methods_units_id"  wire:model.live="methods_units_id">
+                <select class="form-control" name="methods_units_id" id="methods_units_id"  wire:model.lazy="methods_units_id">
                     @foreach ($UnitsSelect as $item)
                     <option value="{{ $item->id }}" >{{ $item->code }} - {{ $item->label }}</option>
                     @endforeach
@@ -104,13 +104,13 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-percentage"></i></span>
                 </div>
-                <input type="number" class="form-control @error('discount') is-invalid @enderror" id="discount" placeholder="{{ __('general_content.discount_trans_key') }}" wire:model.live="discount" step=".01">
+                <input type="number" class="form-control @error('discount') is-invalid @enderror" id="discount" placeholder="{{ __('general_content.discount_trans_key') }}" wire:model.lazy="discount" step=".01">
             </div>
             @error('discount') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
         <div class="form-group col-md-2">
             <label for="delivery_date">{{ __('general_content.delivery_date_trans_key') }}</label>
-            <input type="date" class="form-control" @error('delivery_date') is-invalid @enderror name="delivery_date"  id="delivery_date" wire:model.live="delivery_date">
+            <input type="date" class="form-control" @error('delivery_date') is-invalid @enderror name="delivery_date"  id="delivery_date" wire:model.lazy="delivery_date">
             @error('delivery_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
         </div>
         <div class="form-group col-md-2">

--- a/resources/views/livewire/invoices-request.blade.php
+++ b/resources/views/livewire/invoices-request.blade.php
@@ -11,7 +11,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-building"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id">
+                            <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                 <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                             @forelse ($CompanieSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -28,7 +28,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-calendar-alt"></i></span>
                             </div>
-                            <input type="date" class="form-control" wire:model.live="deliveryDateStart" name="delivery_date_start" id="delivery_date_start">
+                            <input type="date" class="form-control" wire:model.lazy="deliveryDateStart" name="delivery_date_start" id="delivery_date_start">
                         </div>
                     </div>
                     <div class="form-group col-md-3">
@@ -37,7 +37,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-calendar-alt"></i></span>
                             </div>
-                            <input type="date" class="form-control" wire:model.live="deliveryDateEnd" name="delivery_date_end" id="delivery_date_end">
+                            <input type="date" class="form-control" wire:model.lazy="deliveryDateEnd" name="delivery_date_end" id="delivery_date_end">
                         </div>
                     </div>
                     <div class="form-group col-md-3">
@@ -46,7 +46,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                            <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                             @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                         </div>
                     </div>
@@ -56,7 +56,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="label" name="label"  id="label"  placeholder="Name of quote" required>
+                            <input type="text" class="form-control" wire:model.lazy="label" name="label"  id="label"  placeholder="Name of quote" required>
                         </div>
                         @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -66,7 +66,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-user"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="user_id" name="user_id" id="user_id">
+                            <select class="form-control" wire:model.lazy="user_id" name="user_id" id="user_id">
                                 <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                             @foreach ($userSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -81,7 +81,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-map-marked-alt"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_addresses_id" name="companies_addresses_id" id="companies_addresses_id">
+                            <select class="form-control" wire:model.lazy="companies_addresses_id" name="companies_addresses_id" id="companies_addresses_id">
                                 <option value="">{{ __('general_content.select_address_trans_key') }}</option>
                             @forelse ($AddressSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->label }} - {{ $item->adress }}</option>
@@ -98,7 +98,7 @@
                             <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id">
+                            <select class="form-control" wire:model.lazy="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id">
                                 <option value="">{{ __('general_content.select_contact_trans_key') }}</option>
                             @forelse ($ContactSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->first_name }} - {{ $item->name }}</option>
@@ -169,7 +169,7 @@
                             <td>{{ $InvoicesRequestsLine->orderLine->VAT['label'] }} %</td>
                             <td>
                                 <div class="custom-control custom-checkbox">
-                                    <input class="custom-control-input" value="{{ $InvoicesRequestsLine->id }}" wire:model.live="data.{{ $InvoicesRequestsLine->id }}.deliveryLine_id" id="data.{{ $InvoicesRequestsLine->id }}.deliveryLine_id"  type="checkbox">
+                                    <input class="custom-control-input" value="{{ $InvoicesRequestsLine->id }}" wire:model.lazy="data.{{ $InvoicesRequestsLine->id }}.deliveryLine_id" id="data.{{ $InvoicesRequestsLine->id }}.deliveryLine_id"  type="checkbox">
                                     <label for="data.{{ $InvoicesRequestsLine->id }}.deliveryLine_id" class="custom-control-label">{{ __('general_content.add_to_document_trans_key') }}</label>
                                 </div>
                             </td>

--- a/resources/views/livewire/kanban-setting.blade.php
+++ b/resources/views/livewire/kanban-setting.blade.php
@@ -11,7 +11,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-ruler"></i></span>
                             </div>
-                            <select class="form-control @error('title') is-invalid @enderror" name="title" id="title"  wire:model.live="title">
+                            <select class="form-control @error('title') is-invalid @enderror" name="title" id="title"  wire:model.lazy="title">
                                 <option value="" selected>{{ __('general_content.select_type_trans_key') }}</option>
                                 <option value="Open" >{{ __('general_content.open_trans_key') }}</option>
                                 <option value="Started" >{{ __('general_content.started_trans_key') }}</option>
@@ -32,7 +32,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <input type="number" class="form-control @error('order') is-invalid @enderror" id="order" placeholder="{{ __('general_content.sort_trans_key') }}" wire:model.live="order">
+                            <input type="number" class="form-control @error('order') is-invalid @enderror" id="order" placeholder="{{ __('general_content.sort_trans_key') }}" wire:model.lazy="order">
                         </div>
                         @error('order') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>

--- a/resources/views/livewire/leads-index.blade.php
+++ b/resources/views/livewire/leads-index.blade.php
@@ -117,7 +117,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                         </div>
-                                        <input type="text" class="form-control @error('source') is-invalid @enderror" wire:model.live="source"  name="source" id="source" placeholder="{{ __('general_content.source_trans_key') }}" >
+                                        <input type="text" class="form-control @error('source') is-invalid @enderror" wire:model.lazy="source"  name="source" id="source" placeholder="{{ __('general_content.source_trans_key') }}" >
                                     </div>
                                     @error('source') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -127,7 +127,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                         </div>
-                                        <input type="text" class="form-control @error('campaign') is-invalid @enderror" wire:model.live="campaign"  name="campaign" id="campaign" placeholder="{{ __('general_content.campaign_trans_key') }}" >
+                                        <input type="text" class="form-control @error('campaign') is-invalid @enderror" wire:model.lazy="campaign"  name="campaign" id="campaign" placeholder="{{ __('general_content.campaign_trans_key') }}" >
                                     </div>
                                     @error('campaign') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -142,7 +142,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="user_id" name="user_id" id="user_id">
+                                        <select class="form-control" wire:model.lazy="user_id" name="user_id" id="user_id">
                                             <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                                         @foreach ($userSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -157,7 +157,7 @@
                                         <div class="input-group-text bg-gradient-success">
                                             <i class="fas fa-exclamation"></i>
                                         </div>
-                                        <select class="form-control" wire:model.live="priority" name="priority" id="priority">
+                                        <select class="form-control" wire:model.lazy="priority" name="priority" id="priority">
                                             <option value="1" >{{ __('general_content.burning_trans_key') }}</option>
                                             <option value="2" >{{ __('general_content.hot_trans_key') }}</option>
                                             <option value="3" >{{ __('general_content.lukewarm_trans_key') }}</option>
@@ -172,7 +172,7 @@
                             <div class="row">
                                 <div class="col-12">
                                     <label>{{ __('general_content.comment_trans_key') }}</label>
-                                    <textarea class="form-control" rows="3" wire:model.live="comment" name="comment"  placeholder="..."></textarea>
+                                    <textarea class="form-control" rows="3" wire:model.lazy="comment" name="comment"  placeholder="..."></textarea>
                                     @error('comment') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>

--- a/resources/views/livewire/opportunities-index.blade.php
+++ b/resources/views/livewire/opportunities-index.blade.php
@@ -21,7 +21,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <input type="text" class="form-control"  wire:model.live="label" name="label"  id="label"  placeholder="{{ __('general_content.name_opportunity_trans_key') }}" required>
+                                        <input type="text" class="form-control"  wire:model.lazy="label" name="label"  id="label"  placeholder="{{ __('general_content.name_opportunity_trans_key') }}" required>
                                     </div>
                                     @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -31,7 +31,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                                         </div>
-                                        <select class="form-control"  wire:model.live="user_id" name="user_id" id="user_id">
+                                        <select class="form-control"  wire:model.lazy="user_id" name="user_id" id="user_id">
                                             <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                                             @foreach ($userSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -54,7 +54,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-building"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id">
+                                        <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                             <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                                         @forelse ($CompanieSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -115,7 +115,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-percentage"></i></span>
                                         </div>
-                                        <input type="number" class="form-control @error('probality') is-invalid @enderror" wire:model.live="probality" name="probality"  id="probality"  placeholder="50" required>
+                                        <input type="number" class="form-control @error('probality') is-invalid @enderror" wire:model.lazy="probality" name="probality"  id="probality"  placeholder="50" required>
                                     </div>
                                     @error('probality') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -125,7 +125,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text">{{ $Factory->curency }}</span>
                                         </div>
-                                        <input type="number" class="form-control @error('budget') is-invalid @enderror" id="budget" placeholder="0" min="0" wire:model.live="budget" step=".001" value="0">
+                                        <input type="number" class="form-control @error('budget') is-invalid @enderror" id="budget" placeholder="0" min="0" wire:model.lazy="budget" step=".001" value="0">
                                     </div>
                                     @error('budget') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -135,7 +135,7 @@
                             <div class="row">
                                 <div class="col-12">
                                     <label>{{ __('general_content.comment_trans_key') }}</label>
-                                    <textarea class="form-control" rows="3"  wire:model.live="comment" name="comment"  placeholder="..."></textarea>
+                                    <textarea class="form-control" rows="3"  wire:model.lazy="comment" name="comment"  placeholder="..."></textarea>
                                     @error('comment') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>

--- a/resources/views/livewire/order-lines.blade.php
+++ b/resources/views/livewire/order-lines.blade.php
@@ -7,11 +7,11 @@
             @if($OrderStatu == 1)
                 @if($updateLines)
                 <form wire:submit.prevent="update">
-                            <input type="hidden" wire:model.live="order_lines_id">
+                            <input type="hidden" wire:model.lazy="order_lines_id">
                             @include('livewire.form.line-update')
                 @else
                 <form wire:submit.prevent="storeOrderLine">
-                            <input type="hidden"  name="orders_id"  id="orders_id" value="1" wire:model.live="orders_id" >
+                            <input type="hidden"  name="orders_id"  id="orders_id" value="1" wire:model.lazy="orders_id" >
                             @include('livewire.form.line-create')
                 @endif
                 @include('livewire.form.customer-price-grid')
@@ -31,7 +31,7 @@
                 <div class="col-md-6">
                     <div class="input-group">
                         <input type="number" step="0.01" min="0" class="form-control"
-                               wire:model.live="priceIncreaseAmount"
+                               wire:model.lazy="priceIncreaseAmount"
                                placeholder="{{ __('general_content.price_increase_amount_trans_key') }}"
                                @disabled($OrderStatu == 6 || $OrderType == 2)>
                         <div class="input-group-append">
@@ -641,7 +641,7 @@
                             <td>
                                 @if($OrderStatu != 6 && (($OrderLine->delivery_status != 3 && $OrderLine->order->type != 2) && ($OrderLine->delivery_status != 4 && $OrderLine->order->type != 2)))
                                 <div class="custom-control custom-checkbox">
-                                    <input class="custom-control-input" value="{{ $OrderLine->id }}" wire:model.live="data.{{ $OrderLine->id }}.order_line_id" id="data.{{ $OrderLine->id }}.order_line_id"  type="checkbox">
+                                    <input class="custom-control-input" value="{{ $OrderLine->id }}" wire:model.lazy="data.{{ $OrderLine->id }}.order_line_id" id="data.{{ $OrderLine->id }}.order_line_id"  type="checkbox">
                                     <label for="data.{{ $OrderLine->id }}.order_line_id" class="custom-control-label">+</label>
                                 </div>
                                 @endif
@@ -675,11 +675,11 @@
                                 @can('stock-lot-serial-management')
                                 <div>
                                     <label for="RemoveFromStock">{{ __('general_content.remove_component_lines_stock_trans_key') }}</label>
-                                    <input type="checkbox" id="RemoveFromStock" wire:model.live="RemoveFromStock" >
+                                    <input type="checkbox" id="RemoveFromStock" wire:model.lazy="RemoveFromStock" >
                                 </div>
                                 <div>
                                     <label for="CreateSerialNumber">{{ __('general_content.create_serial_number_trans_key') }}</label>
-                                    <input type="checkbox" id="CreateSerialNumber" wire:model.live="CreateSerialNumber" >
+                                    <input type="checkbox" id="CreateSerialNumber" wire:model.lazy="CreateSerialNumber" >
                                 </div>
                                 @endcan
                                 <div>

--- a/resources/views/livewire/orders-index.blade.php
+++ b/resources/views/livewire/orders-index.blade.php
@@ -26,7 +26,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                                        <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                                     </div>
                                     @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -36,7 +36,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="label" name="label"  id="label" placeholder="{{ __('general_content.name_order_trans_key') }}" required>
+                                        <input type="text" class="form-control" wire:model.lazy="label" name="label"  id="label" placeholder="{{ __('general_content.name_order_trans_key') }}" required>
                                         @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                     </div>
                                 </div>
@@ -46,7 +46,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="user_id" name="user_id" id="user_id">
+                                        <select class="form-control" wire:model.lazy="user_id" name="user_id" id="user_id">
                                             <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                                         @foreach ($userSelect as $item)
                                             <option value="{{ $item->id }}" >{{ $item->name }}</option>
@@ -61,7 +61,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                                         </div>
-                                        <select class="form-control" wire:click.prevent="changeLabel()" wire:model.live="type" name="type" id="type">)
+                                        <select class="form-control" wire:click.prevent="changeLabel()" wire:model.lazy="type" name="type" id="type">)
                                             <option value="1" >{{ __('general_content.customer_type_order_trans_key') }}</option>
                                             <option value="2" >{{ __('general_content.internal_type_order_trans_key') }}</option>
                                         </select>
@@ -82,7 +82,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-building"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id" @if($type == 2) disabled @endif>
+                                        <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id" @if($type == 2) disabled @endif>
                                             <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                                         @forelse ($CompanieSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -99,7 +99,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user-tag"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="customer_reference"  name="customer_reference"  id="customer_reference" placeholder="{{ __('general_content.customer_reference_trans_key') }}" @if($type == 2) disabled @endif>
+                                        <input type="text" class="form-control" wire:model.lazy="customer_reference"  name="customer_reference"  id="customer_reference" placeholder="{{ __('general_content.customer_reference_trans_key') }}" @if($type == 2) disabled @endif>
                                         @error('customer_reference') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                     </div>
                                 </div>
@@ -111,7 +111,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-map-marked-alt"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="companies_addresses_id" name="companies_addresses_id" id="companies_addresses_id" @if($type == 2) disabled @endif>
+                                        <select class="form-control" wire:model.lazy="companies_addresses_id" name="companies_addresses_id" id="companies_addresses_id" @if($type == 2) disabled @endif>
                                         <option value="">{{ __('general_content.select_address_trans_key') }}</option>
                                         @forelse ($AddressSelect as $item)
                                             <option value="{{ $item->id }}" >{{ $item->label }} - {{ $item->adress }}</option>
@@ -128,7 +128,7 @@
                                         <div class="input-group-prepend">
                                         <span class="input-group-text"><i class="fas fa-user"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id" @if($type == 2) disabled @endif>
+                                        <select class="form-control" wire:model.lazy="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id" @if($type == 2) disabled @endif>
                                             <option value="">{{ __('general_content.select_contact_trans_key') }}</option>
                                         @forelse ($ContactSelect as $item)
                                             <option value="{{ $item->id }}" >{{ $item->first_name }} - {{ $item->name }}</option>
@@ -149,7 +149,7 @@
                             <div class="form-row">
                                 <div class="form-group col-md-6">
                                     <label for="accounting_payment_conditions_id">{{ __('general_content.payment_conditions_trans_key') }}</label>
-                                    <select class="form-control" wire:model.live="accounting_payment_conditions_id"  name="accounting_payment_conditions_id" id="accounting_payment_conditions_id" @if($type == 2) disabled @endif>
+                                    <select class="form-control" wire:model.lazy="accounting_payment_conditions_id"  name="accounting_payment_conditions_id" id="accounting_payment_conditions_id" @if($type == 2) disabled @endif>
                                         <option value="">{{ __('general_content.select_payement_condition_trans_key') }}</option>
                                     @forelse ($AccountingConditionSelect as $item)
                                         <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -161,7 +161,7 @@
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="accounting_payment_methods_id">{{ __('general_content.select_payement_methods_trans_key') }}</label>
-                                    <select class="form-control" wire:model.live="accounting_payment_methods_id" name="accounting_payment_methods_id" id="accounting_payment_methods_id" @if($type == 2) disabled @endif>
+                                    <select class="form-control" wire:model.lazy="accounting_payment_methods_id" name="accounting_payment_methods_id" id="accounting_payment_methods_id" @if($type == 2) disabled @endif>
                                         <option value="">{{ __('general_content.select_payement_methods_trans_key') }}</option>
                                     @forelse ($AccountingMethodsSelect as $item)
                                         <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -179,7 +179,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-truck"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="accounting_deliveries_id" name="accounting_deliveries_id" id="accounting_deliveries_id" @if($type == 2) disabled @endif>
+                                        <select class="form-control" wire:model.lazy="accounting_deliveries_id" name="accounting_deliveries_id" id="accounting_deliveries_id" @if($type == 2) disabled @endif>
                                             <option value="">{{ __('general_content.select_delivery_trans_key') }}</option>
                                         @forelse ($AccountingDeleveriesSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -192,7 +192,7 @@
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="label">{{ __('general_content.delivery_date_trans_key') }}</label>
-                                    <input type="date" class="form-control" wire:model.live="validity_date"  name="validity_date"  id="validity_date">
+                                    <input type="date" class="form-control" wire:model.lazy="validity_date"  name="validity_date"  id="validity_date">
                                     @error('validity_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -201,7 +201,7 @@
                             <div class="row">
                                 <div class="col-12">
                                     <label>{{ __('general_content.comment_trans_key') }}</label>
-                                    <textarea class="form-control" rows="3" wire:model.live="comment" name="comment"  placeholder=" ..."></textarea>
+                                    <textarea class="form-control" rows="3" wire:model.lazy="comment" name="comment"  placeholder=" ..."></textarea>
                                     @error('comment') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>

--- a/resources/views/livewire/products-index.blade.php
+++ b/resources/views/livewire/products-index.blade.php
@@ -21,7 +21,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                                        <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                                     </div>
                                     @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -31,13 +31,13 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="label" name="label"  id="label" placeholder="{{ __('general_content.description_trans_key') }}">
+                                        <input type="text" class="form-control" wire:model.lazy="label" name="label"  id="label" placeholder="{{ __('general_content.description_trans_key') }}">
                                     </div>
                                     @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-4">
                                     <label for="ind">{{ __('general_content.index_trans_key') }}</label>
-                                    <input type="text" class="form-control"  wire:model.live="ind" name="ind"  id="ind" placeholder="{{ __('general_content.index_trans_key') }}">
+                                    <input type="text" class="form-control"  wire:model.lazy="ind" name="ind"  id="ind" placeholder="{{ __('general_content.index_trans_key') }}">
                                     @error('ind') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -50,7 +50,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-list"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="methods_services_id" name="methods_services_id" id="methods_services_id">
+                                        <select class="form-control" wire:model.lazy="methods_services_id" name="methods_services_id" id="methods_services_id">
                                             <option value="">{{ __('general_content.select_service_trans_key') }}</option>
                                             @forelse ($ServicesSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->label }}</option>
@@ -67,7 +67,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-grip-horizontal"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="methods_families_id" name="methods_families_id" id="methods_families_id">
+                                        <select class="form-control" wire:model.lazy="methods_families_id" name="methods_families_id" id="methods_families_id">
                                             <option value="">{{ __('general_content.family_trans_key') }}</option>
                                             @forelse ($FamiliesSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->label }}</option>
@@ -84,7 +84,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="methods_units_id" name="methods_units_id" id="methods_units_id">
+                                        <select class="form-control" wire:model.lazy="methods_units_id" name="methods_units_id" id="methods_units_id">
                                             <option value="">{{ __('general_content.select_unit_trans_key') }}</option>
                                             @forelse ($UnitsSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->label }}</option>
@@ -105,7 +105,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-exclamation"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="purchased" name="purchased" id="purchased">
+                                        <select class="form-control" wire:model.lazy="purchased" name="purchased" id="purchased">
                                             <option value="">{{ __('general_content.select_statu_trans_key') }}</option>
                                             <option value="2">{{ __('general_content.no_trans_key') }}</option>
                                             <option value="1">{{ __('general_content.yes_trans_key') }}</option>
@@ -119,7 +119,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-exclamation"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="sold" name="sold" id="sold">
+                                        <select class="form-control" wire:model.lazy="sold" name="sold" id="sold">
                                             <option value="">{{ __('general_content.select_statu_trans_key') }}</option>
                                             <option value="2">{{ __('general_content.no_trans_key') }}</option>
                                             <option value="1">{{ __('general_content.yes_trans_key') }}</option>
@@ -129,7 +129,7 @@
                                 </div>
                                 <div class="form-group col-md-4">
                                     <label for="tracability_type">{{ __('general_content.tracability_trans_key') }}</label>
-                                    <select class="form-control" wire:model.live="tracability_type" name="tracability_type" id="tracability_type">
+                                    <select class="form-control" wire:model.lazy="tracability_type" name="tracability_type" id="tracability_type">
                                         <option value="">{{ __('general_content.select_type_trans_key') }}</option>
                                         <option value="1">{{ __('general_content.no_traceability_trans_key') }}</option>
                                         <option value="2">{{ __('general_content.with_batch_number_trans_key') }}</option>
@@ -144,7 +144,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text">{{ $Factory->curency }}</span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="purchased_price" name="purchased_price" id="purchased_price" min="0" placeholder="{{ __('general_content.purchased_price_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="purchased_price" name="purchased_price" id="purchased_price" min="0" placeholder="{{ __('general_content.purchased_price_trans_key') }}" step=".001">
                                     </div>
                                     @error('purchased_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -153,7 +153,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text">{{ $Factory->curency }}</span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="selling_price" name="selling_price" id="selling_price" min="0" placeholder="{{ __('general_content.price_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="selling_price" name="selling_price" id="selling_price" min="0" placeholder="{{ __('general_content.price_trans_key') }}" step=".001">
                                     </div>
                                 </div>
                             </div>
@@ -168,7 +168,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fab fa-mdb"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="material" name="material" id="material"  placeholder="{{ __('general_content.material_trans_key') }}">
+                                        <input type="text" class="form-control" wire:model.lazy="material" name="material" id="material"  placeholder="{{ __('general_content.material_trans_key') }}">
                                     </div>
                                     @error('material') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -177,7 +177,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-vertical"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="thickness" name="thickness" id="thickness" min="0"  placeholder="{{ __('general_content.thickness_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="thickness" name="thickness" id="thickness" min="0"  placeholder="{{ __('general_content.thickness_trans_key') }}" step=".001">
                                     </div>
                                     @error('thickness') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -186,7 +186,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-weight-hanging"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="weight" name="weight" id="weight" min="0"  placeholder="{{ __('general_content.weight_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="weight" name="weight" id="weight" min="0"  placeholder="{{ __('general_content.weight_trans_key') }}" step=".001">
                                     </div>
                                     @error('weight') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -197,7 +197,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fab fa-mdb"></i></span>
                                         </div>
-                                        <input type="text" class="form-control" wire:model.live="finishing" name="finishing" id="finishing"  placeholder="{{ __('general_content.finishing_trans_key') }}">
+                                        <input type="text" class="form-control" wire:model.lazy="finishing" name="finishing" id="finishing"  placeholder="{{ __('general_content.finishing_trans_key') }}">
                                     </div>
                                 </div>
                                 <div class="col-4">
@@ -213,7 +213,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="x_size" name="x_size" id="x_size" min="0"  placeholder="{{ __('general_content.x_size_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="x_size" name="x_size" id="x_size" min="0"  placeholder="{{ __('general_content.x_size_trans_key') }}" step=".001">
                                     </div>
                                     @error('x_size') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -223,7 +223,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="y_size" name="y_size" id="y_size" min="0"  placeholder="{{ __('general_content.y_size_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="y_size" name="y_size" id="y_size" min="0"  placeholder="{{ __('general_content.y_size_trans_key') }}" step=".001">
                                     </div>
                                     @error('y_size') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -233,7 +233,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="z_size" name="z_size" id="z_size" min="0"  placeholder="{{ __('general_content.z_size_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="z_size" name="z_size" id="z_size" min="0"  placeholder="{{ __('general_content.z_size_trans_key') }}" step=".001">
                                     </div>
                                     @error('z_size') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -244,7 +244,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="x_oversize" name="x_oversize" id="x_oversize" min="0"   placeholder="{{ __('general_content.x_oversize_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="x_oversize" name="x_oversize" id="x_oversize" min="0"   placeholder="{{ __('general_content.x_oversize_trans_key') }}" step=".001">
                                     </div>
                                     @error('x_oversize') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -253,7 +253,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="y_oversize" name="y_oversize" id="y_oversize" min="0"  placeholder="{{ __('general_content.y_oversize_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="y_oversize" name="y_oversize" id="y_oversize" min="0"  placeholder="{{ __('general_content.y_oversize_trans_key') }}" step=".001">
                                     </div>
                                     @error('diameter') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -262,7 +262,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-ruler-combined"></i></span>
                                         </div>
-                                        <input type="number" class="form-control" wire:model.live="z_oversize" name="z_oversize" id="z_oversize" min="0"   placeholder="{{ __('general_content.z_oversize_trans_key') }}" step=".001">
+                                        <input type="number" class="form-control" wire:model.lazy="z_oversize" name="z_oversize" id="z_oversize" min="0"   placeholder="{{ __('general_content.z_oversize_trans_key') }}" step=".001">
                                     </div>
                                     @error('diameter') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -270,15 +270,15 @@
                             <hr>
                             <div class="row">
                                 <div class="form-group col-md-4">
-                                    <input type="number" class="form-control" wire:model.live="diameter" name="diameter" id="diameter" min="0"  placeholder="{{ __('general_content.diameter_trans_key') }}" step=".001">
+                                    <input type="number" class="form-control" wire:model.lazy="diameter" name="diameter" id="diameter" min="0"  placeholder="{{ __('general_content.diameter_trans_key') }}" step=".001">
                                     @error('diameter') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-4">
-                                    <input type="number" class="form-control" wire:model.live="diameter_oversize" name="diameter_oversize" id="diameter_oversize" min="0"  placeholder="{{ __('general_content.diameter_oversize_trans_key') }}" step=".001">
+                                    <input type="number" class="form-control" wire:model.lazy="diameter_oversize" name="diameter_oversize" id="diameter_oversize" min="0"  placeholder="{{ __('general_content.diameter_oversize_trans_key') }}" step=".001">
                                     @error('diameter_oversize') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-4">
-                                    <input type="number" class="form-control" wire:model.live="section_size" name="section_size" id="section_size" min="0" placeholder="{{ __('general_content.section_size_trans_key') }}" step=".001">
+                                    <input type="number" class="form-control" wire:model.lazy="section_size" name="section_size" id="section_size" min="0" placeholder="{{ __('general_content.section_size_trans_key') }}" step=".001">
                                     @error('section_size') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -289,15 +289,15 @@
                             </div>
                             <div class="form-row">
                                 <div class="form-group col-md-4">
-                                    <input type="number" class="form-control" wire:model.live="qty_eco_min" name="qty_eco_min" id="qty_eco_min" min="0" placeholder="{{ __('general_content.quantite_eco_min_trans_key') }}" step=".001">
+                                    <input type="number" class="form-control" wire:model.lazy="qty_eco_min" name="qty_eco_min" id="qty_eco_min" min="0" placeholder="{{ __('general_content.quantite_eco_min_trans_key') }}" step=".001">
                                     @error('qty_eco_min') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-4">
-                                    <input type="number" class="form-control" wire:model.live="qty_eco_max" name="qty_eco_max" id="qty_eco_max" min="0" placeholder="{{ __('general_content.quantite_eco_max_trans_key') }}" step=".001">
+                                    <input type="number" class="form-control" wire:model.lazy="qty_eco_max" name="qty_eco_max" id="qty_eco_max" min="0" placeholder="{{ __('general_content.quantite_eco_max_trans_key') }}" step=".001">
                                     @error('qty_eco_max') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-4">
-                                    <textarea class="form-control" rows="3"  wire:model.live="comment" name="comment"  placeholder="..."></textarea>
+                                    <textarea class="form-control" rows="3"  wire:model.lazy="comment" name="comment"  placeholder="..."></textarea>
                                     @error('comment') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -324,7 +324,7 @@
                         <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fas fa-calendar-alt fa-fw"></i></span>
                         </div>
-                        <input type="date" class="form-control" wire:model.live="createdAtFrom" aria-label="Date de création du" title="Date de création du">
+                        <input type="date" class="form-control" wire:model.lazy="createdAtFrom" aria-label="Date de création du" title="Date de création du">
                     </div>
                 </div>
                 <div class="col-md-2">
@@ -332,7 +332,7 @@
                         <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fas fa-calendar-alt fa-fw"></i></span>
                         </div>
-                        <input type="date" class="form-control" wire:model.live="createdAtTo" aria-label="Date de création au" title="Date de création au">
+                        <input type="date" class="form-control" wire:model.lazy="createdAtTo" aria-label="Date de création au" title="Date de création au">
                     </div>
                 </div>
             </div>

--- a/resources/views/livewire/purchases-lines-index.blade.php
+++ b/resources/views/livewire/purchases-lines-index.blade.php
@@ -7,11 +7,11 @@
             @if($OrderStatu == 1)
                 @if($updateLines)
                 <form wire:submit.prevent="updatePurchaseLine">
-                            <input type="hidden" wire:model.live="purchase_lines_id">
+                            <input type="hidden" wire:model.lazy="purchase_lines_id">
                             @include('livewire.form.line-update')
                 @else
                 <form wire:submit.prevent="storeOrderLine">
-                            <input type="hidden"  name="purchase_id"  id="purchase_id" value="1" wire:model.live="purchase_id" >
+                            <input type="hidden"  name="purchase_id"  id="purchase_id" value="1" wire:model.lazy="purchase_id" >
                             @include('livewire.form.line-create')
                 @endif
             @else
@@ -139,7 +139,7 @@
                                 <td>
                                     @if($PurchaseLine->qty > $PurchaseLine->receipt_qty)
                                     <div class="custom-control custom-checkbox">
-                                        <input class="custom-control-input" value="{{ $PurchaseLine->id }}" wire:model.live="data.{{ $PurchaseLine->id }}.purchase_line_id" id="data.{{ $PurchaseLine->id }}.purchase_line_id"  type="checkbox">
+                                        <input class="custom-control-input" value="{{ $PurchaseLine->id }}" wire:model.lazy="data.{{ $PurchaseLine->id }}.purchase_line_id" id="data.{{ $PurchaseLine->id }}.purchase_line_id"  type="checkbox">
                                         <label for="data.{{ $PurchaseLine->id }}.purchase_line_id" class="custom-control-label">+</label>
                                     </div>
                                     @endif

--- a/resources/views/livewire/purchases-quotation-lines.blade.php
+++ b/resources/views/livewire/purchases-quotation-lines.blade.php
@@ -4,12 +4,12 @@
             <div class="card">
                 <div class="card-body">
                     @include('include.alert-result')
-                    <input type="hidden" wire:model.live="purchase_quotation_id">
+                    <input type="hidden" wire:model.lazy="purchase_quotation_id">
 
                     @if($OrderStatu == 1)
                         @if($updateLines)
                         <form wire:submit.prevent="updatePurchaseQuotationLine">
-                            <input type="hidden" wire:model.live="purchase_quotation_line_id">
+                            <input type="hidden" wire:model.lazy="purchase_quotation_line_id">
                         @else
                         <form wire:submit.prevent="storePurchaseQuotationLine">
                         @endif
@@ -20,13 +20,13 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-sort-numeric-down"></i></span>
                                         </div>
-                                        <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.live="ordre">
+                                        <input type="number" class="form-control @error('ordre') is-invalid @enderror" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.lazy="ordre">
                                     </div>
                                     @error('ordre') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-2">
                                     <x-adminlte-select name="product_id" id="product_id" label="{{ __('general_content.product_trans_key') }}" label-class="text-lightblue"
-                                        igroup-size="s" data-placeholder="{{ __('general_content.select_product_trans_key') }}" wire:model.live="product_id" wire:change.prevent="ChangeCodelabel()">
+                                        igroup-size="s" data-placeholder="{{ __('general_content.select_product_trans_key') }}" wire:model.lazy="product_id" wire:change.prevent="ChangeCodelabel()">
                                         <x-slot name="prependSlot">
                                             <div class="input-group-text bg-gradient-info">
                                                 <i class="fas fa-barcode"></i>
@@ -45,7 +45,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                         </div>
-                                        <input type="text" class="code form-control @error('code') is-invalid @enderror" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" wire:model.live="code">
+                                        <input type="text" class="code form-control @error('code') is-invalid @enderror" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" wire:model.lazy="code">
                                     </div>
                                     @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -55,7 +55,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <input type="text" class="form-control @error('line_label') is-invalid @enderror" id="line_label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.live="line_label">
+                                        <input type="text" class="form-control @error('line_label') is-invalid @enderror" id="line_label" placeholder="{{ __('general_content.description_trans_key') }}" wire:model.lazy="line_label">
                                     </div>
                                     @error('line_label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -65,7 +65,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-times"></i></span>
                                         </div>
-                                        <input type="number" class="form-control @error('qty_to_order') is-invalid @enderror" id="qty_to_order" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.live="qty_to_order">
+                                        <input type="number" class="form-control @error('qty_to_order') is-invalid @enderror" id="qty_to_order" placeholder="{{ __('general_content.qty_trans_key') }}" min="0" wire:model.lazy="qty_to_order">
                                     </div>
                                     @error('qty_to_order') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -75,7 +75,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text">{{ $Factory->curency ?? 'EUR' }}</span>
                                         </div>
-                                        <input type="number" class="form-control @error('unit_price') is-invalid @enderror" id="unit_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" step="0.001" wire:model.live="unit_price">
+                                        <input type="number" class="form-control @error('unit_price') is-invalid @enderror" id="unit_price" placeholder="{{ __('general_content.price_trans_key') }}" min="0" step="0.001" wire:model.lazy="unit_price">
                                     </div>
                                     @error('unit_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>

--- a/resources/views/livewire/purchases-request.blade.php
+++ b/resources/views/livewire/purchases-request.blade.php
@@ -11,7 +11,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="document_type" name="document_type" id="document_type">
+                            <select class="form-control" wire:model.lazy="document_type" name="document_type" id="document_type">
                                 <option value="">{{ __('general_content.select_document_trans_key') }}</option>
                                 <option value="PU">{{ __('general_content.purchase_order_trans_key') }}</option>
                                 <option value="PQ">{{ __('general_content.purchase_quotation_trans_key') }}</option>
@@ -25,7 +25,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-building"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id">
+                            <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                 <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                             @forelse ($CompanieSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -43,7 +43,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-industry"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="selected_companies" name="selected_companies[]" id="selected_companies" multiple>
+                            <select class="form-control" wire:model.lazy="selected_companies" name="selected_companies[]" id="selected_companies" multiple>
                                 @forelse ($CompanieSelect as $item)
                                     <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
                                 @empty
@@ -60,7 +60,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                            <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                         </div>
                         @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -70,7 +70,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="label" name="label"  id="label"  placeholder="{{ __('general_content.name_purchase_trans_key') }}" required>
+                            <input type="text" class="form-control" wire:model.lazy="label" name="label"  id="label"  placeholder="{{ __('general_content.name_purchase_trans_key') }}" required>
                         </div>
                         @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -152,7 +152,7 @@
                             </td>
                             <td>
                                 <div class="custom-control custom-checkbox">
-                                    <input class="custom-control-input" value="{{ $PurchasesRequestsLines->id }}" wire:model.live="data.{{ $PurchasesRequestsLines->id }}.task_id" id="data.{{ $PurchasesRequestsLines->id }}.task_id"  type="checkbox">
+                                    <input class="custom-control-input" value="{{ $PurchasesRequestsLines->id }}" wire:model.lazy="data.{{ $PurchasesRequestsLines->id }}.task_id" id="data.{{ $PurchasesRequestsLines->id }}.task_id"  type="checkbox">
                                     <label for="data.{{ $PurchasesRequestsLines->id }}.task_id" class="custom-control-label">{{ __('general_content.add_to_document_trans_key') }} </label>
                                 </div>
                             </td>

--- a/resources/views/livewire/purchases-wainting-invoice.blade.php
+++ b/resources/views/livewire/purchases-wainting-invoice.blade.php
@@ -11,7 +11,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-building"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id">
+                            <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                 <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                             @forelse ($CompanieSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -28,7 +28,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                             </div>
-                            <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                            <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                         </div>
                         @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -38,7 +38,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-user"></i></span>
                             </div>
-                            <select class="form-control" wire:model.live="user_id" name="user_id" id="user_id">
+                            <select class="form-control" wire:model.lazy="user_id" name="user_id" id="user_id">
                                 <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                             @foreach ($userSelect as $item)
                                 <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -109,7 +109,7 @@
                         <td>{{ number_format($PurchasesWaintingInvoiceLine->receipt_qty, 0, '', ' ')  }}</td>
                         <td>
                             <div class="custom-control custom-checkbox">
-                                <input class="custom-control-input" value="{{ $PurchasesWaintingInvoiceLine->id }}" wire:model.live="data.{{ $PurchasesWaintingInvoiceLine->id }}.purchase_receipt_line_id" id="data.{{ $PurchasesWaintingInvoiceLine->id }}.purchase_receipt_line_id"  type="checkbox">
+                                <input class="custom-control-input" value="{{ $PurchasesWaintingInvoiceLine->id }}" wire:model.lazy="data.{{ $PurchasesWaintingInvoiceLine->id }}.purchase_receipt_line_id" id="data.{{ $PurchasesWaintingInvoiceLine->id }}.purchase_receipt_line_id"  type="checkbox">
                                 <label for="data.{{ $PurchasesWaintingInvoiceLine->id }}.purchase_receipt_line_id" class="custom-control-label">{{ __('general_content.add_to_document_trans_key') }} </label>
                             </div>
                         </td>

--- a/resources/views/livewire/purchases-wainting-receipt.blade.php
+++ b/resources/views/livewire/purchases-wainting-receipt.blade.php
@@ -11,7 +11,7 @@
                                 <div class="input-group-prepend">
                                     <span class="input-group-text"><i class="fas fa-building"></i></span>
                                 </div>
-                                <select class="form-control" wire:model.live="companies_id" name="companies_id" id="companies_id">
+                                <select class="form-control" wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                     <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                                 @forelse ($CompanieSelect as $item)
                                     <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -28,7 +28,7 @@
                                 <div class="input-group-prepend">
                                     <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                 </div>
-                                <input type="text" class="form-control" wire:model.live="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
+                                <input type="text" class="form-control" wire:model.lazy="code" name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}">
                             </div>
                             @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                         </div>
@@ -38,7 +38,7 @@
                                 <div class="input-group-prepend">
                                     <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                 </div>
-                                <input type="text" class="form-control" wire:model.live="deliveryNoteNumber" name="delivery_note_number" id="delivery_note_number" placeholder="{{ __('general_content.delivery_note_number_trans_key') }}">
+                                <input type="text" class="form-control" wire:model.lazy="deliveryNoteNumber" name="delivery_note_number" id="delivery_note_number" placeholder="{{ __('general_content.delivery_note_number_trans_key') }}">
                             </div>
                             @error('delivery_note_number') <span class="text-danger">{{ $message }}<br/></span>@enderror
                         </div>
@@ -48,7 +48,7 @@
                                 <div class="input-group-prepend">
                                     <span class="input-group-text"><i class="fas fa-user"></i></span>
                                 </div>
-                                <select class="form-control" wire:model.live="user_id" name="user_id" id="user_id">
+                                <select class="form-control" wire:model.lazy="user_id" name="user_id" id="user_id">
                                     <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                                 @foreach ($userSelect as $item)
                                     <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -144,7 +144,7 @@
                             <td>{{ number_format($PurchasesWaintingReceiptLine->qty, 0, '', ' ')  }}</td>
                             <td>
                                 <div class="custom-control custom-checkbox">
-                                    <input class="custom-control-input" value="{{ $PurchasesWaintingReceiptLine->id }}" wire:model.live="data.{{ $PurchasesWaintingReceiptLine->id }}.purchase_line_id" id="data.{{ $PurchasesWaintingReceiptLine->id }}.purchase_line_id"  type="checkbox">
+                                    <input class="custom-control-input" value="{{ $PurchasesWaintingReceiptLine->id }}" wire:model.lazy="data.{{ $PurchasesWaintingReceiptLine->id }}.purchase_line_id" id="data.{{ $PurchasesWaintingReceiptLine->id }}.purchase_line_id"  type="checkbox">
                                     <label for="data.{{ $PurchasesWaintingReceiptLine->id }}.purchase_line_id" class="custom-control-label">{{ __('general_content.add_to_document_trans_key') }}</label>
                                 </div>
                             </td>

--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -5,11 +5,11 @@
             @if($QuoteStatu == 1)
                 @if($updateLines)
                 <form wire:submit.prevent="updateQuoteLine">
-                            <input type="hidden" wire:model.live="quote_lines_id">
+                            <input type="hidden" wire:model.lazy="quote_lines_id">
                             @include('livewire.form.line-update')
                 @else
                 <form wire:submit.prevent="storeQuoteLine">
-                            <input type="hidden"  name="quotes_id"  id="quotes_id" value="1" wire:model.live="quotes_id" >
+                            <input type="hidden"  name="quotes_id"  id="quotes_id" value="1" wire:model.lazy="quotes_id" >
                             @include('livewire.form.line-create')
                 @endif
                 @include('livewire.form.customer-price-grid')
@@ -29,7 +29,7 @@
                 <div class="col-md-6">
                     <div class="input-group">
                         <input type="number" step="0.01" min="0" class="form-control"
-                               wire:model.live="priceIncreaseAmount"
+                               wire:model.lazy="priceIncreaseAmount"
                                placeholder="{{ __('general_content.price_increase_amount_trans_key') }}"
                                @disabled($QuoteStatu != 1)>
                         <div class="input-group-append">
@@ -610,7 +610,7 @@
                             </td>
                             <td>
                                 <div class="custom-control custom-checkbox">
-                                    <input class="custom-control-input" wire:model.live="data.{{ $QuoteLine->id }}.quote_line_id" id="data.{{ $QuoteLine->id }}.quote_line_id" type="checkbox">
+                                    <input class="custom-control-input" wire:model.lazy="data.{{ $QuoteLine->id }}.quote_line_id" id="data.{{ $QuoteLine->id }}.quote_line_id" type="checkbox">
                                     <label for="data.{{ $QuoteLine->id }}.quote_line_id" class="custom-control-label">+</label>
                                 </div>
                             </td>

--- a/resources/views/livewire/quotes-index.blade.php
+++ b/resources/views/livewire/quotes-index.blade.php
@@ -22,7 +22,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-external-link-square-alt"></i></span>
                                         </div>
-                                        <input type="text" class="form-control"  wire:model.live="code"  name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" >
+                                        <input type="text" class="form-control"  wire:model.lazy="code"  name="code" id="code" placeholder="{{ __('general_content.external_id_trans_key') }}" >
                                     </div>
                                     @error('code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -32,7 +32,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <input type="text" class="form-control"  wire:model.live="label" name="label"  id="label"  placeholder="{{ __('general_content.name_quote_trans_key') }}" required>
+                                        <input type="text" class="form-control"  wire:model.lazy="label" name="label"  id="label"  placeholder="{{ __('general_content.name_quote_trans_key') }}" required>
                                     </div>
                                     @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -42,7 +42,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                                         </div>
-                                        <select class="form-control"  wire:model.live="user_id" name="user_id" id="user_id">
+                                        <select class="form-control"  wire:model.lazy="user_id" name="user_id" id="user_id">
                                             <option value="">{{ __('general_content.select_user_management_trans_key') }}</option>
                                             @foreach ($userSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->name }}</option>
@@ -65,7 +65,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-building"></i></span>
                                         </div>
-                                        <select class="form-control"  wire:model.live="companies_id" name="companies_id" id="companies_id">
+                                        <select class="form-control"  wire:model.lazy="companies_id" name="companies_id" id="companies_id">
                                             <option value="">{{ __('general_content.select_company_trans_key') }}</option>
                                             @forelse ($CompanieSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -82,7 +82,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-user-tag"></i></span>
                                         </div>
-                                        <input type="text" class="form-control"  wire:model.live="customer_reference" name="customer_reference"  id="customer_reference" placeholder="{{ __('general_content.customer_reference_trans_key') }}">
+                                        <input type="text" class="form-control"  wire:model.lazy="customer_reference" name="customer_reference"  id="customer_reference" placeholder="{{ __('general_content.customer_reference_trans_key') }}">
                                     </div>
                                     @error('customer_reference') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -165,7 +165,7 @@
                                             <span class="input-group-text"><i class="fas fa-map-marked-alt"></i></span>
                                             @endif
                                         </div>
-                                        <select class="form-control"  wire:model.live="companies_addresses_id"  name="companies_addresses_id" id="companies_addresses_id">
+                                        <select class="form-control"  wire:model.lazy="companies_addresses_id"  name="companies_addresses_id" id="companies_addresses_id">
                                             <option value="">{{ __('general_content.select_address_trans_key') }}</option>
                                             @forelse ($AddressSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->label }} - {{ $item->adress }}</option>
@@ -249,7 +249,7 @@
                                             <span class="input-group-text"><i class="fas fa-user"></i></span>
                                             @endif
                                         </div>
-                                        <select class="form-control"  wire:model.live="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id">
+                                        <select class="form-control"  wire:model.lazy="companies_contacts_id" name="companies_contacts_id" id="companies_contacts_id">
                                             <option value="">{{ __('general_content.select_contact_trans_key') }}</option>
                                             @forelse ($ContactSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->first_name }} - {{ $item->name }}</option>
@@ -270,7 +270,7 @@
                             <div class="form-row">
                                 <div class="form-group col-md-6">
                                     <label for="accounting_payment_conditions_id">{{ __('general_content.payment_conditions_trans_key') }}</label>
-                                    <select class="form-control"  wire:model.live="accounting_payment_conditions_id" name="accounting_payment_conditions_id" id="accounting_payment_conditions_id">
+                                    <select class="form-control"  wire:model.lazy="accounting_payment_conditions_id" name="accounting_payment_conditions_id" id="accounting_payment_conditions_id">
                                         <option value="">{{ __('general_content.select_payement_condition_trans_key') }}</option>
                                         @forelse ($AccountingConditionSelect as $item)
                                         <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -282,7 +282,7 @@
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="accounting_payment_methods_id">{{ __('general_content.select_payement_methods_trans_key') }}</label>
-                                    <select class="form-control"  wire:model.live="accounting_payment_methods_id" name="accounting_payment_methods_id" id="accounting_payment_methods_id">
+                                    <select class="form-control"  wire:model.lazy="accounting_payment_methods_id" name="accounting_payment_methods_id" id="accounting_payment_methods_id">
                                         <option value="">{{ __('general_content.select_payement_methods_trans_key') }}</option>
                                         @forelse ($AccountingMethodsSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -300,7 +300,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-truck"></i></span>
                                         </div>
-                                        <select class="form-control"  wire:model.live="accounting_deliveries_id" name="accounting_deliveries_id" id="accounting_deliveries_id">
+                                        <select class="form-control"  wire:model.lazy="accounting_deliveries_id" name="accounting_deliveries_id" id="accounting_deliveries_id">
                                             <option value="">{{ __('general_content.select_delivery_trans_key') }}</option>
                                         @forelse ($AccountingDeleveriesSelect as $item)
                                             <option value="{{ $item->id }}">{{ $item->code }} - {{ $item->label }}</option>
@@ -313,7 +313,7 @@
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="label">{{ __('general_content.validity_date_trans_key') }}</label>
-                                    <input type="date" class="form-control"  wire:model.live="validity_date" name="validity_date"  id="validity_date">
+                                    <input type="date" class="form-control"  wire:model.lazy="validity_date" name="validity_date"  id="validity_date">
                                     @error('validity_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -322,7 +322,7 @@
                             <div class="row">
                                 <div class="col-12">
                                     <label>{{ __('general_content.comment_trans_key') }}</label>
-                                    <textarea class="form-control" rows="3"  wire:model.live="comment" name="comment"  placeholder="..."></textarea>
+                                    <textarea class="form-control" rows="3"  wire:model.lazy="comment" name="comment"  placeholder="..."></textarea>
                                     @error('comment') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>

--- a/resources/views/livewire/task-lines.blade.php
+++ b/resources/views/livewire/task-lines.blade.php
@@ -44,7 +44,7 @@
                                 <div class="form-control overflow-auto" style="max-height: 200px;">
                                     @forelse ($StatusSelect as $item)
                                         <div class="form-check">
-                                            <input class="form-check-input" type="checkbox" value="{{ $item->id }}" id="status-{{ $item->id }}" wire:model.live="selectedStatuses">
+                                            <input class="form-check-input" type="checkbox" value="{{ $item->id }}" id="status-{{ $item->id }}" wire:model.lazy="selectedStatuses">
                                             <label class="form-check-label" for="status-{{ $item->id }}">
                                                 {{ $item->title }}
                                             </label>
@@ -80,7 +80,7 @@
                     <div class="card-body">
                         <div class="form-group">
                             <label for="ShowGenericTask">{{ __('general_content.show_generic_task_trans_key') }}</label>
-                            <input type="checkbox" id="ShowGenericTask" wire:model.live="ShowGenericTask" style=" display:flex; align-items:center;">
+                            <input type="checkbox" id="ShowGenericTask" wire:model.lazy="ShowGenericTask" style=" display:flex; align-items:center;">
                         </div>
                     </div>
                 </div>

--- a/resources/views/livewire/task-manage.blade.php
+++ b/resources/views/livewire/task-manage.blade.php
@@ -34,7 +34,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <select class="form-control" wire:click.prevent="ChangeTaskType()" wire:model.live="TaskType" name="TaskType" id="TaskType">
+                            <select class="form-control" wire:click.prevent="ChangeTaskType()" wire:model.lazy="TaskType" name="TaskType" id="TaskType">
                                 <option value="">{{ __('general_content.select_task_type_trans_key') }}</option>
                                 <option value="TechCut">{{__('general_content.technical_cut_trans_key') }}</option>
                                 <option value="BOM">{{__('general_content.bom_trans_key') }}</option>
@@ -48,7 +48,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-sort-numeric-down"></i></span>
                             </div>
-                            <input type="number" class="form-control @error('ordre') is-invalid @enderror" name="ordre" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.live="ordre">
+                            <input type="number" class="form-control @error('ordre') is-invalid @enderror" name="ordre" id="ordre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.lazy="ordre">
                             
                             <input type="hidden" name="{{ $idType }}" value="{{ $Line->id   }}">
                         </div>
@@ -60,7 +60,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-list"></i></span>
                             </div>
-                            <select class="form-control @error('methods_services_id') is-invalid @enderror" wire:click.prevent="ChangeCodelabel()" name="methods_services_id" id="methods_services_id" wire:change="changeInputValues" wire:model.live="methods_services_id" required>
+                            <select class="form-control @error('methods_services_id') is-invalid @enderror" wire:click.prevent="ChangeCodelabel()" name="methods_services_id" id="methods_services_id" wire:change="changeInputValues" wire:model.lazy="methods_services_id" required>
                             <option>{{ __('general_content.select_service_trans_key') }}</option>
                                 @foreach ($ServicesSelect as $item)
                                 <option value="{{ $item->id }}-{{ $item->type }}" data-txt="{{ $item->label }}">{{ $item->code }}</option>
@@ -75,7 +75,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <input type="text" class="form-control @error('label') is-invalid @enderror"  name="label"  id="LABEL_TechnicalCut" placeholder="{{__('general_content.label_trans_key') }}" wire:model.live="label">
+                            <input type="text" class="form-control @error('label') is-invalid @enderror"  name="label"  id="LABEL_TechnicalCut" placeholder="{{__('general_content.label_trans_key') }}" wire:model.lazy="label">
                         </div>
                         @error('label') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -85,7 +85,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tools"></i></span>
                             </div>
-                            <select class="form-control @error('methods_tools_id') is-invalid @enderror" name="methods_tools_id" id="methods_tools_id" wire:model.live="methods_tools_id">
+                            <select class="form-control @error('methods_tools_id') is-invalid @enderror" name="methods_tools_id" id="methods_tools_id" wire:model.lazy="methods_tools_id">
                                 <option value="">{{ __('general_content.select_trans_key') }}</option>
                                 @foreach ($ToolsSelect as $tool)
                                 <option value="{{ $tool->id }}">{{ $tool->code }} - {{ $tool->label }}</option>
@@ -101,7 +101,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-barcode"></i></span>
                             </div>
-                            <select class="form-control @error('component_id') is-invalid @enderror" name="component_id" id="component_id"  wire:change="componentCost" wire:model.live="component_id" >
+                            <select class="form-control @error('component_id') is-invalid @enderror" name="component_id" id="component_id"  wire:change="componentCost" wire:model.lazy="component_id" >
                                 <option>{{ __('general_content.select_component_trans_key') }}</option>
                                 @foreach ($ProductSelect as $item)
                                 <option value="{{ $item->id }}" class="{{ $item->methods_services_id }}">{{ $item->code }}</option>
@@ -120,7 +120,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tools"></i></span>
                             </div>
-                            <select class="form-control" name="methods_tools_id" id="methods_tools_id" wire:model.live="methods_tools_id">
+                            <select class="form-control" name="methods_tools_id" id="methods_tools_id" wire:model.lazy="methods_tools_id">
                                 <option value="">{{ __('general_content.select_tool_trans_key') }}</option>
                                 @foreach ($ToolsSelect as $tool)
                                 <option value="{{ $tool->id }}">{{ $tool->code }} - {{ $tool->label }}</option>
@@ -145,7 +145,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-times"></i></span>
                             </div>
-                            <input type="number" class="form-control @error('qty') is-invalid @enderror" name="qty"  id="qty" value="{{ $Line->qty  }}" placeholder="{{ __('general_content.qty_trans_key') }}" step=".001"  min="0" wire:model.live="qty">
+                            <input type="number" class="form-control @error('qty') is-invalid @enderror" name="qty"  id="qty" value="{{ $Line->qty  }}" placeholder="{{ __('general_content.qty_trans_key') }}" step=".001"  min="0" wire:model.lazy="qty">
                         </div>
                         @error('qty') <span class="text-danger">{{ $message }}<br/></span>@enderror
                         @endif
@@ -168,7 +168,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-calendar"></i></span>
                             </div>
-                            <input type="datetime-local" class="form-control @error('start_date') is-invalid @enderror" name="start_date" id="start_date" wire:model.live="start_date">
+                            <input type="datetime-local" class="form-control @error('start_date') is-invalid @enderror" name="start_date" id="start_date" wire:model.lazy="start_date">
                         </div>
                         @error('start_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -178,7 +178,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-calendar-check"></i></span>
                             </div>
-                            <input type="datetime-local" class="form-control @error('end_date') is-invalid @enderror" name="end_date" id="end_date" wire:model.live="end_date">
+                            <input type="datetime-local" class="form-control @error('end_date') is-invalid @enderror" name="end_date" id="end_date" wire:model.lazy="end_date">
                         </div>
                         @error('end_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -198,7 +198,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('unit_price') is-invalid @enderror" name="unit_price"  id="unit_price" placeholder="{{ __('general_content.unit_time_trans_key') }}" value="0" step=".001" min="0" wire:model.live="unit_price">
+                            <input type="number" class="form-control @error('unit_price') is-invalid @enderror" name="unit_price"  id="unit_price" placeholder="{{ __('general_content.unit_time_trans_key') }}" value="0" step=".001" min="0" wire:model.lazy="unit_price">
                         </div>
                         <p>{{ $unit_cost  }} {{ $Factory->curency }} x {{ $methods_services_margin }} %  = {{ round( (float)$unit_cost*(1+((float)$methods_services_margin/100)),2) }}</p>
                         @error('unit_price') <span class="text-danger">{{ $message }}<br/></span>@enderror
@@ -480,7 +480,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-sort-numeric-down"></i></span>
                             </div>
-                            <input type="number" class="form-control @error('subAssemblyOrdre') is-invalid @enderror" name="subAssemblyOrdre" id="subAssemblyOrdre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.live="subAssemblyOrdre">
+                            <input type="number" class="form-control @error('subAssemblyOrdre') is-invalid @enderror" name="subAssemblyOrdre" id="subAssemblyOrdre" placeholder="{{ __('general_content.sort_trans_key') }}" min="0" wire:model.lazy="subAssemblyOrdre">
                             
                         </div>
                         @error('subAssemblyOrdre') <span class="text-danger">{{ $message }}<br/></span>@enderror
@@ -492,7 +492,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-barcode"></i></span>
                             </div>
-                            <select class="form-control @error('subAssemblyComponentId') is-invalid @enderror" name="subAssemblyComponentId" id="subAssemblyComponentId"  wire:click.prevent="ChangeSubAssemblyCodelabel()" wire:model.live="subAssemblyComponentId" >
+                            <select class="form-control @error('subAssemblyComponentId') is-invalid @enderror" name="subAssemblyComponentId" id="subAssemblyComponentId"  wire:click.prevent="ChangeSubAssemblyCodelabel()" wire:model.lazy="subAssemblyComponentId" >
                                 <option>{{ __('general_content.select_component_trans_key') }}</option>
                                 @foreach ($ComponentSelect as $item)
                                 <option value="{{ $item->id }}" class="{{ $item->methods_services_id }}">{{ $item->code }}</option>
@@ -507,7 +507,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-tags"></i></span>
                             </div>
-                            <input type="text" class="form-control @error('subAssemblylabel') is-invalid @enderror"  name="subAssemblylabel"  id="subAssemblylabel" placeholder="{{__('general_content.label_trans_key') }}" wire:model.live="subAssemblylabel" disabled>
+                            <input type="text" class="form-control @error('subAssemblylabel') is-invalid @enderror"  name="subAssemblylabel"  id="subAssemblylabel" placeholder="{{__('general_content.label_trans_key') }}" wire:model.lazy="subAssemblylabel" disabled>
                         </div>
                         @error('subAssemblylabel') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -517,7 +517,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-times"></i></span>
                             </div>
-                            <input type="number" class="form-control @error('subAssemblyQty') is-invalid @enderror" name="subAssemblyQty"  id="subAssemblyQty" value="1" placeholder="{{ __('general_content.qty_trans_key') }}" step="1"  min="0" wire:model.live="subAssemblyQty">
+                            <input type="number" class="form-control @error('subAssemblyQty') is-invalid @enderror" name="subAssemblyQty"  id="subAssemblyQty" value="1" placeholder="{{ __('general_content.qty_trans_key') }}" step="1"  min="0" wire:model.lazy="subAssemblyQty">
                         </div>
                         @error('subAssemblyQty') <span class="text-danger">{{ $message }}<br/></span>@enderror
                     </div>
@@ -527,7 +527,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}</span>
                             </div>
-                            <input type="number" class="form-control @error('subAssemblyUnit_price') is-invalid @enderror" name="subAssemblyUnit_price"  id="subAssemblyUnit_price" placeholder="{{ __('general_content.price_trans_key') }}" value="0" step=".001" min="0" wire:model.live="subAssemblyUnit_price">
+                            <input type="number" class="form-control @error('subAssemblyUnit_price') is-invalid @enderror" name="subAssemblyUnit_price"  id="subAssemblyUnit_price" placeholder="{{ __('general_content.price_trans_key') }}" value="0" step=".001" min="0" wire:model.lazy="subAssemblyUnit_price">
                         </div>
                     </div>
                     <div class="form-group col-md-2">

--- a/resources/views/livewire/task-statu.blade.php
+++ b/resources/views/livewire/task-statu.blade.php
@@ -339,7 +339,7 @@
                           <div class="input-group-prepend">
                               <span class="input-group-text"><i class="fas fa-times"></i></span>
                           </div>
-                          <input type="number" class="form-control @error('addGoodQt') is-invalid @enderror" id="addGoodQt" placeholder="{{ __('general_content.good_rejected_trans_key') }}" min="0" wire:model.live="addGoodQt">
+                          <input type="number" class="form-control @error('addGoodQt') is-invalid @enderror" id="addGoodQt" placeholder="{{ __('general_content.good_rejected_trans_key') }}" min="0" wire:model.lazy="addGoodQt">
                           <span class="input-group-append">
                             <button type="submit" class="btn btn-info btn-flat">Set</button>
                           </span>
@@ -376,7 +376,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fas fa-times"></i></span>
                             </div>
-                            <input type="number" class="form-control @error('addGoodQt') is-invalid @enderror" id="addGoodQt" placeholder="{{ __('general_content.good_rejected_trans_key') }}" min="0" wire:model.live="addGoodQt">
+                            <input type="number" class="form-control @error('addGoodQt') is-invalid @enderror" id="addGoodQt" placeholder="{{ __('general_content.good_rejected_trans_key') }}" min="0" wire:model.lazy="addGoodQt">
                             <span class="input-group-append">
                               <button type="submit" class="btn btn-info btn-flat">Set</button>
                             </span>
@@ -412,7 +412,7 @@
                           <div class="input-group-prepend">
                               <span class="input-group-text"><i class="fas fa-times"></i></span>
                           </div>
-                          <input type="number" class="form-control @error('addBadQt') is-invalid @enderror" id="addBadQt" placeholder="{{ __('general_content.quantity_rejected_trans_key') }}" min="0" wire:model.live="addBadQt">
+                          <input type="number" class="form-control @error('addBadQt') is-invalid @enderror" id="addBadQt" placeholder="{{ __('general_content.quantity_rejected_trans_key') }}" min="0" wire:model.lazy="addBadQt">
                           <span class="input-group-append">
                             <button type="submit" class="btn btn-info btn-flat">Set</button>
                           </span>
@@ -434,7 +434,7 @@
                       <div class="col-md-2 text-muted">
                         <div class="form-group">
                           <label for="not_recalculate">Not Recalculate</label>
-                          <input type="checkbox" id="not_recalculate" wire:model.live="not_recalculate" style=" display:flex; align-items:center;">
+                          <input type="checkbox" id="not_recalculate" wire:model.lazy="not_recalculate" style=" display:flex; align-items:center;">
                         </div>
                       </div>
                       <div class="col-md-8 text-muted">
@@ -444,7 +444,7 @@
                               <div class="input-group-prepend">
                                   <span class="input-group-text"><i class="fas fa-calendar"></i></span>
                               </div>
-                              <input type="datetime-local" class="form-control @error('end_date') is-invalid @enderror" id="end_date"  wire:model.live="end_date">
+                              <input type="datetime-local" class="form-control @error('end_date') is-invalid @enderror" id="end_date"  wire:model.lazy="end_date">
                               <span class="input-group-append">
                                 <button type="submit" class="btn btn-info btn-flat">Set</button>
                               </span>
@@ -463,7 +463,7 @@
                       <div class="col-md-4 text-muted">
                         <div class="form-group">
                           <label for="userforced_ressource">{{ __('general_content.user_choise_trans_key') }}</label>
-                          <input type="checkbox" id="userforced_ressource" wire:model.live="userforced_ressource" style=" display:flex; align-items:center;">
+                          <input type="checkbox" id="userforced_ressource" wire:model.lazy="userforced_ressource" style=" display:flex; align-items:center;">
                         </div>
                       </div>
                       <div class="col-md-8">

--- a/resources/views/livewire/user-profile.blade.php
+++ b/resources/views/livewire/user-profile.blade.php
@@ -6,7 +6,7 @@
 
                             <div class="form-group">
                                 <label for="name">{{ __('general_content.name_trans_key') }}</label>
-                                <input wire:model.live="name" type="text" class="form-control" />
+                                <input wire:model.lazy="name" type="text" class="form-control" />
                                 @error('name') <span class="text-danger">{{ $message }}<br/></span>@enderror
                             </div>
                             <div class="form-group">
@@ -15,13 +15,13 @@
                                     <div class="input-group-prepend">
                                         <span class="input-group-text"><i class="fas fa-envelope"></i></span>
                                     </div>
-                                    <input wire:model.live="email" type="email" class="form-control" />
+                                    <input wire:model.lazy="email" type="email" class="form-control" />
                                 </div>
                                 @error('email') <span class="text-danger">{{ $message }}<br/></span>@enderror
                             </div>
                             <div class="form-group">
                                 <label for="password">{{ __('general_content.password_account_trans_key') }}</label>
-                                <input wire:model.live="password" type="password" class="form-control" />
+                                <input wire:model.lazy="password" type="password" class="form-control" />
                                 @error('password') <span class="text-danger">{{ $message }}<br/></span>@enderror
                             </div>
                         <x-slot name="footerSlot">
@@ -39,7 +39,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-phone"></i></span>
                                         </div>
-                                        <input type="text" wire:model.live="personnal_phone_number"  name="personnal_phone_number" class="form-control">
+                                        <input type="text" wire:model.lazy="personnal_phone_number"  name="personnal_phone_number" class="form-control">
                                     </div>
                                     @error('personnal_phone_number') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -49,7 +49,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-envelope"></i></span>
                                         </div>
-                                        <input type="text" wire:model.live="private_email"  name="private_email" class="form-control">
+                                        <input type="text" wire:model.lazy="private_email"  name="private_email" class="form-control">
                                     </div>
                                     @error('private_email') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -59,7 +59,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="far fa-calendar-alt"></i></span>
                                         </div>
-                                        <input type="date" class="form-control" wire:model.live="born_date"  name="born_date"  id="born_date">
+                                        <input type="date" class="form-control" wire:model.lazy="born_date"  name="born_date"  id="born_date">
                                     </div>
                                     @error('born_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -69,7 +69,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-flag"></i></span>
                                         </div>
-                                        <input type="text" wire:model.live="nationality"  name="nationality" class="form-control">
+                                        <input type="text" wire:model.lazy="nationality"  name="nationality" class="form-control">
                                     </div>
                                     @error('nationality') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
@@ -82,7 +82,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="gender" name="gender" id="gender">
+                                        <select class="form-control" wire:model.lazy="gender" name="gender" id="gender">
                                             <option value="">{{ __('general_content.select_gender_trans_key') }}</option>
                                             <option value="1">{{ __('general_content.male_trans_key') }}</option>
                                             <option value="2">{{ __('general_content.female_trans_key') }}</option>
@@ -98,7 +98,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fas fa-tags"></i></span>
                                         </div>
-                                        <select class="form-control" wire:model.live="marital_status" name="marital_status" id="marital_status">
+                                        <select class="form-control" wire:model.lazy="marital_status" name="marital_status" id="marital_status">
                                             <option value="">{{ __('general_content.select_marital_status_trans_key') }}</option>
                                             <option value="1">{{ __('general_content.married_trans_key') }}</option>
                                             <option value="2">{{ __('general_content.single_trans_key') }}</option>
@@ -114,7 +114,7 @@
                             <div class="row">
                                 <div class="form-group col-md-3">
                                     <label for="password">{{ __('general_content.driving_license_trans_key') }} :</label>
-                                    <input wire:model.live="driving_license" type="text" class="form-control" />
+                                    <input wire:model.lazy="driving_license" type="text" class="form-control" />
                                     @error('driving_license') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
@@ -123,18 +123,18 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="far fa-calendar-alt"></i></span>
                                         </div>
-                                        <input type="date" class="form-control" wire:model.live="driving_license_exp_date"  name="driving_license_exp_date"  id="driving_license_exp_date">
+                                        <input type="date" class="form-control" wire:model.lazy="driving_license_exp_date"  name="driving_license_exp_date"  id="driving_license_exp_date">
                                     </div>
                                     @error('driving_license_exp_date') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label>{{ __('general_content.ssn_num_trans_key') }} :</label>
-                                    <input wire:model.live="ssn_num" type="text" class="form-control" />
+                                    <input wire:model.lazy="ssn_num" type="text" class="form-control" />
                                     @error('ssn_num') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label>{{ __('general_content.nic_num_trans_key') }} :</label>
-                                    <input wire:model.live="nic_num" type="text" class="form-control" />
+                                    <input wire:model.lazy="nic_num" type="text" class="form-control" />
                                     @error('nic_num') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -146,34 +146,34 @@
                             <div class="row">
                                 <div class="form-group col-md-6">
                                     <label for="address1">{{ __('general_content.adress_trans_key') }} 1 :</label>
-                                    <input type="text" wire:model.live="address1"  name="address1" class="form-control">
+                                    <input type="text" wire:model.lazy="address1"  name="address1" class="form-control">
                                     @error('address1') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="address2">{{ __('general_content.adress_trans_key') }} 2 :</label>
-                                    <input type="text" wire:model.live="address2"  name="address2" class="form-control">
+                                    <input type="text" wire:model.lazy="address2"  name="address2" class="form-control">
                                     @error('address2') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="form-group col-md-3">
                                     <label for="city">{{ __('general_content.city_trans_key') }} :</label>
-                                    <input type="text" wire:model.live="city"  name="city" class="form-control">
+                                    <input type="text" wire:model.lazy="city"  name="city" class="form-control">
                                     @error('city') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="postal_code">{{ __('general_content.postal_code_trans_key') }} :</label>
-                                    <input type="text" wire:model.live="postal_code"  name="postal_code" class="form-control">
+                                    <input type="text" wire:model.lazy="postal_code"  name="postal_code" class="form-control">
                                     @error('postal_code') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="province">{{ __('general_content.province_trans_key') }}  :</label>
-                                    <input type="text" wire:model.live="province"  name="province" class="form-control">
+                                    <input type="text" wire:model.lazy="province"  name="province" class="form-control">
                                     @error('province') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="country">{{ __('general_content.country_trans_key') }} :</label>
-                                    <input type="text" wire:model.live="country"  name="country" class="form-control">
+                                    <input type="text" wire:model.lazy="country"  name="country" class="form-control">
                                     @error('country') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -185,22 +185,22 @@
                             <div class="row">
                                 <div class="form-group col-md-3">
                                     <label for="custom1">{{ __('general_content.custom_trans_key') }} 1 :</label>
-                                    <input wire:model.live="custom1" type="text" class="form-control" />
+                                    <input wire:model.lazy="custom1" type="text" class="form-control" />
                                     @error('custom1') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="custom2">{{ __('general_content.custom_trans_key') }} 2:</label>
-                                    <input wire:model.live="custom2" type="text" class="form-control" />
+                                    <input wire:model.lazy="custom2" type="text" class="form-control" />
                                     @error('custom2') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="custom3">{{ __('general_content.custom_trans_key') }} 3:</label>
-                                    <input wire:model.live="custom3" type="text" class="form-control" />
+                                    <input wire:model.lazy="custom3" type="text" class="form-control" />
                                     @error('custom3') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="custom4">{{ __('general_content.custom_trans_key') }} 4</label>
-                                    <input wire:model.live="custom4" type="text" class="form-control" />
+                                    <input wire:model.lazy="custom4" type="text" class="form-control" />
                                     @error('custom4') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>
@@ -208,7 +208,7 @@
                             <div class="row">
                                 <div class="col-12">
                                     <label>{{ __('general_content.about_you_trans_key') }}</label>
-                                    <textarea class="form-control" wire:model.live="desc" rows="3" placeholder="..."></textarea>
+                                    <textarea class="form-control" wire:model.lazy="desc" rows="3" placeholder="..."></textarea>
                                     @error('desc') <span class="text-danger">{{ $message }}<br/></span>@enderror
                                 </div>
                             </div>


### PR DESCRIPTION
### Motivation
- Modernize Livewire bindings by switching `wire:model.live=` to `wire:model.lazy=` across UI forms to avoid unnecessary realtime updates while keeping search inputs reactive.
- Preserve existing search behavior by excluding bindings that contain `search` in the `wire:model` value or in the `name` attribute to avoid changing search fields semantics.

### Description
- Replaced `wire:model.live=` with `wire:model.lazy=` in 25 Blade templates under `resources/views/livewire/` across inputs, selects, textareas and checkboxes. 
- Search-related bindings containing `search` in either the `wire:model` expression or the `name` attribute were explicitly skipped. 
- Changes were applied by a scripted update and then committed with a descriptive message. 
- A validation script was run to ensure no non-search `wire:model.live=` usages remain in the `resources/views/livewire` tree. 

### Testing
- Searched for occurrences before and after the change with `rg -n "wire:model\.live=" resources/views/livewire --glob "*.blade.php"` and confirmed only search-related matches remain, and the command succeeded. 
- Ran the replacement and verification using the provided Python scripts (performed find/replace and checked `name` attributes) and the verification script reported no non-search `wire:model.live` occurrences, and the scripts completed successfully. 
- Performed `git status --short` and committed the updates with `git commit -m "Replace wire:model.live with lazy in Livewire blades"`, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b683e54888832d9c5fd0413a63f978)