### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/public/vendor/summernote/plugin/databasic/summernote-ext-databasic.js
+++ b/public/vendor/summernote/plugin/databasic/summernote-ext-databasic.js
@@ -169,8 +169,10 @@
     };
 
     self.setContent = function($node) {
-      $node.html('<p contenteditable="false">' + self.icon + ' ' + lang.databasic.name + ': ' +
-        $node.attr('data-test') + '</p>');
+      var $p = $('<p></p>').attr('contenteditable', 'false');
+      var prefix = self.icon + ' ' + lang.databasic.name + ': ';
+      $p.text(prefix + $node.attr('data-test'));
+      $node.empty().append($p);
     };
 
     self.updateNode = function(info) {


### PR DESCRIPTION
Potential fix for [https://github.com/SMEWebify/WebErpMesv2/security/code-scanning/14](https://github.com/SMEWebify/WebErpMesv2/security/code-scanning/14)

In general, the problem is that an attribute value (`data-test`) is being inserted into HTML using `.html()` without escaping. To fix this, the untrusted value must be treated as text, not as HTML. This can be done in two main ways: (1) build the DOM structure using jQuery/DOM APIs and set the untrusted value via `.text()` (preferred), or (2) HTML‑escape the value before concatenating it into the string.

The best fix here, without changing functionality, is to construct the `<p>` element via jQuery and set its textual content via `.text()`. That way, even if `data-test` contains `<script>` or other HTML, it will be displayed as literal text. Concretely, in `self.setContent` (lines 171–174), replace the string concatenation with something like:

- Create a `<p contenteditable="false">` jQuery element.
- Build the label prefix (icon + name + colon + space) as a string.
- Use `.text()` for the dynamic `data-test` part so it is escaped.
- Append the combined text to the `<p>` or, alternately, set the whole text via `.text()`.

This change happens entirely within `public/vendor/summernote/plugin/databasic/summernote-ext-databasic.js`, in the body of `self.setContent`. No new imports or external libraries are needed; only jQuery is used, which is already available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
