### PR TITLE
Passer les modèles complets dans les events de mise à jour des lignes (order / delivery)

### DIFF
--- a/app/Events/DeliveryLineUpdated.php
+++ b/app/Events/DeliveryLineUpdated.php
@@ -2,8 +2,8 @@
 
 namespace App\Events;
 
-use Illuminate\Broadcasting\Channel;
 use App\Models\Workflow\DeliveryLines;
+use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Broadcasting\PresenceChannel;
@@ -15,15 +15,15 @@ class DeliveryLineUpdated
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $deliveryLineId;
+    public $deliveryLine;
 
 
     /**
      * Create a new event instance.
      */
-    public function __construct($deliveryLineId)
+    public function __construct(DeliveryLines $deliveryLine)
     {
-        $this->deliveryLineId = $deliveryLineId;
+        $this->deliveryLine = $deliveryLine;
     }
 
     /**

--- a/app/Events/OrderLineUpdated.php
+++ b/app/Events/OrderLineUpdated.php
@@ -2,6 +2,7 @@
 
 namespace App\Events;
 
+use App\Models\Workflow\OrderLines;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
@@ -14,14 +15,14 @@ class OrderLineUpdated
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $orderLineId;
+    public $orderLine;
 
     /**
      * Create a new event instance.
      */
-    public function __construct($orderLineId)
+    public function __construct(OrderLines $orderLine)
     {
-        $this->orderLineId = $orderLineId;
+        $this->orderLine = $orderLine;
     }
 
     /**

--- a/app/Http/Controllers/Workflow/InvoicesController.php
+++ b/app/Http/Controllers/Workflow/InvoicesController.php
@@ -97,7 +97,7 @@ class InvoicesController extends Controller
     {
         $DeliveryLine->invoice_status = 4;
         $DeliveryLine->save();
-        event(new DeliveryLineUpdated($DeliveryLine->id));
+        event(new DeliveryLineUpdated($DeliveryLine));
     }
 
     /**

--- a/app/Listeners/CheckOrderDeliveredStatus.php
+++ b/app/Listeners/CheckOrderDeliveredStatus.php
@@ -24,7 +24,7 @@ class CheckOrderDeliveredStatus implements ShouldQueue
     public function handle(OrderLineUpdated $event)
     {
 
-        $orderLine = OrderLines::find($event->orderLineId);
+        $orderLine = $event->orderLine;
         $orderId = $orderLine->orders_id;
         
         #1 = Not delivered

--- a/app/Listeners/UpdateDeliveryStatus.php
+++ b/app/Listeners/UpdateDeliveryStatus.php
@@ -23,7 +23,7 @@ class UpdateDeliveryStatus implements ShouldQueue
      */
     public function handle(DeliveryLineUpdated $event)
     {
-        $deliveryLine = DeliveryLines::find($event->deliveryLineId);
+        $deliveryLine = $event->deliveryLine;
         $deliveryId = $deliveryLine->deliverys_id;
 
         #1 = Chargeable

--- a/app/Livewire/DeliverysRequest.php
+++ b/app/Livewire/DeliverysRequest.php
@@ -207,7 +207,7 @@ class DeliverysRequest extends Component
         }
     
         $orderLine->save();
-        event(new OrderLineUpdated($orderLine->id));
+        event(new OrderLineUpdated($orderLine));
     }
     
     private function generateSerialNumbers($productId, $orderLineId, $scumQty, $batchId = null)

--- a/app/Livewire/InvoicesRequest.php
+++ b/app/Livewire/InvoicesRequest.php
@@ -249,7 +249,7 @@ class InvoicesRequest extends Component
     {
         $deliveryLine->invoice_status = 4;
         $deliveryLine->save();
-        event(new DeliveryLineUpdated($deliveryLine->id));
+        event(new DeliveryLineUpdated($deliveryLine));
     }
 
     private function updateOrderLineInfo($deliveryLine)

--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -1070,7 +1070,7 @@ class OrderLine extends Component
         $OrderLineData->delivered_remaining_qty = 0;
         $OrderLineData->delivery_status = $OrderLineData->delivered_remaining_qty == 0 ? 3 : 2;
         $OrderLineData->save();
-        event(new OrderLineUpdated($OrderLineData->id));
+        event(new OrderLineUpdated($OrderLineData));
     }
 
     // Helper method to update order line info
@@ -1080,7 +1080,7 @@ class OrderLine extends Component
         $OrderLineData->invoiced_remaining_qty = 0;
         $OrderLineData->invoice_status  = $OrderLineData->invoiced_remaining_qty == 0 ? 3 : 2;
         $OrderLineData->save();
-        event(new OrderLineUpdated($OrderLineData->id));
+        event(new OrderLineUpdated($OrderLineData));
     }
     
 

--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -51,7 +51,7 @@ class StockService
         }
 
         $OrderLine->save();
-        event(new OrderLineUpdated($OrderLine->id));
+        event(new OrderLineUpdated($OrderLine));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Simplifier les listeners en fournissant directement le modèle de ligne (OrderLines / DeliveryLines) dans l'event au lieu d'un identifiant numérique.

### Description
- `OrderLineUpdated` et `DeliveryLineUpdated` ont été modifiés pour exposer la propriété `$orderLine` et `$deliveryLine` et leurs constructeurs acceptent désormais `OrderLines` et `DeliveryLines` respectivement.
- Les listeners `CheckOrderDeliveredStatus` et `UpdateDeliveryStatus` utilisent désormais directement `$event->orderLine` et `$event->deliveryLine` au lieu d'appeler `find()` par ID.
- Les points d'émission des events ont été adaptés pour passer les instances modèles au lieu des IDs dans `app/Livewire/OrderLine.php`, `app/Livewire/DeliverysRequest.php`, `app/Livewire/InvoicesRequest.php`, `app/Services/StockService.php` et `app/Http/Controllers/Workflow/InvoicesController.php`.
- Import des modèles nécessaires ajouté via `use App\Models\Workflow\OrderLines;` et `use App\Models\Workflow\DeliveryLines;` là où requis.

### Testing
- Exécution de la vérification syntaxique PHP via `php -l` sur tous les fichiers modifiés; tous les fichiers vérifiés sont passés sans erreur de syntaxe.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b684a89b60832d91bcacfae466eede)