### PR TITLE
Invalidate menu orders cache on order create/update

### DIFF
--- a/app/Observers/OrdersObserver.php
+++ b/app/Observers/OrdersObserver.php
@@ -5,15 +5,25 @@ namespace App\Observers;
 use App\Jobs\PushOrderToN2P;
 use App\Models\Workflow\Orders;
 use App\Services\Settings\SettingsService;
+use Illuminate\Support\Facades\Cache;
 
 class OrdersObserver
 {
+    private const MENU_ORDERS_NOT_FINISH_CACHE_KEY = 'menu_orders_not_finish';
+
     public function __construct(private SettingsService $settings)
     {
     }
 
+    public function created(Orders $order): void
+    {
+        Cache::forget(self::MENU_ORDERS_NOT_FINISH_CACHE_KEY);
+    }
+
     public function updated(Orders $order): void
     {
+        Cache::forget(self::MENU_ORDERS_NOT_FINISH_CACHE_KEY);
+
         if (!$order->isDirty('statu')) {
             return;
         }


### PR DESCRIPTION
### Motivation

- The menu counters are cached under the `menu_orders_not_finish` key for 60s which can show stale values after order changes, so cache must be invalidated on write events for immediate freshness.
- Ensure the UI counter is refreshed instantly when an order is created or updated while keeping existing N2P dispatch behavior intact.

### Description

- Add `use Illuminate\Support\Facades\Cache;` and a constant `MENU_ORDERS_NOT_FINISH_CACHE_KEY` to `app/Observers/OrdersObserver.php`.
- Invalidate the menu cache with `Cache::forget(self::MENU_ORDERS_NOT_FINISH_CACHE_KEY)` in a new `created(Orders $order)` observer method.
- Call `Cache::forget(self::MENU_ORDERS_NOT_FINISH_CACHE_KEY)` at the start of `updated(Orders $order)` before the existing N2P status-transition logic.

### Testing

- Attempted to run `php artisan test tests/Feature/N2PStatusChangeTest.php`, but the test run failed in this environment due to missing dependencies (`vendor/autoload.php` not found), so automated tests could not complete.
- No other automated test failures were observed from source-level checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6887a9be8832db058ec24ac2bc286)