### PR TITLE
Move OrderCreated dispatch outside DB::transaction in QuoteLine::storeOrder

### DIFF
--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -949,7 +949,7 @@ class QuoteLine extends Component
         }
 
         if($i>0){
-            return DB::transaction(function() use ($quoteId) {
+            $OrdersCreated = DB::transaction(function() use ($quoteId) {
 
                 //get data to dulicate for new order
                 $QuoteData = Quotes::find($quoteId);
@@ -979,10 +979,6 @@ class QuoteLine extends Component
                     $QuoteData->id,
                     null
                 );
-
-               // Trigger the event
-                event(new OrderCreated($OrdersCreated));
-
                 if($OrdersCreated){
                     // Create lines
                     foreach ($this->data as $key => $item) {
@@ -1072,9 +1068,13 @@ class QuoteLine extends Component
                     return redirect()->back()->with('error', 'Something went wrong');
                 }
 
-                // Reset Form Fields After Creating line
-                return redirect()->route('orders.show', ['id' => $OrdersCreated->id])->with('success', 'Successfully created new order');
+                return $OrdersCreated;
             });
+
+            event(new OrderCreated($OrdersCreated));
+
+            // Reset Form Fields After Creating line
+            return redirect()->route('orders.show', ['id' => $OrdersCreated->id])->with('success', 'Successfully created new order');
         }
         else{
             $errors = $this->getErrorBag();


### PR DESCRIPTION
### Motivation
- Prevent listeners from handling an `OrderCreated` event while the creating transaction is still open, which could lead to listeners reading rows that are later rolled back.
- Address the unsafe pattern where `event(new OrderCreated(...))` was dispatched inside the `DB::transaction()` closure in `storeOrder()`.

### Description
- Update `app/Livewire/QuoteLine.php::storeOrder()` so the `DB::transaction()` closure returns the created order model (`$OrdersCreated`) instead of returning the redirect directly.
- Move `event(new OrderCreated($OrdersCreated))` to execute after the transaction completes so the event is dispatched only after commit.
- Keep the existing redirect to `route('orders.show', ['id' => $OrdersCreated->id])` and the success flash message unchanged.
- Small local refactor to assign the transaction result to `$OrdersCreated` and return it from the closure.

### Testing
- Ran a PHP syntax check with `php -l app/Livewire/QuoteLine.php` which reported no syntax errors (success).
- Verified the code diff to confirm the event dispatch was moved out of the transaction and the redirect flow remains the same (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68718b69c832daad588a3db452696)