### PR TITLE
fix(imbrication): corrige la colonne produit et optimise /nesting/she…

### DIFF
--- a/app/Http/Controllers/Planning/NestingController.php
+++ b/app/Http/Controllers/Planning/NestingController.php
@@ -15,6 +15,10 @@ use Illuminate\Http\Request;
 
 class NestingController extends Controller
 {
+    /** Stock move types counted as entries / exits (cf. StockReservationService). */
+    private const STOCK_ENTRY_TYPES   = [1, 3, 5, 12, 14];
+    private const STOCK_SORTING_TYPES = [2, 4, 6, 9];
+
     public function index()
     {
         return view('planning.nesting-index');
@@ -76,13 +80,36 @@ class NestingController extends Controller
 
         $productIds = $products->pluck('id');
 
+        if ($productIds->isEmpty()) {
+            return response()->json([]);
+        }
+
         // Purchase lines still awaiting receipt: sum of (qty - receipt_qty) per product
-        $incoming = $productIds->isEmpty() ? collect() : \DB::table('purchase_lines')
-            ->whereIn('products_id', $productIds)
+        $incoming = \DB::table('purchase_lines')
+            ->whereIn('product_id', $productIds->map(fn ($id) => (string) $id))
             ->whereColumn('receipt_qty', '<', 'qty')
-            ->groupBy('products_id')
-            ->selectRaw('products_id, SUM(qty - receipt_qty) as pending_qty')
-            ->pluck('pending_qty', 'products_id');
+            ->groupBy('product_id')
+            ->selectRaw('product_id, SUM(qty - receipt_qty) as pending_qty')
+            ->pluck('pending_qty', 'product_id');
+
+        // On-hand stock per product, in a single aggregate instead of
+        // Products::getTotalStockMove() (1 query per location + 2 per move bucket).
+        $entryList   = implode(',', self::STOCK_ENTRY_TYPES);
+        $sortingList = implode(',', self::STOCK_SORTING_TYPES);
+
+        $onHand = \DB::table('stock_moves')
+            ->join('stock_location_products', 'stock_moves.stock_location_products_id', '=', 'stock_location_products.id')
+            ->whereIn('stock_location_products.products_id', $productIds)
+            ->groupBy('stock_location_products.products_id')
+            ->selectRaw("
+                stock_location_products.products_id,
+                COALESCE(SUM(CASE
+                    WHEN stock_moves.typ_move IN ($entryList)   THEN stock_moves.qty
+                    WHEN stock_moves.typ_move IN ($sortingList) THEN -stock_moves.qty
+                    ELSE 0
+                END), 0) AS stock_qty
+            ")
+            ->pluck('stock_qty', 'products_id');
 
         return response()->json(
             $products->map(fn ($p) => [
@@ -93,7 +120,7 @@ class NestingController extends Controller
                 'thickness'    => (float) $p->thickness,
                 'x_size'       => (float) $p->x_size,
                 'y_size'       => (float) $p->y_size,
-                'stock_qty'    => (float) Products::find($p->id)->getTotalStockMove(),
+                'stock_qty'    => (float) ($onHand[$p->id] ?? 0),
                 'incoming_qty' => (float) ($incoming[$p->id] ?? 0),
             ])
         );

--- a/database/migrations/2026_08_11_000001_add_indexes_stock_location_products_and_purchase_lines.php
+++ b/database/migrations/2026_08_11_000001_add_indexes_stock_location_products_and_purchase_lines.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Index de performance complémentaires.
+ *
+ * stock_location_products n'avait pas d'index sur products_id : toute agrégation
+ * de stock par produit (getTotalStockMove, physicalStockOf, /nesting/sheet-stock)
+ * scannait la table pour joindre stock_moves.
+ *
+ * purchase_lines n'avait pas d'index sur product_id : le calcul des quantités en
+ * attente de réception par produit faisait un scan complet.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('stock_location_products') && ! Schema::hasIndex('stock_location_products', 'stock_location_products_products_id_index')) {
+            Schema::table('stock_location_products', function (Blueprint $table) {
+                $table->index('products_id');
+            });
+        }
+
+        if (Schema::hasTable('purchase_lines') && ! Schema::hasIndex('purchase_lines', 'purchase_lines_product_id_index')) {
+            Schema::table('purchase_lines', function (Blueprint $table) {
+                $table->index('product_id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasIndex('stock_location_products', 'stock_location_products_products_id_index')) {
+            Schema::table('stock_location_products', function (Blueprint $table) {
+                $table->dropIndex('stock_location_products_products_id_index');
+            });
+        }
+
+        if (Schema::hasIndex('purchase_lines', 'purchase_lines_product_id_index')) {
+            Schema::table('purchase_lines', function (Blueprint $table) {
+                $table->dropIndex('purchase_lines_product_id_index');
+            });
+        }
+    }
+};


### PR DESCRIPTION
…et-stock

La requete des receptions en attente utilisait products_id alors que la colonne de purchase_lines est product_id (SQLSTATE 42S22 en production).

Le stock disponible etait calcule via Products::getTotalStockMove() dans la boucle de rendu : 1 find + 1 chargement des emplacements + 2 requetes par emplacement, chacune rapatriant tous les stock_moves pour les sommer en PHP. Remplace par un agregat SQL unique groupe par produit, sur le meme modele que StockReservationService::physicalStockOf(). L'endpoint passe de ~1+4N requetes a 3 requetes fixes.

Ajoute les index manquants sur stock_location_products.products_id (cle de jointure de tous les calculs de stock par produit) et purchase_lines.product_id.