### PR TITLE
Require default customer address/contact when converting pre-orders

### DIFF
--- a/app/Http/Controllers/Workflow/PreOrdersController.php
+++ b/app/Http/Controllers/Workflow/PreOrdersController.php
@@ -8,6 +8,8 @@ use App\Models\Accounting\AccountingPaymentConditions;
 use App\Models\Accounting\AccountingPaymentMethod;
 use App\Models\Accounting\AccountingVat;
 use App\Models\Companies\Companies;
+use App\Models\Companies\CompaniesAddresses;
+use App\Models\Companies\CompaniesContacts;
 use App\Models\Methods\MethodsUnits;
 use App\Models\Products\Products;
 use App\Models\Workflow\OrderLineDetails;
@@ -310,13 +312,32 @@ class PreOrdersController extends Controller
             return redirect()->route('pre-orders.show', $preOrder)->withErrors('Pré-commande vide, impossible de convertir.');
         }
 
-        DB::transaction(function () use ($preOrder, $data) {
+        $defaultAddressId = null;
+        $defaultContactId = null;
+
+        if (! empty($data['companies_id'])) {
+            $defaultAddress = CompaniesAddresses::getDefault(['companies_id' => $data['companies_id']]);
+            $defaultContact = CompaniesContacts::getDefault(['companies_id' => $data['companies_id']]);
+
+            if (is_null($defaultAddress) || is_null($defaultContact)) {
+                return redirect()->route('pre-orders.show', $preOrder)
+                    ->withInput()
+                    ->withErrors("Le client sélectionné ne possède pas d'adresse et/ou de contact par défaut.");
+            }
+
+            $defaultAddressId = $defaultAddress->id;
+            $defaultContactId = $defaultContact->id;
+        }
+
+        DB::transaction(function () use ($preOrder, $data, $defaultAddressId, $defaultContactId) {
             $order = Orders::create([
                 'uuid' => Str::uuid(),
                 'code' => $data['code'],
                 'label' => $data['label'],
                 'customer_reference' => $data['customer_reference'] ?? null,
                 'companies_id' => $data['companies_id'] ?? null,
+                'companies_contacts_id' => $defaultContactId,
+                'companies_addresses_id' => $defaultAddressId,
                 'validity_date' => $data['validity_date'] ?? null,
                 'statu' => 1,
                 'user_id' => $data['user_id'],


### PR DESCRIPTION
### Motivation
- Ensure that when a pre-order is converted to an order the newly created order is linked to the customer's default address and contact if a customer is selected. 
- Prevent creation of orders without default contact/address and return the conversion form with the entered data and a clear error when defaults are missing. 
- Align pre-order conversion behavior with existing patterns used elsewhere (lead → opportunity / opportunity → quote) where defaults are required.

### Description
- Added imports for `CompaniesAddresses` and `CompaniesContacts` and resolve the selected customer’s default address and contact before creating the order in `app/Http/Controllers/Workflow/PreOrdersController.php`. 
- If `companies_id` is provided and a default address or contact cannot be found, the controller returns to the conversion form with `withInput()` and an explicit error message. 
- The created `Orders` record is now populated with `companies_contacts_id` and `companies_addresses_id` using the resolved default IDs. 
- Introduced `defaultAddressId` and `defaultContactId` variables and propagated them into the `DB::transaction` closure used to create the order.

### Testing
- Ran a PHP syntax check with `php -l app/Http/Controllers/Workflow/PreOrdersController.php` and it reported no syntax errors. 
- Attempted to run the test suite filter with `php artisan test --filter=PreOrder --stop-on-failure` but it could not run in this environment due to missing Composer vendor autoload (`vendor/autoload.php`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d22677a0832da006d482aaed3a2a)