### PR TITLE
fix(qonto): aligne le depot de factures sur la Business API /client_i…

### DIFF
--- a/app/Http/Controllers/Api/Integrations/QontoIntegrationController.php
+++ b/app/Http/Controllers/Api/Integrations/QontoIntegrationController.php
@@ -14,6 +14,7 @@ use App\Models\Workflow\Invoices;
 use App\Services\Integrations\QontoClientSyncService;
 use App\Services\Integrations\QontoConnectionService;
 use App\Services\Integrations\Pdp\PdpInvoiceService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -24,6 +25,15 @@ use Illuminate\Support\Str;
 
 class QontoIntegrationController extends Controller
 {
+    /**
+     * Scopes Qonto requis par l'intégration :
+     * - organization.read  → IBAN du compte, porté par payment_methods.iban
+     * - client.*           → synchronisation des tiers
+     * - client_invoices.read / client_invoice.write → dépôt et suivi des factures
+     *   (le pluriel sur la lecture n'est pas une faute : c'est le nom du scope Qonto)
+     */
+    public const OAUTH_SCOPES = 'offline_access organization.read client.read client.write client_invoices.read client_invoice.write';
+
     public function __construct(
         private QontoClientSyncService  $syncService,
         private QontoConnectionService  $connectionService,
@@ -42,7 +52,7 @@ class QontoIntegrationController extends Controller
             'client_id' => config('services.qonto.client_id'),
             'redirect_uri' => route('api.integrations.qonto.callback', absolute: true),
             'response_type' => 'code',
-            'scope' => 'offline_access client.read client.write',
+            'scope' => self::OAUTH_SCOPES,
             'state' => $state,
         ]);
 
@@ -271,7 +281,16 @@ class QontoIntegrationController extends Controller
             'Seules les factures (type 1) peuvent être soumises à Qonto.'
         );
 
-        $mapping = $this->pdpInvoiceService->submit($invoice);
+        try {
+            $mapping = $this->pdpInvoiceService->submit($invoice);
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'message' => 'Aucune connexion Qonto active : connectez le compte avant de déposer une facture.',
+            ], 422);
+        } catch (\RuntimeException $e) {
+            // Données manquantes ou refus Qonto : le message est destiné à l'utilisateur.
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
 
         return response()->json(['mapping' => $mapping]);
     }

--- a/app/Http/Controllers/Integrations/QontoSettingsController.php
+++ b/app/Http/Controllers/Integrations/QontoSettingsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Integrations;
 
+use App\Http\Controllers\Api\Integrations\QontoIntegrationController;
 use App\Http\Controllers\Controller;
 use App\Models\Customer\Customer;
 use App\Services\Integrations\QontoConnectionService;
@@ -69,7 +70,7 @@ class QontoSettingsController extends Controller
             'client_id'     => config('services.qonto.client_id'),
             'redirect_uri'  => route('admin.integrations.qonto.callback', absolute: true),
             'response_type' => 'code',
-            'scope'         => 'offline_access client.read client.write',
+            'scope'         => QontoIntegrationController::OAUTH_SCOPES,
             'state'         => $state,
         ]);
 

--- a/app/Services/Integrations/Pdp/Drivers/QontoGateway.php
+++ b/app/Services/Integrations/Pdp/Drivers/QontoGateway.php
@@ -2,7 +2,6 @@
 
 namespace App\Services\Integrations\Pdp\Drivers;
 
-use App\Http\Controllers\PrintController;
 use App\Models\Integrations\QontoClientMapping;
 use App\Models\Workflow\Invoices;
 use App\Services\Integrations\Pdp\Contracts\PdpGateway;
@@ -11,16 +10,27 @@ use App\Services\Integrations\Pdp\Data\PdpWebhookEvent;
 use App\Services\Integrations\Pdp\Enums\PdpLifecycle;
 use App\Services\Integrations\Pdp\Exceptions\PdpSignatureException;
 use App\Services\Integrations\QontoConnectionService;
+use App\Services\InvoiceCalculatorService;
+use Carbon\Carbon;
+use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 /**
- * Driver PDP pour Qonto.
+ * Driver Qonto, branché sur la Business API v2 (`/client_invoices`).
  *
- * Encapsule l'I/O HTTP (OAuth via QontoConnectionService), le dépôt de la
- * facture Factur-X, l'interrogation de statut, et la vérification/traduction
- * des webhooks signés HMAC-SHA256.
+ * WEM reste la source de vérité : numérotation, prix, TVA et comptabilité sont
+ * calculés ici, puis poussés en **données structurées**. C'est Qonto qui produit
+ * le document (PDF / Factur-X) à partir de ce payload — on ne lui envoie jamais
+ * notre propre PDF, sans quoi la conformité du document reposerait sur nous.
+ *
+ * Périmètre : facturation commerciale Qonto. Le champ `einvoicing_status` renvoyé
+ * par l'API (canal Plateforme Agréée) est journalisé mais volontairement pas
+ * interprété ici — il relève du raccordement PDP, traité séparément.
+ *
+ * @see https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/client-invoices
  */
 class QontoGateway implements PdpGateway
 {
@@ -38,28 +48,25 @@ class QontoGateway implements PdpGateway
 
     public function submit(Invoices $invoice): PdpInvoiceResult
     {
-        $tenantId = $invoice->user_id;
+        $tenantId = (int) $invoice->user_id;
         $token    = $this->connectionService->getValidToken($tenantId);
 
-        $pdfContent = $this->generateFactureXContent($invoice);
-
         $response = Http::withToken($token)
-            ->attach('file', $pdfContent, $invoice->code . '.pdf', ['Content-Type' => 'application/pdf'])
-            ->post("{$this->baseUrl()}/invoices", [
-                'invoice_number' => $invoice->code,
-                'issue_date'     => $invoice->created_at->format('Y-m-d'),
-                'due_date'       => $invoice->due_date,
-                'currency'       => 'EUR',
-                'client_id'      => $this->resolveClientId($tenantId, $invoice->companies_id),
-            ])
-            ->throw()
-            ->json();
+            ->asJson()
+            ->post("{$this->baseUrl()}/client_invoices", $this->buildPayload($invoice, $tenantId));
 
-        $externalId = $response['invoice']['id'] ?? $response['id'] ?? null;
+        $this->guardAgainstRejection($response, $invoice);
 
-        Log::info('QontoGateway: submitted', ['invoice_id' => $invoice->id, 'external_id' => $externalId]);
+        $clientInvoice = (array) $response->json('client_invoice', []);
+        $externalId    = $clientInvoice['id'] ?? null;
 
-        return new PdpInvoiceResult($externalId, PdpLifecycle::Submitted, null, $response ?? []);
+        Log::info('QontoGateway: client invoice created', [
+            'invoice_id'  => $invoice->id,
+            'external_id' => $externalId,
+            'status'      => $clientInvoice['status'] ?? null,
+        ]);
+
+        return $this->toResult($externalId, $clientInvoice, $response->json() ?? []);
     }
 
     public function poll(string $externalId, int $tenantId): PdpInvoiceResult
@@ -67,17 +74,19 @@ class QontoGateway implements PdpGateway
         $token = $this->connectionService->getValidToken($tenantId);
 
         $response = Http::withToken($token)
-            ->get("{$this->baseUrl()}/invoices/{$externalId}")
-            ->throw()
-            ->json();
+            ->get("{$this->baseUrl()}/client_invoices/{$externalId}")
+            ->throw();
 
-        $status    = $response['invoice']['status'] ?? $response['status'] ?? null;
-        $lifecycle = $this->mapProviderStatus($status) ?? PdpLifecycle::Submitted;
-        $reason    = $response['invoice']['rejection_reason'] ?? $response['rejection_reason'] ?? null;
-
-        return new PdpInvoiceResult($externalId, $lifecycle, $reason, $response ?? []);
+        return $this->toResult($externalId, (array) $response->json('client_invoice', []), $response->json() ?? []);
     }
 
+    /**
+     * Qonto ne publie aujourd'hui aucun événement webhook sur les client_invoices
+     * (seuls les événements `registrations.*` de l'Onboarding API sont documentés).
+     * L'endpoint est donc opérationnel mais inerte : le mécanisme fiable de suivi
+     * reste le polling. La correspondance ci-dessous est prête si Qonto ouvre ces
+     * événements ; tout autre payload est ignoré après vérification de signature.
+     */
     public function parseWebhook(Request $request): ?PdpWebhookEvent
     {
         if (! $this->verifySignature($request)) {
@@ -85,24 +94,23 @@ class QontoGateway implements PdpGateway
         }
 
         $payload = $request->json()->all();
-        $event   = (string) ($payload['event_type'] ?? '');
+        $event   = (string) ($payload['event'] ?? $payload['event_type'] ?? '');
 
-        // Événement non lié aux factures (transaction, attachment…) → à ignorer.
-        if (! str_starts_with($event, 'invoice.')) {
+        if (! str_starts_with($event, 'client_invoice.')) {
             return null;
         }
 
-        $externalId = $payload['data']['id'] ?? $payload['invoice']['id'] ?? null;
-        $lifecycle  = $this->mapEvent($event);
+        $clientInvoice = $payload['data']['client_invoice'] ?? $payload['client_invoice'] ?? $payload['data'] ?? [];
+        $clientInvoice = is_array($clientInvoice) ? $clientInvoice : [];
+        $externalId    = $clientInvoice['id'] ?? null;
+        $lifecycle     = $this->mapStatus($clientInvoice['status'] ?? null) ?? $this->mapEvent($event);
 
         if (! $externalId || ! $lifecycle) {
             Log::warning('QontoGateway: unprocessable webhook', ['event' => $event]);
             return null;
         }
 
-        $reason = $payload['invoice']['rejection_reason'] ?? $payload['rejection_reason'] ?? null;
-
-        return new PdpWebhookEvent($externalId, $lifecycle, $reason, $payload);
+        return new PdpWebhookEvent((string) $externalId, $lifecycle, null, $payload);
     }
 
     private function baseUrl(): string
@@ -110,26 +118,217 @@ class QontoGateway implements PdpGateway
         return rtrim(config('services.qonto.api_base_url', 'https://thirdparty.qonto.com/v2'), '/');
     }
 
-    /** Traduit un statut renvoyé par l'API Qonto vers le vocabulaire canonique. */
-    private function mapProviderStatus(?string $status): ?PdpLifecycle
+    /**
+     * Payload de création d'une client_invoice.
+     *
+     * `status: unpaid` crée la facture directement finalisée : elle est déjà
+     * validée dans WEM, la laisser en `draft` imposerait un second appel
+     * (POST /client_invoices/{id}/finalize) sans rien apporter.
+     */
+    private function buildPayload(Invoices $invoice, int $tenantId): array
     {
-        return $status ? PdpLifecycle::tryFrom($status) : null;
+        $currency = $this->currency();
+
+        $payload = [
+            'client_id'       => $this->resolveClientId($tenantId, (int) $invoice->companies_id, $invoice),
+            'number'          => Str::limit((string) $invoice->code, 40, ''),
+            'issue_date'      => Carbon::parse($invoice->created_at)->format('Y-m-d'),
+            'due_date'        => $this->resolveDueDate($invoice),
+            'currency'        => $currency,
+            'status'          => 'unpaid',
+            'payment_methods' => ['iban' => $this->connectionService->getInvoicingIban($tenantId)],
+            'items'           => $this->buildItems($invoice, $currency),
+        ];
+
+        if ($invoice->customer_reference) {
+            $payload['purchase_order'] = Str::limit((string) $invoice->customer_reference, 40, '');
+        }
+
+        return $payload;
     }
 
-    /** Traduit un type d'événement webhook Qonto vers le vocabulaire canonique. */
-    private function mapEvent(string $event): ?PdpLifecycle
+    /**
+     * Lignes de facture au format Qonto, construites depuis le snapshot de prix
+     * figé sur invoice_lines (même source que le PDF et le Factur-X internes).
+     *
+     * Remise : transmise telle quelle en pourcentage plutôt que fondue dans le
+     * prix net, pour que le document Qonto affiche la même chose que le nôtre.
+     */
+    private function buildItems(Invoices $invoice, string $currency): array
     {
-        return match ($event) {
-            'invoice.submitted'    => PdpLifecycle::Submitted,
-            'invoice.acknowledged' => PdpLifecycle::Acknowledged,
-            'invoice.rejected'     => PdpLifecycle::Rejected,
-            'invoice.refused'      => PdpLifecycle::Refused,
-            'invoice.accepted'     => PdpLifecycle::Accepted,
-            'invoice.paid'         => PdpLifecycle::Paid,
-            default                => null,
+        $items = [];
+
+        foreach ((new InvoiceCalculatorService($invoice))->getNormalizedLines() as $line) {
+            $label = trim((string) $line['label']);
+            $code  = trim((string) $line['code']);
+            $title = $label !== '' ? $label : $code;
+
+            $item = [
+                'title'      => Str::limit($title !== '' ? $title : 'Ligne de facture', 40, ''),
+                'quantity'   => $this->decimal($line['qty'], 4),
+                'unit_price' => [
+                    // Qonto stocke les prix au cent (unit_price_cents) : au-delà de
+                    // 2 décimales, la valeur serait arrondie côté plateforme.
+                    'value'    => $this->decimal($line['unit_price'], 2),
+                    'currency' => $currency,
+                ],
+                // Qonto attend un ratio ('0.2'), WEM stocke un pourcentage (20).
+                'vat_rate'   => $this->decimal($line['vat_rate'] / 100, 4),
+            ];
+
+            $description = trim(implode(' — ', array_filter([$code, $label])));
+            if ($description !== '' && $description !== $item['title']) {
+                $item['description'] = Str::limit($description, 1800, '');
+            }
+
+            if (! empty($line['unit_code'])) {
+                $item['unit'] = Str::limit((string) $line['unit_code'], 20, '');
+            }
+
+            if ((float) $line['discount'] > 0) {
+                $item['discount'] = [
+                    'type'  => 'percentage',
+                    'value' => $this->decimal($line['discount'], 2),
+                ];
+            }
+
+            $items[] = $item;
+        }
+
+        if ($items === []) {
+            throw new \RuntimeException("La facture #{$invoice->id} n'a aucune ligne : rien à déposer chez Qonto.");
+        }
+
+        return $items;
+    }
+
+    /** Résout l'ID Qonto du client WEM ; obligatoire pour créer une facture. */
+    private function resolveClientId(int $tenantId, int $companyId, Invoices $invoice): string
+    {
+        $clientId = QontoClientMapping::where('tenant_id', $tenantId)
+            ->where('wem_client_id', $companyId)
+            ->whereNotNull('qonto_client_id')
+            ->value('qonto_client_id');
+
+        if (! $clientId) {
+            throw new \RuntimeException(
+                "Aucun client Qonto associé à l'entreprise #{$companyId} (facture {$invoice->code}). "
+                .'Lancez la synchronisation des clients avant de déposer la facture.'
+            );
+        }
+
+        return (string) $clientId;
+    }
+
+    /** `due_date` est obligatoire côté Qonto ; on ne l'invente pas sur un document légal. */
+    private function resolveDueDate(Invoices $invoice): string
+    {
+        if (! $invoice->due_date) {
+            throw new \RuntimeException(
+                "La facture {$invoice->code} n'a pas de date d'échéance : renseignez-la avant le dépôt."
+            );
+        }
+
+        return Carbon::parse($invoice->due_date)->format('Y-m-d');
+    }
+
+    private function currency(): string
+    {
+        return app('Factory')->curency ?? 'EUR';
+    }
+
+    private function decimal(float|int|string $value, int $precision): string
+    {
+        return number_format((float) $value, $precision, '.', '');
+    }
+
+    /** Transforme une erreur d'API en message exploitable dans l'UI. */
+    private function guardAgainstRejection(Response $response, Invoices $invoice): void
+    {
+        if ($response->successful()) {
+            return;
+        }
+
+        if ($response->status() === 409) {
+            throw new \RuntimeException(
+                "Le numéro {$invoice->code} correspond déjà à une facture Qonto : "
+                .'utilisez « Actualiser le statut » plutôt qu\'un nouveau dépôt.'
+            );
+        }
+
+        if (in_array($response->status(), [400, 422], true)) {
+            throw new \RuntimeException(
+                "Qonto a refusé la facture {$invoice->code} : ".$this->formatErrors($response->json() ?? [])
+            );
+        }
+
+        $response->throw();
+    }
+
+    private function formatErrors(array $body): string
+    {
+        $errors = collect($body['errors'] ?? [])
+            ->map(fn ($error) => is_array($error) ? ($error['detail'] ?? $error['code'] ?? json_encode($error)) : (string) $error)
+            ->filter()
+            ->implode(' ; ');
+
+        return $errors !== '' ? $errors : ($body['message'] ?? 'erreur inconnue');
+    }
+
+    /** Normalise une réponse client_invoice vers le vocabulaire canonique. */
+    private function toResult(?string $externalId, array $clientInvoice, array $raw): PdpInvoiceResult
+    {
+        $status    = $clientInvoice['status'] ?? null;
+        $lifecycle = $this->mapStatus($status);
+
+        if (! $lifecycle) {
+            Log::warning('QontoGateway: unknown client invoice status', [
+                'external_id' => $externalId,
+                'status'      => $status,
+            ]);
+            $lifecycle = PdpLifecycle::Submitted;
+        }
+
+        // Canal Plateforme Agréée : conservé dans raw et journalisé, non interprété.
+        if (! empty($clientInvoice['einvoicing_status'])) {
+            Log::info('QontoGateway: einvoicing status reported', [
+                'external_id'       => $externalId,
+                'einvoicing_status' => $clientInvoice['einvoicing_status'],
+            ]);
+        }
+
+        return new PdpInvoiceResult($externalId, $lifecycle, null, $raw);
+    }
+
+    /** Statut commercial Qonto → vocabulaire canonique. */
+    private function mapStatus(?string $status): ?PdpLifecycle
+    {
+        return match ($status) {
+            'draft'    => PdpLifecycle::Pending,
+            'unpaid'   => PdpLifecycle::Submitted,
+            'paid'     => PdpLifecycle::Paid,
+            'canceled' => PdpLifecycle::Canceled,
+            default    => null,
         };
     }
 
+    /** Repli si un webhook ne porte pas l'objet complet (cf. parseWebhook). */
+    private function mapEvent(string $event): ?PdpLifecycle
+    {
+        return match ($event) {
+            'client_invoice.created'   => PdpLifecycle::Pending,
+            'client_invoice.finalized' => PdpLifecycle::Submitted,
+            'client_invoice.paid'      => PdpLifecycle::Paid,
+            'client_invoice.canceled'  => PdpLifecycle::Canceled,
+            default                    => null,
+        };
+    }
+
+    /**
+     * Signature Qonto : HMAC-SHA256 hexadécimal du corps brut, avec le secret
+     * fourni par nos soins lors de l'abonnement (POST /data_api/webhooks),
+     * transmis dans l'en-tête `Qonto-SHA256-Signature` (sans préfixe).
+     */
     private function verifySignature(Request $request): bool
     {
         $secret = config('services.qonto.webhook_secret', '');
@@ -143,35 +342,9 @@ class QontoGateway implements PdpGateway
             return true;
         }
 
-        $signature = $request->header('X-Qonto-Signature-256', '');
-        $expected  = 'sha256=' . hash_hmac('sha256', $request->getContent(), $secret);
+        $signature = (string) $request->header('Qonto-SHA256-Signature', '');
+        $expected  = hash_hmac('sha256', $request->getContent(), $secret);
 
         return hash_equals($expected, $signature);
-    }
-
-    /**
-     * Génère le contenu binaire du PDF Factur-X en réutilisant la logique Zugferd
-     * de PrintController (qui écrit le fichier sur disque), puis le relit.
-     */
-    private function generateFactureXContent(Invoices $invoice): string
-    {
-        app(PrintController::class)->getInvoiceFactureX($invoice);
-
-        $path = public_path('pdf/invoices/' . __('general_content.invoice_trans_key') . '-' . $invoice->id . '.pdf');
-
-        if (! file_exists($path)) {
-            throw new \RuntimeException("Factur-X PDF not found at {$path} for invoice #{$invoice->id}");
-        }
-
-        return file_get_contents($path);
-    }
-
-    /** Résout l'ID Qonto du client WEM correspondant à une entreprise. */
-    private function resolveClientId(int $tenantId, int $companyId): ?string
-    {
-        return QontoClientMapping::where('tenant_id', $tenantId)
-            ->where('wem_client_id', $companyId)
-            ->whereNotNull('qonto_client_id')
-            ->value('qonto_client_id');
     }
 }

--- a/app/Services/Integrations/Pdp/Enums/PdpLifecycle.php
+++ b/app/Services/Integrations/Pdp/Enums/PdpLifecycle.php
@@ -9,13 +9,14 @@ namespace App\Services\Integrations\Pdp\Enums;
  */
 enum PdpLifecycle: string
 {
-    case Pending      = 'pending';      // non encore soumise
-    case Submitted    = 'submitted';    // déposée chez la PDP
+    case Pending      = 'pending';      // non encore soumise (ou brouillon côté plateforme)
+    case Submitted    = 'submitted';    // déposée / émise chez la plateforme
     case Acknowledged = 'acknowledged'; // accusé de réception PDP
     case Rejected     = 'rejected';     // rejetée (format / données invalides)
     case Refused      = 'refused';      // refusée par le destinataire
     case Accepted     = 'accepted';     // acceptée par le destinataire
     case Paid         = 'paid';         // encaissée
+    case Canceled     = 'canceled';     // annulée côté plateforme
 
     /**
      * Correspondance vers le statut interne WEM (colonne invoices.statu).
@@ -30,6 +31,7 @@ enum PdpLifecycle: string
             self::Refused                   => 4,     // Impayée
             self::Accepted                  => 3,     // En attente de paiement
             self::Paid                      => 5,     // Payée
+            self::Canceled                  => 1,     // Retour en cours (à retraiter)
         };
     }
 }

--- a/app/Services/Integrations/QontoConnectionService.php
+++ b/app/Services/Integrations/QontoConnectionService.php
@@ -53,6 +53,47 @@ class QontoConnectionService
     }
 
     /**
+     * IBAN du compte Qonto à faire figurer sur les factures émises
+     * (`payment_methods.iban`, obligatoire à la création d'une client_invoice).
+     *
+     * Résolu une fois puis mis en cache sur la connexion. Nécessite le scope
+     * `organization.read`.
+     *
+     * @throws \RuntimeException si aucun compte bancaire n'est exposé par Qonto
+     */
+    public function getInvoicingIban(int $tenantId): string
+    {
+        $connection = $this->getValidConnection($tenantId);
+
+        if ($connection->iban) {
+            return $connection->iban;
+        }
+
+        $organization = Http::withToken(Crypt::decryptString($connection->access_token))
+            ->get(rtrim(config('services.qonto.api_base_url', 'https://thirdparty.qonto.com/v2'), '/').'/organization')
+            ->throw()
+            ->json('organization', []);
+
+        $accounts = $organization['bank_accounts'] ?? [];
+        $main     = collect($accounts)->firstWhere('main', true) ?? ($accounts[0] ?? null);
+        $iban     = $main['iban'] ?? null;
+
+        if (! $iban) {
+            throw new \RuntimeException(
+                'Aucun IBAN Qonto disponible : vérifiez que le scope organization.read est accordé.'
+            );
+        }
+
+        // iban et organization_slug sont castés (encrypted / string) : on assigne en clair.
+        $connection->forceFill([
+            'iban'              => $iban,
+            'organization_slug' => $organization['slug'] ?? $connection->organization_slug,
+        ])->save();
+
+        return $iban;
+    }
+
+    /**
      * Vérifie si l'intégration Qonto est activée (credentials présents).
      */
     public static function isEnabled(): bool

--- a/docs/integration-qonto.md
+++ b/docs/integration-qonto.md
@@ -4,15 +4,39 @@
 
 L'intégration Qonto couvre deux périmètres :
 1. **Synchronisation des clients** — mise en correspondance des tiers WEM ↔ Qonto
-2. **Facturation électronique** — dépôt des factures au format Factur-X/EN16931 et suivi du cycle de vie, en conformité avec la réforme de facturation électronique obligatoire (sept. 2026 grandes entreprises / 2027 PME)
+2. **Facturation commerciale** — dépôt des factures WEM dans Qonto (`/v2/client_invoices`) et suivi de leur statut
+
+> **Périmètre — à lire avant toute évolution.**
+> Cette intégration s'appuie sur la **Business API** de Qonto, c'est-à-dire son outil de
+> facturation commerciale. Ce n'est **pas** le canal Plateforme Agréée (ex-PDP) : elle ne
+> réalise donc pas, en l'état, l'émission conforme au sens de la réforme (réception
+> obligatoire au 1er sept. 2026, émission PME 2027).
+>
+> Qonto est bien immatriculé Plateforme Agréée, mais son API de dépôt PDP n'est pas
+> documentée publiquement. Le champ `einvoicing_status` renvoyé par `/client_invoices`
+> est le point de raccordement naturel le jour où ce canal sera ouvert aux éditeurs :
+> il est conservé dans la réponse brute et journalisé, mais volontairement **non
+> interprété** par le driver.
 
 **Sens de la synchronisation clients :**
 - **WEM → Qonto** : les clients WEM sont créés/liés dans Qonto (toujours actif)
 - **Qonto → WEM** : les tiers Qonto non trouvés dans WEM créent des entreprises/contacts (optionnel, toggle)
 
 **Sens de la synchronisation factures :**
-- **WEM → Qonto** : dépôt du PDF Factur-X via l'API (manuel depuis la fiche facture)
-- **Qonto → WEM** : mise à jour automatique du statut WEM via webhook
+- **WEM → Qonto** : dépôt des **données structurées** de la facture (manuel depuis la fiche facture)
+- **Qonto → WEM** : mise à jour du statut WEM par polling (« Actualiser le statut »)
+
+### Qui produit quoi
+
+WEM reste la source de vérité : numérotation, prix, remises, TVA, écritures comptables et
+export FEC. On envoie à Qonto le **JSON structuré** de la facture, et c'est Qonto qui génère
+le document. Notre PDF Factur-X (`PrintController::getInvoiceFactureX`) reste utilisé pour
+l'archivage et l'envoi direct au client, mais n'est **pas** transmis à Qonto : envoyer un PDF
+ferait reposer la conformité du document sur nous plutôt que sur la plateforme.
+
+Corollaire : un bon de livraison n'est jamais envoyé à Qonto. Une facture WEM agrège des
+lignes issues de plusieurs BL (`invoice_lines.delivery_line_id`), et couvre aussi les cas
+sans BL (acomptes, prestations, avoirs).
 
 ---
 
@@ -33,13 +57,27 @@ Les variables `QONTO_CLIENT_ID` et `QONTO_CLIENT_SECRET` sont obligatoires pour 
 - Le bloc Qonto n'apparaît pas sur la fiche facture
 - La colonne statut Qonto n'apparaît pas dans la liste des factures
 
-`QONTO_WEBHOOK_SECRET` est optionnel en dev/test mais **obligatoire en production** pour valider la signature des webhooks entrants.
+`QONTO_WEBHOOK_SECRET` est le secret que **nous** choisissons et transmettons à Qonto lors de
+l'abonnement (`POST /data_api/webhooks`). Voir la section Webhook pour la limite actuelle.
 
 ### Scopes OAuth requis
 
 ```
-offline_access  client.read  client.write
+offline_access  organization.read  client.read  client.write  client_invoices.read  client_invoice.write
 ```
+
+Définis une seule fois dans `QontoIntegrationController::OAUTH_SCOPES`, réutilisés par le
+contrôleur web. Le pluriel de `client_invoices.read` face au singulier de
+`client_invoice.write` n'est pas une coquille : ce sont les noms exacts des scopes Qonto.
+
+`organization.read` sert à découvrir l'IBAN du compte (`GET /v2/organization`), obligatoire
+dans `payment_methods.iban` à la création d'une facture. Il est résolu une fois puis mis en
+cache chiffré dans `qonto_connections.iban`.
+
+> ⚠️ **Les connexions établies avant cette liste de scopes doivent être refaites.** Un token
+> obtenu avec les anciens scopes (`offline_access client.read client.write`) sera refusé en
+> 403 sur `/client_invoices` et `/organization` : le refresh ne réélargit pas les droits.
+> Déconnecter puis reconnecter le compte depuis `/admin/integrations/qonto`.
 
 ---
 
@@ -55,7 +93,7 @@ offline_access  client.read  client.write
 | `app/Services/Integrations/QontoConnectionService.php` | Gestion centralisée du token OAuth |
 | `app/Services/Integrations/QontoClientSyncService.php` | Logique de réconciliation clients |
 | `app/Services/Integrations/Pdp/Contracts/PdpGateway.php` | Contrat PDP (driver) — agnostique fournisseur |
-| `app/Services/Integrations/Pdp/Drivers/QontoGateway.php` | Driver Qonto : I/O HTTP, Factur-X, webhooks |
+| `app/Services/Integrations/Pdp/Drivers/QontoGateway.php` | Driver Qonto : I/O HTTP `/client_invoices`, mapping de statuts, webhooks |
 | `app/Services/Integrations/Pdp/PdpInvoiceService.php` | Orchestration agnostique (persistance + cycle de vie) |
 | `app/Services/Integrations/Pdp/PdpManager.php` | Registre/résolveur des drivers PDP |
 | `app/Services/Integrations/Pdp/Enums/PdpLifecycle.php` | Statuts canoniques + mapping WEM |
@@ -252,7 +290,51 @@ Auth : `auth:api` (token bearer)
 
 ---
 
-## Facturation électronique
+## Facturation
+
+### Dépôt d'une facture
+
+`POST /v2/client_invoices`, corps **JSON** (jamais de PDF en multipart).
+
+| Champ Qonto | Source WEM |
+|---|---|
+| `client_id` | `qonto_client_mappings.qonto_client_id` (obligatoire — dépôt refusé sans mapping) |
+| `number` | `invoices.code`, tronqué à 40 caractères |
+| `issue_date` | `invoices.created_at` |
+| `due_date` | `invoices.due_date` (obligatoire — jamais inventée, erreur explicite si absente) |
+| `currency` | `Factory.curency`, défaut `EUR` |
+| `status` | `unpaid` — la facture est déjà validée dans WEM, inutile de passer par `draft` puis `POST /finalize` |
+| `payment_methods.iban` | `qonto_connections.iban` (découvert via `GET /v2/organization`) |
+| `purchase_order` | `invoices.customer_reference` si renseignée |
+| `items[]` | `InvoiceCalculatorService::getNormalizedLines()` |
+
+Les lignes viennent du **snapshot de prix figé sur `invoice_lines`** — même source que le PDF
+et le Factur-X internes, donc pas de divergence possible entre les deux documents.
+
+| Champ item | Construction |
+|---|---|
+| `title` | `label` de la ligne (repli sur `code`), tronqué à 40 |
+| `description` | `code — label` si différent du titre |
+| `quantity` | décimal, 4 chiffres |
+| `unit` | code unité (`methods_units`), tronqué à 20 |
+| `unit_price.value` | **2 décimales** — Qonto stocke au cent (`unit_price_cents`) |
+| `vat_rate` | **ratio** (`0.2000`), alors que WEM stocke un pourcentage (`20`) |
+| `discount` | `{type: percentage, value}` — transmise séparément plutôt que fondue dans le prix net, pour que le document Qonto affiche la même chose que le nôtre |
+
+> **Limite connue** : un prix unitaire à plus de 2 décimales (petites pièces facturées au
+> millième d'euro) est arrondi au cent lors du dépôt. Le total Qonto peut alors différer de
+> quelques centimes du total WEM sur de grandes quantités.
+
+Erreurs traduites en message utilisateur (HTTP 422 sur `/submit`) :
+
+| Situation | Message |
+|---|---|
+| Pas de connexion Qonto | « Aucune connexion Qonto active… » |
+| Entreprise non mappée | « Aucun client Qonto associé à l'entreprise #X… » |
+| `due_date` absente | « …n'a pas de date d'échéance… » |
+| Facture sans ligne | « …n'a aucune ligne… » |
+| 409 Qonto (numéro déjà pris) | « …utilisez Actualiser le statut plutôt qu'un nouveau dépôt » |
+| 400/422 Qonto | détail des `errors[].detail` renvoyés par l'API |
 
 ### Table `pdp_invoice_submissions`
 
@@ -269,40 +351,53 @@ Auth : `auth:api` (token bearer)
 
 ### Cycle de vie et mapping vers WEM
 
-| Lifecycle Qonto | Signification | → `invoices.statu` WEM |
+`PdpLifecycle` est le vocabulaire **canonique**, indépendant de la plateforme. Le driver Qonto
+n'alimente aujourd'hui que les quatre premières lignes ; les statuts `acknowledged`, `rejected`,
+`refused` et `accepted` sont réservés à un futur canal Plateforme Agréée.
+
+| Statut Qonto | PdpLifecycle | → `invoices.statu` WEM |
 |---|---|---|
-| `pending` | Non encore soumise | aucun changement |
-| `submitted` | Déposée chez Qonto | 2 (Envoyée) |
-| `acknowledged` | Accusé réception Qonto | 2 (Envoyée) |
-| `rejected` | Rejetée (format / données) | 1 (En cours) |
-| `refused` | Refusée par le destinataire | 4 (Impayée) |
-| `accepted` | Acceptée par le destinataire | 3 (En attente) |
-| `paid` | Payée côté Qonto | 5 (Payée) |
+| `draft` | `pending` | aucun changement |
+| `unpaid` | `submitted` | 2 (Envoyée) |
+| `paid` | `paid` | 5 (Payée) |
+| `canceled` | `canceled` | 1 (En cours) |
+| — | `acknowledged` | 2 (Envoyée) |
+| — | `rejected` | 1 (En cours) |
+| — | `refused` | 4 (Impayée) |
+| — | `accepted` | 3 (En attente) |
+
+Un statut Qonto inconnu est journalisé (`warning`) et retombe sur `submitted` sans écraser
+la facture WEM de façon silencieuse.
 
 ### Webhook
 
 **URL** : `POST /api/integrations/qonto/webhook/invoice`  
-**Auth** : Aucune — signature HMAC-SHA256 vérifiée via `X-Qonto-Signature-256`  
-**Secret** : `QONTO_WEBHOOK_SECRET` dans `.env`  
+**Auth** : Aucune — HMAC-SHA256 **hexadécimal** du corps brut, en-tête `Qonto-SHA256-Signature` (sans préfixe)  
+**Secret** : `QONTO_WEBHOOK_SECRET`, à transmettre à Qonto via `POST /data_api/webhooks` (`callback_url` + `secret`)
 
-Événements traités : `invoice.submitted`, `invoice.acknowledged`, `invoice.rejected`, `invoice.refused`, `invoice.accepted`, `invoice.paid`
+> **Endpoint inerte à ce jour.** Qonto ne documente des webhooks que pour l'Onboarding API
+> (`registrations.*`) ; aucun événement `client_invoice.*` n'est publié. La signature est
+> vérifiée correctement et la correspondance d'événements est prête, mais **le mécanisme de
+> suivi réellement supporté est le polling**. Aucun abonnement n'est créé automatiquement.
 
-> Si `QONTO_WEBHOOK_SECRET` est absent, la signature n'est pas vérifiée (log warning). À configurer impérativement en production.
+> Si `QONTO_WEBHOOK_SECRET` est absent, la signature n'est pas vérifiée hors production (log
+> warning) ; en production le webhook est rejeté.
 
 ### API REST — factures
 
 | Endpoint | Méthode | Description |
 |---|---|---|
-| `/api/integrations/qonto/invoices/{id}/submit` | POST | Soumet la facture (PDF Factur-X) à Qonto |
+| `/api/integrations/qonto/invoices/{id}/submit` | POST | Crée la facture chez Qonto à partir des données structurées |
 | `/api/integrations/qonto/invoices/{id}/poll` | POST | Interroge Qonto pour mettre à jour le statut |
 
 ### Interface facture
 
-Le bloc **"Facturation électronique — Qonto"** apparaît sur la fiche facture uniquement si :
+Le bloc **"Facturation Qonto"** apparaît sur la fiche facture uniquement si :
 - `QONTO_CLIENT_ID` et `QONTO_CLIENT_SECRET` sont configurés
 - La facture est de type 1 (Facture, pas avoir / proforma)
 
-Il affiche le statut lifecycle courant, la date de dépôt, le motif de rejet éventuel, et les boutons Soumettre / Actualiser.
+Il affiche le statut courant, la date de dépôt, le motif d'erreur éventuel, et les boutons
+Déposer / Actualiser.
 
 ### Liste des factures
 
@@ -321,6 +416,15 @@ L'API Qonto Partner v2 utilise `registration_number` pour le SIREN. Le champ `si
 ### Données existantes
 Si des mappings ont été créés avant la correction (`wem_client_id` = `customer->id`), une migration manuelle est nécessaire pour les convertir en `company->id`.
 
+### Chiffrement de `qonto_connections`
+`iban` et `organization_slug` sont écrits **en clair** dans le modèle : le cast `encrypted`
+fait le chiffrement. Ne pas ajouter de `Crypt::encryptString()` par-dessus.
+
+À l'inverse, `access_token` et `refresh_token` sont écrits déjà chiffrés **en plus** du cast
+(double chiffrement, symétrique donc fonctionnel) — c'est incohérent mais volontairement
+laissé en l'état pour ne pas casser les connexions existantes. Toute uniformisation impose
+une migration de ré-encodage des lignes existantes.
+
 ---
 
 ## Tests
@@ -335,3 +439,10 @@ Fichier : `tests/Feature/QontoIntegrationApiTest.php`
 | `test_sync_creates_review_when_matching_is_ambiguous` | Match ambigu → `review_required` en base |
 | `test_settings_persist_bidirectional_import_flag` | Toggle bidirectionnel persisté |
 | `test_resolve_links_review_to_mapping` | Action `link` crée le mapping |
+| `test_submit_invoice_posts_structured_payload_to_client_invoices` | URL `/client_invoices`, JSON, IBAN, quantité/prix/TVA/remise au format Qonto |
+| `test_submit_invoice_fails_cleanly_when_client_is_not_mapped` | 422 explicite, aucun appel HTTP, aucune ligne de suivi créée |
+| `test_poll_maps_paid_status_to_wem_paid_status` | `paid` Qonto → `invoices.statu = 5` |
+
+> Les appels Qonto sont mockés (`Http::fake`) : ces tests valident le **format** du payload
+> face à la documentation, pas le comportement du service distant. Une validation en sandbox
+> (`https://thirdparty-sandbox.staging.qonto.co/v2`) reste nécessaire avant mise en production.

--- a/resources/js/components/InvoicesIndex.jsx
+++ b/resources/js/components/InvoicesIndex.jsx
@@ -467,19 +467,20 @@ function SortIcon({ field, sortField, sortAsc }) {
 }
 
 const QONTO_LIFECYCLE_CONFIG = {
-    pending:      { badge: 'badge-secondary', label: 'Non soumise' },
-    submitted:    { badge: 'badge-info',      label: 'Déposée' },
+    pending:      { badge: 'badge-secondary', label: 'Non déposée' },
+    submitted:    { badge: 'badge-info',      label: 'Émise (à payer)' },
     acknowledged: { badge: 'badge-primary',   label: 'Accusé reçu' },
     rejected:     { badge: 'badge-danger',    label: 'Rejetée' },
     refused:      { badge: 'badge-danger',    label: 'Refusée' },
     accepted:     { badge: 'badge-success',   label: 'Acceptée' },
     paid:         { badge: 'badge-success',   label: 'Payée' },
+    canceled:     { badge: 'badge-warning',   label: 'Annulée chez Qonto' },
 };
 
 function QontoStatusBadge({ status }) {
     if (!status) return <span className="text-muted small">—</span>;
     const cfg = QONTO_LIFECYCLE_CONFIG[status] ?? { badge: 'badge-secondary', label: status };
-    return <span className={`badge ${cfg.badge}`} title="Statut facturation électronique Qonto">{cfg.label}</span>;
+    return <span className={`badge ${cfg.badge}`} title="Statut de la facture chez Qonto">{cfg.label}</span>;
 }
 
 function colDefs(trans, qontoEnabled) {

--- a/resources/views/integrations/partials/qonto-invoice-card.blade.php
+++ b/resources/views/integrations/partials/qonto-invoice-card.blade.php
@@ -2,13 +2,14 @@
 use App\Services\Integrations\Pdp\Enums\PdpLifecycle;
 
 $lifecycleLabels = [
-    PdpLifecycle::Pending->value      => ['label' => 'Non soumise',  'badge' => 'secondary'],
-    PdpLifecycle::Submitted->value    => ['label' => 'Déposée',      'badge' => 'info'],
-    PdpLifecycle::Acknowledged->value => ['label' => 'Accusé reçu', 'badge' => 'primary'],
-    PdpLifecycle::Rejected->value     => ['label' => 'Rejetée',      'badge' => 'danger'],
-    PdpLifecycle::Refused->value      => ['label' => 'Refusée',      'badge' => 'danger'],
-    PdpLifecycle::Accepted->value     => ['label' => 'Acceptée',     'badge' => 'success'],
-    PdpLifecycle::Paid->value         => ['label' => 'Payée',        'badge' => 'success'],
+    PdpLifecycle::Pending->value      => ['label' => 'Non déposée',       'badge' => 'secondary'],
+    PdpLifecycle::Submitted->value    => ['label' => 'Émise (à payer)',   'badge' => 'info'],
+    PdpLifecycle::Acknowledged->value => ['label' => 'Accusé reçu',       'badge' => 'primary'],
+    PdpLifecycle::Rejected->value     => ['label' => 'Rejetée',           'badge' => 'danger'],
+    PdpLifecycle::Refused->value      => ['label' => 'Refusée',           'badge' => 'danger'],
+    PdpLifecycle::Accepted->value     => ['label' => 'Acceptée',          'badge' => 'success'],
+    PdpLifecycle::Paid->value         => ['label' => 'Payée',             'badge' => 'success'],
+    PdpLifecycle::Canceled->value     => ['label' => 'Annulée chez Qonto', 'badge' => 'warning'],
 ];
 
 $currentStatus = $submission?->lifecycle_status ?? PdpLifecycle::Pending->value;
@@ -19,7 +20,7 @@ $canSubmit     = ! $submission || in_array($currentStatus, [
 ]);
 @endphp
 
-<x-adminlte-card title="Facturation électronique - Qonto" theme="info" theme-mode="outline" collapsible>
+<x-adminlte-card title="Facturation Qonto" theme="info" theme-mode="outline" collapsible>
     <div class="mb-2">
         <span class="text-muted small">Statut :</span>
         <span class="badge badge-{{ $statusInfo['badge'] }} ml-1">{{ $statusInfo['label'] }}</span>
@@ -30,6 +31,12 @@ $canSubmit     = ! $submission || in_array($currentStatus, [
 
         @if($submission?->submitted_at)
             <br><small class="text-muted">Déposée le : {{ $submission->submitted_at->format('d/m/Y H:i') }}</small>
+        @endif
+
+        @if(! $submission)
+            <br><small class="text-muted">
+                Le document est généré par Qonto à partir des lignes de cette facture.
+            </small>
         @endif
 
         @if($submission?->rejection_reason)
@@ -44,7 +51,7 @@ $canSubmit     = ! $submission || in_array($currentStatus, [
                 data-invoice-id="{{ $Invoice->id }}"
                 data-url="{{ route('api.integrations.qonto.invoices.submit', $Invoice->id) }}">
             <i class="fas fa-paper-plane mr-1"></i>
-            {{ $submission ? 'Re-soumettre' : 'Soumettre à Qonto' }}
+            {{ $submission ? 'Redéposer' : 'Déposer dans Qonto' }}
         </button>
         @endif
 

--- a/tests/Feature/QontoIntegrationApiTest.php
+++ b/tests/Feature/QontoIntegrationApiTest.php
@@ -2,15 +2,22 @@
 
 namespace Tests\Feature;
 
+use App\Events\InvoiceStatusChanged;
 use App\Models\Companies\Companies;
 use App\Models\Companies\CompaniesAddresses;
 use App\Models\Customer\Customer;
+use App\Models\Integrations\PdpInvoiceSubmission;
 use App\Models\Integrations\QontoClientMapping;
 use App\Models\Integrations\QontoConnection;
 use App\Models\Integrations\QontoSyncReview;
+use App\Models\Workflow\InvoiceLines;
+use App\Models\Workflow\Invoices;
+use App\Models\Workflow\OrderLines;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request as ClientRequest;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -191,5 +198,146 @@ class QontoIntegrationApiTest extends TestCase
             'qonto_client_id' => 'qonto-123',
             'sync_status' => 'linked',
         ]);
+    }
+
+    public function test_submit_invoice_posts_structured_payload_to_client_invoices(): void
+    {
+        config()->set('services.qonto.api_base_url', 'https://thirdparty.qonto.com/v2');
+
+        $user    = $this->authenticateApiUser();
+        $invoice = $this->makeInvoiceWithSingleLine($user->id);
+
+        $this->connectQonto($user->id);
+        QontoClientMapping::create([
+            'tenant_id'       => $user->id,
+            'wem_client_id'   => $invoice->companies_id,
+            'qonto_client_id' => 'qonto-client-1',
+            'sync_status'     => 'linked',
+            'matching_score'  => 100,
+        ]);
+
+        Http::fake([
+            'https://thirdparty.qonto.com/v2/client_invoices' => Http::response([
+                'client_invoice' => ['id' => 'qi-1', 'status' => 'unpaid'],
+            ], 201),
+        ]);
+
+        $this->postJson("/api/integrations/qonto/invoices/{$invoice->id}/submit")->assertOk();
+
+        Http::assertSent(function (ClientRequest $request) {
+            $body = $request->data();
+
+            return $request->method() === 'POST'
+                && $request->url() === 'https://thirdparty.qonto.com/v2/client_invoices'
+                && $body['client_id'] === 'qonto-client-1'
+                && $body['number'] === 'FA-2026-001'
+                && $body['due_date'] === '2026-09-30'
+                && $body['status'] === 'unpaid'
+                && $body['payment_methods']['iban'] === 'FR7616798000010000123456789'
+                // Prix bruts + remise séparée, TVA en ratio : format attendu par Qonto.
+                && $body['items'][0]['quantity'] === '4.0000'
+                && $body['items'][0]['unit_price'] === ['value' => '125.50', 'currency' => 'EUR']
+                && $body['items'][0]['vat_rate'] === '0.2000'
+                && $body['items'][0]['discount'] === ['type' => 'percentage', 'value' => '10.00'];
+        });
+
+        $this->assertDatabaseHas('pdp_invoice_submissions', [
+            'invoice_id'       => $invoice->id,
+            'provider'         => 'qonto',
+            'external_id'      => 'qi-1',
+            'lifecycle_status' => 'submitted',
+        ]);
+    }
+
+    public function test_submit_invoice_fails_cleanly_when_client_is_not_mapped(): void
+    {
+        config()->set('services.qonto.api_base_url', 'https://thirdparty.qonto.com/v2');
+
+        $user    = $this->authenticateApiUser();
+        $invoice = $this->makeInvoiceWithSingleLine($user->id);
+
+        $this->connectQonto($user->id);
+        Http::fake();
+
+        $this->postJson("/api/integrations/qonto/invoices/{$invoice->id}/submit")
+            ->assertStatus(422)
+            ->assertJsonPath('message', fn ($message) => str_contains($message, 'Aucun client Qonto'));
+
+        Http::assertNothingSent();
+        $this->assertDatabaseCount('pdp_invoice_submissions', 0);
+    }
+
+    public function test_poll_maps_paid_status_to_wem_paid_status(): void
+    {
+        config()->set('services.qonto.api_base_url', 'https://thirdparty.qonto.com/v2');
+        Event::fake([InvoiceStatusChanged::class]);
+
+        $user    = $this->authenticateApiUser();
+        $invoice = $this->makeInvoiceWithSingleLine($user->id);
+
+        $this->connectQonto($user->id);
+        PdpInvoiceSubmission::create([
+            'tenant_id'        => $user->id,
+            'invoice_id'       => $invoice->id,
+            'provider'         => 'qonto',
+            'external_id'      => 'qi-1',
+            'lifecycle_status' => 'submitted',
+            'submitted_at'     => now(),
+        ]);
+
+        Http::fake([
+            'https://thirdparty.qonto.com/v2/client_invoices/qi-1' => Http::response([
+                'client_invoice' => ['id' => 'qi-1', 'status' => 'paid'],
+            ], 200),
+        ]);
+
+        $this->postJson("/api/integrations/qonto/invoices/{$invoice->id}/poll")->assertOk();
+
+        $this->assertDatabaseHas('pdp_invoice_submissions', [
+            'invoice_id'       => $invoice->id,
+            'lifecycle_status' => 'paid',
+        ]);
+        $this->assertDatabaseHas('invoices', ['id' => $invoice->id, 'statu' => 5]);
+    }
+
+    private function connectQonto(int $tenantId): QontoConnection
+    {
+        return QontoConnection::create([
+            'tenant_id'               => $tenantId,
+            'access_token'            => Crypt::encryptString('token'),
+            'refresh_token'           => Crypt::encryptString('refresh'),
+            'access_token_expires_at' => now()->addHour(),
+            // Renseigné ici pour éviter l'appel de découverte GET /organization.
+            'iban'                    => 'FR7616798000010000123456789',
+        ]);
+    }
+
+    private function makeInvoiceWithSingleLine(int $tenantId): Invoices
+    {
+        $invoice = Invoices::factory()->create([
+            'user_id'      => $tenantId,
+            'code'         => 'FA-2026-001',
+            'invoice_type' => 1,
+            'statu'        => 1,
+            'due_date'     => '2026-09-30',
+        ]);
+
+        $orderLine = OrderLines::factory()->create([
+            'code'  => 'PART-1',
+            'label' => 'Tôle pliée 3mm',
+        ]);
+
+        InvoiceLines::create([
+            'invoices_id'    => $invoice->id,
+            'order_line_id'  => $orderLine->id,
+            'ordre'          => 10,
+            'qty'            => 4,
+            'unit_price'     => 125.50,
+            'discount'       => 10,
+            'vat_rate'       => 20,
+            'invoice_status' => 1,
+        ]);
+
+        return $invoice->fresh();
     }
 }


### PR DESCRIPTION
…nvoices

Le driver ciblait un endpoint /invoices inexistant et lui envoyait un PDF Factur-X en multipart, avec des statuts de cycle de vie et un en-tete de signature webhook inventes. Aucun appel n'aurait abouti en production : les tests ne le voyaient pas puisque tout passe par Http::fake.

- POST /v2/client_invoices en JSON structure ; on n'envoie plus notre PDF, c'est Qonto qui genere le document a partir des donnees
- items construits depuis InvoiceCalculatorService (meme snapshot de prix que le PDF interne) : TVA en ratio, remise en pourcentage separee, prix au cent
- statuts reels draft/unpaid/paid/canceled mappes vers PdpLifecycle, nouveau cas Canceled ; un statut inconnu est loggue au lieu d'un repli silencieux
- signature webhook Qonto-SHA256-Signature (hex, sans prefixe) ; l'endpoint reste inerte, Qonto ne publiant pas d'evenement client_invoice
- scopes centralises dans OAUTH_SCOPES : ajout de organization.read, client_invoices.read et client_invoice.write
- IBAN du compte decouvert via GET /v2/organization, mis en cache chiffre
- erreurs API et donnees manquantes traduites en 422 avec message utilisateur

Les connexions Qonto existantes doivent etre refaites : un token emis avec les anciens scopes sera refuse en 403 sur /client_invoices.

Le canal Plateforme Agreee (ex-PDP) reste hors perimetre : einvoicing_status est conserve dans la reponse brute et journalise, sans etre interprete.