### PR TITLE
Add bs-custom-file-input plugin to AdminLTE configuration

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -1010,6 +1010,16 @@ return [
                 ],
             ],
         ],
+        'BsCustomFileInput' => [
+            'active' => true,
+            'files' => [
+                [
+                    'type' => 'js',
+                    'asset' => false,
+                    'location' => '//cdn.jsdelivr.net/npm/bs-custom-file-input/dist/bs-custom-file-input.min.js',
+                ],
+            ],
+        ],
         'FlagIconCss' => [
             'active' => true,
             'files' => [


### PR DESCRIPTION
### Motivation
- Pages use Bootstrap custom-file inputs and call `bsCustomFileInput` on document ready, which led to `ReferenceError: bsCustomFileInput is not defined` because the library was not registered with AdminLTE.
- The project does not rely on a local `bs-custom-file-input` asset being present in `node_modules`, so registering a CDN-loaded plugin ensures the global is available without changing views.

### Description
- Added a new `BsCustomFileInput` plugin entry to `config/adminlte.php` and set it `active => true` to load `bs-custom-file-input` from jsDelivr. (File: `config/adminlte.php`.)
- The change is configuration-only and makes the global `bsCustomFileInput` object available for existing page scripts that initialize file input labels.

### Testing
- Ran `php -l config/adminlte.php` to verify PHP syntax, which returned no syntax errors. (passed)
- Inspected the resulting diff of `config/adminlte.php` to confirm the plugin entry was added. (passed)
- Verified the local `node_modules/bs-custom-file-input` file is not present, validating the decision to use the CDN. (checked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69e86bd78832dbcd1f972c9e8c02c)