### PR TITLE
Add authentication guard to Livewire store methods

### DIFF
--- a/app/Livewire/CompaniesLines.php
+++ b/app/Livewire/CompaniesLines.php
@@ -128,6 +128,8 @@ class CompaniesLines extends Component
     }
 
     public function storeCompany(){
+        abort_unless(auth()->check(), 403);
+
 
         $this->validate();
             // Create Line

--- a/app/Livewire/DeliverysRequest.php
+++ b/app/Livewire/DeliverysRequest.php
@@ -135,6 +135,8 @@ class DeliverysRequest extends Component
 
     public function storeDeliveryNote()
     {
+        abort_unless(auth()->check(), 403);
+
         // Validate the request
         $this->validate();
     

--- a/app/Livewire/InvoicesRequest.php
+++ b/app/Livewire/InvoicesRequest.php
@@ -112,6 +112,8 @@ class InvoicesRequest extends Component
 
     public function storeInvoice()
     {
+        abort_unless(auth()->check(), 403);
+
         // Validate the request
         $this->validate();
 

--- a/app/Livewire/OrdersIndex.php
+++ b/app/Livewire/OrdersIndex.php
@@ -259,6 +259,8 @@ class OrdersIndex extends Component
     }
 
     public function storeOrder(){
+        abort_unless(auth()->check(), 403);
+
         $this->validate();
 
         if($this->type == 2){

--- a/app/Livewire/QuotesIndex.php
+++ b/app/Livewire/QuotesIndex.php
@@ -220,6 +220,8 @@ class QuotesIndex extends Component
     }
     
     public function storeQuote(){
+        abort_unless(auth()->check(), 403);
+
         $this->validate();
             // Create Line
             $QuotesCreated = Quotes::create([


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated users from invoking public store/create/destroy actions in several Livewire components by enforcing a simple auth check. 
- Keep scope small: only authentication is enforced for now, ownership checks are intentionally omitted.

### Description
- Inserted `abort_unless(auth()->check(), 403);` at the start of public store methods in these files: `app/Livewire/QuotesIndex.php` (`storeQuote`), `app/Livewire/OrdersIndex.php` (`storeOrder`), `app/Livewire/InvoicesRequest.php` (`storeInvoice`), `app/Livewire/DeliverysRequest.php` (`storeDeliveryNote`), and `app/Livewire/CompaniesLines.php` (`storeCompany`).
- No other behavioral changes were made to the methods besides the authentication guard.

### Testing
- Ran PHP lint checks on the modified components with `php -l` for each file and all returned no syntax errors.
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80d15f350832da1c05451e45b193f)