### PR TITLE
Include stderr in logging stack and configure stderr channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => explode(',', env('LOG_STACK', 'stderr,daily')),
             'ignore_exceptions' => false,
         ],
 
@@ -86,12 +86,12 @@ return [
 
         'stderr' => [
             'driver' => 'monolog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'handler' => StreamHandler::class,
-            'formatter' => env('LOG_STDERR_FORMATTER'),
+            'handler' => Monolog\Handler\StreamHandler::class,
+            'formatter' => Monolog\Formatter\LineFormatter::class,
             'with' => [
                 'stream' => 'php://stderr',
             ],
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
 
         'syslog' => [


### PR DESCRIPTION
### Motivation
- Ensure application logs can be emitted to `stderr` and make the stack channels configurable via `LOG_STACK` with a sensible default of `stderr,daily`. 
- Make the `stderr` channel explicit about the Monolog handler and formatter to guarantee consistent stderr formatting.

### Description
- Changed the `stack` channel to use `channels` = `explode(',', env('LOG_STACK', 'stderr,daily'))` instead of the fixed `['single']` list. 
- Updated the `stderr` channel to use `Monolog\Handler\StreamHandler::class` and `Monolog\Formatter\LineFormatter::class` while preserving the `with` stream `php://stderr` and the `level` from `env('LOG_LEVEL', 'debug')`. 
- No other modifications were made to `config/logging.php`.

### Testing
- Ran `php -l config/logging.php` which reported `No syntax errors detected in config/logging.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b685339a48832d842b308a1668b7a2)