### PR TITLE
Add rate limiting to guest routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,11 +25,13 @@ use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 Route::group(['prefix' => LaravelLocalization::setLocale(),
                             'middleware' => [ 'localeSessionRedirect', 'localizationRedirect', 'localeViewPath' ]], function(){
 
-    Route::get('/guest/quote/{uuid}', 'App\Http\Controllers\GuestController@ShowQuoteDocument')->name('guest.quote.show');
-    Route::get('/guest/order/{uuid}', 'App\Http\Controllers\GuestController@ShowOrderDocument')->name('guest.order.show');
-    Route::get('/guest/delivery/{uuid}', 'App\Http\Controllers\GuestController@ShowDeliveryDocument')->name('guest.delivery.show');
-    Route::get('/guest/nonConformitie/{id}', 'App\Http\Controllers\Quality\QualityNonConformityController@createNCFromDelivery')->name('guest.nonConformitie.create');
-    Route::get('/guest/', 'App\Http\Controllers\GuestController@index')->name('guest');
+    Route::middleware(['throttle:60,1'])->group(function () {
+        Route::get('/guest/quote/{uuid}', 'App\Http\Controllers\GuestController@ShowQuoteDocument')->name('guest.quote.show');
+        Route::get('/guest/order/{uuid}', 'App\Http\Controllers\GuestController@ShowOrderDocument')->name('guest.order.show');
+        Route::get('/guest/delivery/{uuid}', 'App\Http\Controllers\GuestController@ShowDeliveryDocument')->name('guest.delivery.show');
+        Route::get('/guest/nonConformitie/{id}', 'App\Http\Controllers\Quality\QualityNonConformityController@createNCFromDelivery')->name('guest.nonConformitie.create');
+        Route::get('/guest/', 'App\Http\Controllers\GuestController@index')->name('guest');
+    });
     Route::get('/pointage', [AttendanceController::class, 'index'])->name('attendance.index');
     Route::post('/pointage', [AttendanceController::class, 'store'])->name('attendance.store');
     //Rating


### PR DESCRIPTION
### Motivation
- Apply rate limiting to publicly accessible guest endpoints to mitigate abuse and control request volume.

### Description
- Wrap the guest routes under `LaravelLocalization` with `Route::middleware(['throttle:60,1'])->group(...)` so endpoints like `guest.quote.show`, `guest.order.show`, `guest.delivery.show`, `guest.nonConformitie.create`, and `guest` are protected by a `60 requests per minute` throttle.

### Testing
- Ran the existing `phpunit` test suite and it completed successfully; no new tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f070e16c832db6c51df008b72a06)