### PR TITLE
Localize 'Add Task' button label in task management view

### DIFF
--- a/resources/views/livewire/task-manage.blade.php
+++ b/resources/views/livewire/task-manage.blade.php
@@ -208,7 +208,7 @@
                             @if($updateLines)
                             <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.update_trans_key') }}" theme="info" icon="fas fa-lg fa-save"/>
                             @else
-                            <x-adminlte-button class="btn-flat" type="submit" label="Add Task" theme="success" icon="fas fa-lg fa-save"/>
+                            <x-adminlte-button class="btn-flat" type="submit" label="{{ __('general_content.add_trans_key') }} {{ __('general_content.task_trans_key') }}" theme="success" icon="fas fa-lg fa-save"/>
                             @endif
                         @endif
                     </div>


### PR DESCRIPTION
### Motivation
- The `Add Task` button in `resources/views/livewire/task-manage.blade.php` was hardcoded in English which prevented localization for French and other locales.

### Description
- Replace the hardcoded label with `{{ __('general_content.add_trans_key') }} {{ __('general_content.task_trans_key') }}` so the button uses existing translation keys.

### Testing
- Committed the change (`git status --short` showed the modified file and the commit succeeded). 
- Attempted to run `php artisan serve` for visual verification but it failed due to missing dependencies (`vendor/autoload.php`), so runtime verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d7559454832d80ff51605f89c695)