### PR TITLE
Hide delivery simulation card on quote page when scheduling rights disabled

### DIFF
--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -198,6 +198,7 @@
               @include('include.sub-total-price')
             </x-adminlte-card>
 
+            @can('scheduling-menu')
             <x-adminlte-card title="{{ __('general_content.delivery_simulation_trans_key') }}" theme="info" collapsible maximizable>
               <form action="{{ route('quotes.delivery.simulation', ['id' => $Quote->id]) }}" method="POST">
                 @csrf
@@ -263,6 +264,7 @@
                 </div>
               @endif
             </x-adminlte-card>
+            @endcan
 
             @if($Quote->opportunities_id)
               <x-adminlte-card title="{{ __('general_content.historical_trans_key') }}" theme="info"  collapsible="collapsed" maximizable>


### PR DESCRIPTION
### Motivation
- Prevent users without scheduling permissions from seeing or interacting with the "Delivery lead-time simulation" card on the quote detail page.  

### Description
- Wrapped the delivery simulation card (form and results) with `@can('scheduling-menu') ... @endcan` in `resources/views/workflow/quotes-show.blade.php` so the entire card is hidden when the `scheduling-menu` permission is not granted.  

### Testing
- Ran `php artisan view:cache` to validate Blade compilation but it failed due to missing vendor dependencies (`vendor/autoload.php`) so view compilation could not be fully validated (failed).  
- Executed an automated Playwright script to capture a screenshot of the page which ran and produced an artifact, but the application was not served for a full end-to-end rendering verification (script executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7da429ef8832d8a31085d25f03932)