### PR TITLE
Cache Finished status id in CheckOrderLineTaskStatus listener

### DIFF
--- a/app/Listeners/CheckOrderLineTaskStatus.php
+++ b/app/Listeners/CheckOrderLineTaskStatus.php
@@ -8,6 +8,7 @@ use App\Models\Planning\Status;
 use App\Models\Workflow\OrderLines;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Cache;
 
 class CheckOrderLineTaskStatus implements ShouldQueue
 {
@@ -28,7 +29,9 @@ class CheckOrderLineTaskStatus implements ShouldQueue
         $orderLineId = $task->order_lines_id;
     
         // Trouvez l'ID du statut "Finished"
-        $finishedStatusId = Status::where('title', 'Finished')->value('id');
+        $finishedStatusId = Cache::rememberForever('status_finished_id', function() {
+            return Status::where('title', 'Finished')->value('id');
+        });
         
         $allLinesOderLine = Task::where('order_lines_id', $orderLineId)
             ->where('status_id', '<>', $finishedStatusId) 


### PR DESCRIPTION
### Motivation
- Avoid repeated database queries for the "Finished" status id in the `CheckOrderLineTaskStatus` listener by caching the lookup permanently.

### Description
- Replaced `Status::where('title', 'Finished')->value('id')` with `Cache::rememberForever('status_finished_id', function() { return Status::where('title', 'Finished')->value('id'); })` and added the import `use Illuminate\Support\Facades\Cache;` in `app/Listeners/CheckOrderLineTaskStatus.php`.

### Testing
- Searched for remaining raw lookups with `rg` and inspected the updated file contents with a diff/line check, confirming the replacement and import are present and no other files in `app/Listeners` contain the original expression; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6847ec758832da8ad4b4aee8145ee)