### PR TITLE
Disable quote delivery simulation for users without scheduling permission

### DIFF
--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -198,19 +198,20 @@
               @include('include.sub-total-price')
             </x-adminlte-card>
 
+            @php($canUseScheduling = auth()->user()->can('scheduling-menu'))
             <x-adminlte-card title="{{ __('general_content.delivery_simulation_trans_key') }}" theme="info" collapsible maximizable>
               <form action="{{ route('quotes.delivery.simulation', ['id' => $Quote->id]) }}" method="POST">
                 @csrf
                 <div class="form-group">
                   <label for="requested_delivery_date">{{ __('general_content.requested_delivery_date_trans_key') }}</label>
-                  <input type="date" class="form-control" id="requested_delivery_date" name="requested_delivery_date" value="{{ old('requested_delivery_date') }}" required>
+                  <input type="date" class="form-control" id="requested_delivery_date" name="requested_delivery_date" value="{{ old('requested_delivery_date') }}" @disabled(!$canUseScheduling) required>
                 </div>
-                <button type="submit" class="btn btn-primary btn-sm">
+                <button type="submit" class="btn btn-primary btn-sm" @disabled(!$canUseScheduling)>
                   <i class="fas fa-play-circle"></i> {{ __('general_content.run_simulation_trans_key') }}
                 </button>
               </form>
 
-              @if(session('delivery_simulation'))
+              @if($canUseScheduling && session('delivery_simulation'))
               @php
                 $simulation = session('delivery_simulation');
               @endphp

--- a/routes/web.php
+++ b/routes/web.php
@@ -163,7 +163,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/{idQuote}/edit-detail-lines/{id}', 'App\Http\Controllers\Workflow\QuoteLinesController@update')->name('quotes.update.detail.line');
         Route::post('/{idQuote}/edit-detail-lines/{id}/image', 'App\Http\Controllers\Workflow\QuoteLinesController@StoreImage')->name('quotes.update.detail.picture');
         Route::post('/{idQuote}/lines/import', 'App\Http\Controllers\Workflow\QuoteLinesController@import')->name('quotes.lines.import');
-        Route::post('/{id}/delivery-simulation', 'App\Http\Controllers\Workflow\QuotesController@simulateDelivery')->name('quotes.delivery.simulation');
+        Route::post('/{id}/delivery-simulation', 'App\Http\Controllers\Workflow\QuotesController@simulateDelivery')->middleware('permission:scheduling-menu')->name('quotes.delivery.simulation');
         //Project estimate
         Route::post('project-estimate/save/{id}', 'App\Http\Controllers\Workflow\QuotesController@saveProjectEstimate')->name('quotes.project.estimates');
         //import


### PR DESCRIPTION
### Motivation
- Prevent users who lack scheduling rights from running or viewing delivery lead-time simulations on quote pages to align UI and server-side access control.

### Description
- In `resources/views/workflow/quotes-show.blade.php` disable the requested date input and the "Run simulation" button when `auth()->user()->can('scheduling-menu')` is false, and hide simulation results unless the user has the permission.
- In `routes/web.php` protect the POST route `quotes.delivery.simulation` with the `permission:scheduling-menu` middleware to enforce server-side access control.
- The changes ensure both client-side disabling and server-side route protection to avoid UI circumvention.

### Testing
- Ran `php -l routes/web.php` and it reported no syntax errors (success). 
- Attempted `php artisan route:list --path=quotes | rg "delivery-simulation|quotes.delivery.simulation"` but it failed in this environment because `vendor/autoload.php` is missing (environmental failure, not a code failure).
- Executed an automated browser script that produced a screenshot artifact but the application endpoint returned a Not Found page in this environment, so visual verification is environment-limited (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d68d60f8832d930fdbcc35865d2a)