### PR TITLE
Add Qonto integration status endpoint and tests

### DIFF
--- a/app/Http/Controllers/Api/Integrations/QontoIntegrationController.php
+++ b/app/Http/Controllers/Api/Integrations/QontoIntegrationController.php
@@ -45,6 +45,24 @@ class QontoIntegrationController extends Controller
         ]);
     }
 
+    public function status(Request $request): JsonResponse
+    {
+        $tenantId = $request->user()->id;
+        $connection = QontoConnection::where('tenant_id', $tenantId)->first();
+
+        $clientId = (string) config('services.qonto.client_id', '');
+        $clientSecret = (string) config('services.qonto.client_secret', '');
+        $featureEnabled = $clientId !== '' && $clientSecret !== '';
+
+        return response()->json([
+            'feature_enabled' => $featureEnabled,
+            'connected' => $connection !== null,
+            'last_sync_at' => $connection?->last_sync_at?->toISOString(),
+            'import_bidirectionnel' => (bool) ($connection?->import_bidirectionnel ?? false),
+            'scope' => $connection?->scope,
+        ]);
+    }
+
     public function callback(Request $request): JsonResponse
     {
         $tenantId = $request->user()->id;

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,7 @@ Route::middleware('auth:api')->group(function () {
 
 
     Route::prefix('integrations/qonto')->name('api.integrations.qonto.')->group(function () {
+        Route::get('/status', [QontoIntegrationController::class, 'status'])->name('status');
         Route::get('/connect', [QontoIntegrationController::class, 'connect'])->name('connect');
         Route::post('/clients/sync', [QontoIntegrationController::class, 'sync'])->name('clients.sync');
         Route::post('/clients/reconcile', [QontoIntegrationController::class, 'reconcile'])->name('clients.reconcile');

--- a/tests/Feature/ApiAuthenticationTest.php
+++ b/tests/Feature/ApiAuthenticationTest.php
@@ -25,6 +25,7 @@ class ApiAuthenticationTest extends TestCase
             ['GET', '/api/companies'],
             ['GET', '/api/exports/sales-orders'],
             ['GET', '/api/collaboration/whiteboards'],
+            ['GET', '/api/integrations/qonto/status'],
             ['GET', '/api/integrations/qonto/connect'],
             ['POST', '/api/integrations/qonto/settings'],
         ];

--- a/tests/Feature/QontoIntegrationApiTest.php
+++ b/tests/Feature/QontoIntegrationApiTest.php
@@ -18,6 +18,52 @@ class QontoIntegrationApiTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_status_reports_feature_disabled_when_missing_credentials(): void
+    {
+        config()->set('services.qonto.client_id', null);
+        config()->set('services.qonto.client_secret', null);
+
+        $this->authenticateApiUser();
+
+        $response = $this->getJson('/api/integrations/qonto/status');
+
+        $response->assertOk()->assertJson([
+            'feature_enabled' => false,
+            'connected' => false,
+            'import_bidirectionnel' => false,
+        ]);
+        $this->assertNull($response->json('last_sync_at'));
+    }
+
+    public function test_status_reports_connection_metadata_when_connected(): void
+    {
+        config()->set('services.qonto.client_id', 'qonto-client-id');
+        config()->set('services.qonto.client_secret', 'qonto-client-secret');
+
+        $user = $this->authenticateApiUser();
+        $lastSyncAt = now()->subHour()->startOfSecond();
+
+        QontoConnection::create([
+            'tenant_id' => $user->id,
+            'access_token' => Crypt::encryptString('token'),
+            'refresh_token' => Crypt::encryptString('refresh'),
+            'access_token_expires_at' => now()->addHour(),
+            'import_bidirectionnel' => true,
+            'last_sync_at' => $lastSyncAt,
+            'scope' => 'offline_access client.read client.write',
+        ]);
+
+        $response = $this->getJson('/api/integrations/qonto/status');
+
+        $response->assertOk()->assertJson([
+            'feature_enabled' => true,
+            'connected' => true,
+            'import_bidirectionnel' => true,
+            'scope' => 'offline_access client.read client.write',
+        ]);
+        $this->assertSame($lastSyncAt->toISOString(), $response->json('last_sync_at'));
+    }
+
     public function test_connect_returns_authorization_url_and_state(): void
     {
         config()->set('services.qonto.client_id', 'qonto-client-id');


### PR DESCRIPTION
### Motivation

- Provide an API endpoint to report whether the Qonto integration feature is enabled and return connection metadata for the current tenant so clients can show integration status.
- Ensure the backend exposes whether credentials are configured and whether a Qonto connection exists for the tenant.

### Description

- Add `status` action to `QontoIntegrationController` that returns `feature_enabled`, `connected`, `last_sync_at`, `import_bidirectionnel`, and `scope` based on config and `QontoConnection` state.
- Register a new route `GET /api/integrations/qonto/status` in `routes/api.php` named `api.integrations.qonto.status`.
- Add feature tests in `tests/Feature/QontoIntegrationApiTest.php` to validate both disabled-credentials and connected-connection scenarios, and update `tests/Feature/ApiAuthenticationTest.php` to include the new endpoint in unauthenticated checks.

### Testing

- Ran the test suite with `vendor/bin/phpunit` and confirmed the updated tests `QontoIntegrationApiTest` and `ApiAuthenticationTest` passed. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d79d722014832d90c26e26482b1e92)