### PR TITLE
Replace mix() asset references with Vite helpers in Blade views

### DIFF
--- a/resources/views/attendance/index.blade.php
+++ b/resources/views/attendance/index.blade.php
@@ -24,7 +24,7 @@
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
         @endif
     @else
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+        <link rel="stylesheet" href="{{ asset(Vite::asset(config('adminlte.laravel_mix_css_path', 'css/app.css'))) }}">
     @endif
 
     {{-- Bootstrap 5 --}}

--- a/resources/views/customer/layouts/app.blade.php
+++ b/resources/views/customer/layouts/app.blade.php
@@ -25,7 +25,7 @@
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
         @endif
     @else
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+        <link rel="stylesheet" href="{{ asset(Vite::asset(config('adminlte.laravel_mix_css_path', 'css/app.css'))) }}">
     @endif
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 

--- a/resources/views/guest/guest-delivery-info.blade.php
+++ b/resources/views/guest/guest-delivery-info.blade.php
@@ -30,7 +30,7 @@
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
         @endif
     @else
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+        <link rel="stylesheet" href="{{ asset(Vite::asset(config('adminlte.laravel_mix_css_path', 'css/app.css'))) }}">
     @endif
 
     <!-- Bootstrap CSS -->

--- a/resources/views/guest/guest-order-info.blade.php
+++ b/resources/views/guest/guest-order-info.blade.php
@@ -30,7 +30,7 @@
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
         @endif
     @else
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+        <link rel="stylesheet" href="{{ asset(Vite::asset(config('adminlte.laravel_mix_css_path', 'css/app.css'))) }}">
     @endif
 
     <!-- Bootstrap CSS -->

--- a/resources/views/guest/guest-quote-info.blade.php
+++ b/resources/views/guest/guest-quote-info.blade.php
@@ -30,7 +30,7 @@
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
         @endif
     @else
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+        <link rel="stylesheet" href="{{ asset(Vite::asset(config('adminlte.laravel_mix_css_path', 'css/app.css'))) }}">
     @endif
 
     <!-- Bootstrap CSS -->

--- a/resources/views/spreadsheet/editor.blade.php
+++ b/resources/views/spreadsheet/editor.blade.php
@@ -143,5 +143,5 @@
             sheets: @json($spreadsheet->sheets->map(fn($s) => ['id' => $s->id, 'name' => $s->name, 'data' => $s->data]))
         };
     </script>
-    <script src="{{ mix('js/spreadsheet.js') }}"></script>
+    <script src="{{ asset(Vite::asset('js/spreadsheet.js')) }}"></script>
 @stop

--- a/resources/views/workshop/workshop-andon-task-activity.blade.php
+++ b/resources/views/workshop/workshop-andon-task-activity.blade.php
@@ -69,7 +69,7 @@
         });
     </script>
 
-    <script src="{{ mix('js/app.js') }}"></script>
+    <script src="{{ asset(Vite::asset('js/app.js')) }}"></script>
     <script>
         Echo.channel('TaskActivity')
         .listen('.task.activity.triggered', function(data) {

--- a/resources/views/workshop/workshop-andon.blade.php
+++ b/resources/views/workshop/workshop-andon.blade.php
@@ -82,7 +82,7 @@
         });
     </script>
 
-    <script src="{{ mix('js/app.js') }}"></script>
+    <script src="{{ asset(Vite::asset('js/app.js')) }}"></script>
     <script>
         Echo.channel('AndonAlert')
         .listen('.andon.alert.triggered', function(data) {


### PR DESCRIPTION
### Motivation
- Migrate remaining Blade asset includes from Laravel Mix to the Vite-based helper so JS/CSS assets resolve correctly under the Vite workflow.  
- Only update asset calls for JS and CSS includes and avoid touching other occurrences of the identifier `mix`.

### Description
- Replaced `mix('...')` stylesheet/script usages with `asset(Vite::asset('...'))` and replaced `mix(config(...))` with `asset(Vite::asset(config(...)))` in affected Blade views.  
- Updated script `src` includes to use `{{ asset(Vite::asset(...)) }}` for JS files and stylesheet `href` includes for CSS files.  
- Files modified: `resources/views/spreadsheet/editor.blade.php`, `resources/views/workshop/workshop-andon.blade.php`, `resources/views/workshop/workshop-andon-task-activity.blade.php`, `resources/views/customer/layouts/app.blade.php`, `resources/views/guest/guest-order-info.blade.php`, `resources/views/guest/guest-delivery-info.blade.php`, `resources/views/guest/guest-quote-info.blade.php`, and `resources/views/attendance/index.blade.php`.

### Testing
- Searched for remaining `@mix(` / `mix(` occurrences with `rg -n "@mix\(|mix\(" resources/views` and confirmed none remain after changes.  
- Validated replacements by scanning for `Vite::asset`, `script src` and stylesheet lines in the updated files with `rg -n "Vite::asset|script src|stylesheet"` and by inspecting the updated file sections to confirm expected tokens appear.  
- All automated checks executed completed successfully and the modified files reflect the intended replacements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68471e950832d9ef914c62e09c33d)