### PR TITLE
Fix orders summary open amount aggregation

### DIFF
--- a/app/Http/Controllers/SpreadsheetDataController.php
+++ b/app/Http/Controllers/SpreadsheetDataController.php
@@ -172,7 +172,9 @@ class SpreadsheetDataController extends Controller
         $totalOrders = (clone $ordersQuery)->count();
         $openOrders = (clone $openOrdersQuery)->count();
         $lateOrders = (clone $openOrdersQuery)->whereDate('created_at', '<', now()->subDays(30))->count();
-        $openAmount = (float) ((clone $openOrdersQuery)->sum('total_price') ?? 0);
+        $openAmount = (float) (clone $openOrdersQuery)
+            ->get()
+            ->sum(fn (Orders $order) => (float) ($order->total_price ?? 0));
 
         $invoices = Invoices::whereBetween('created_at', [$start, $end])->get();
         $totalHt = (float) $invoices->sum(fn (Invoices $invoice) => (float) $invoice->total_price);


### PR DESCRIPTION
### Motivation
- The controller attempted to run `sum('total_price')` in SQL against the `orders` table but `total_price` is a model accessor, not a persisted column, which caused `Unknown column 'total_price'` runtime errors.

### Description
- Replaced the database aggregate call with loading open orders and summing the `Orders::total_price` accessor in PHP using `->get()->sum(fn (Orders $order) => (float) ($order->total_price ?? 0))` in `SpreadsheetDataController::ordersSummary()`.
- Kept the API response keys unchanged so `open_orders_total_ht` is computed the same way but without causing SQL errors.

### Testing
- Ran `php -l app/Http/Controllers/SpreadsheetDataController.php` and the file passed PHP syntax check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69d82096c832da29f135d2fcb6181)