### PR TITLE
Fix Livewire filter/chat bindings to update immediately

### DIFF
--- a/resources/views/livewire/chatlive.blade.php
+++ b/resources/views/livewire/chatlive.blade.php
@@ -66,7 +66,7 @@
     </div> 
         
     <div class="input-group">
-        <input type="text" wire:model.lazy="label" name="label"  id="label" placeholder="Chat ..." class="form-control">
+        <input type="text" wire:model.live="label" name="label"  id="label" placeholder="Chat ..." class="form-control">
         <span class="input-group-append">
             <button type="button" wire:click="storeMessage({{ $idItem }}, '{{ $Class }}')" class="btn btn-danger">{{ __('general_content.add_trans_key') }}</button>
         </span>

--- a/resources/views/livewire/companies-lines.blade.php
+++ b/resources/views/livewire/companies-lines.blade.php
@@ -132,7 +132,7 @@
                                             <div class="input-group-prepend">
                                                 <span class="input-group-text"><i class="fas fa-filter fa-fw"></i></span>
                                             </div>
-                                            <select class="form-control" wire:model.lazy="statusFilter">
+                                            <select class="form-control" wire:model.live="statusFilter">
                                                 <option value="all">{{ __('general_content.view_all_trans_key') }}</option>
                                                 <option value="client">{{ __('general_content.client_trans_key') }}</option>
                                                 <option value="prospect">{{ __('general_content.prospect_trans_key') }}</option>


### PR DESCRIPTION
### Motivation
- Some Livewire bindings used `wire:model.lazy` for UI controls where immediate updates are expected, causing filters and chat input to not react until blur or another event.

### Description
- Changed the chat input binding from `wire:model.lazy` to `wire:model.live` in `resources/views/livewire/chatlive.blade.php` so typing updates component state immediately.
- Changed the companies list status filter select from `wire:model.lazy` to `wire:model.live` in `resources/views/livewire/companies-lines.blade.php` so filtering applies as soon as selection changes.
- Left other form input bindings using `wire:model.lazy` untouched to preserve their intended behavior.

### Testing
- Searched the codebase with `rg` to locate `statusFilter` and relevant `wire:model` usages and verified only the intended selects/inputs were changed (searches succeeded).
- Inspected the modified files and diff with `git show --stat` and `git status` to confirm two files updated and staged; commit `f4f8032` was created successfully.
- Reviewed the resulting diffs to ensure only the two targeted lines were changed and no other behavior-affecting modifications were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6885ebf7c832da81353fe538c3d9e)