### PR TITLE
feat(ui): fusionne titre, statut et navigation dans un header unique

### DIFF
--- a/resources/views/components/document-header.blade.php
+++ b/resources/views/components/document-header.blade.php
@@ -1,0 +1,110 @@
+@props([
+    'h1',
+    'badge'    => null,
+    'previous' => null,
+    'list'     => null,
+    'next'     => null,
+    'steps'    => null,
+    'statu'    => null,
+    'endpoint' => null,
+    'redirect' => null,
+])
+
+@once
+@push('css')
+<style>
+.doc-header {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 1rem;
+    row-gap: .5rem;
+    margin-bottom: .5rem;
+}
+.doc-header__title {
+    font-size: 1.4rem;
+    font-weight: 500;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.doc-header__steps { min-width: 0; }
+.doc-header__nav { margin-left: auto; white-space: nowrap; }
+.doc-header__nav .btn { padding: .3rem .7rem; }
+.doc-header__nav .btn.disabled { opacity: .4; pointer-events: none; }
+
+/* Variante compacte des flèches de workflow (ArrowSteps.jsx) une fois dans le header.
+   La spécificité à 2 classes prime sur les règles .as-btn injectées par le composant React. */
+.doc-header__steps .as-track { padding: 0; }
+.doc-header__steps .as-btn {
+    padding: 7px 16px;
+    font-size: 11.5px;
+    min-width: 62px;
+}
+.doc-header__steps .as-btn:first-child { padding-left: 10px; }
+.doc-header__steps .as-btn:last-child  { padding-right: 10px; }
+.doc-header__steps .as-btn.as-current  { font-size: 12px; }
+.doc-header__steps .alert { font-size: 12px; padding: .3rem .6rem; margin-bottom: .35rem; }
+
+/* Sous 1200px les flèches reprennent leur propre ligne, titre et boutons restent appairés */
+@media (max-width: 1199.98px) {
+    .doc-header { grid-template-columns: minmax(0, 1fr) auto; }
+    .doc-header__steps { grid-column: 1 / -1; grid-row: 2; }
+}
+@media (max-width: 575.98px) {
+    .doc-header__title { white-space: normal; font-size: 1.2rem; }
+}
+</style>
+@endpush
+@endonce
+
+<div class="doc-header">
+    <h1 class="doc-header__title">
+        @if($badge)<span class="badge badge-warning mr-2">{{ $badge }}</span>@endif
+        {{ $h1 }}
+    </h1>
+
+    @if($steps)
+        <div class="doc-header__steps"
+             data-react="arrow-steps"
+             data-steps="{{ is_string($steps) ? $steps : json_encode($steps) }}"
+             data-statu="{{ $statu }}"
+             data-endpoint="{{ $endpoint }}"
+             data-redirect="{{ $redirect }}"></div>
+    @else
+        <div class="doc-header__steps"></div>
+    @endif
+
+    {{-- Les chevrons ne s'affichent que si la page gère la navigation entre documents.
+         Ni l'un ni l'autre renseigné = pas de navigation (ex. proformas) : on ne montre que le retour liste. --}}
+    @php $hasNavigation = $previous || $next; @endphp
+    <div class="doc-header__nav btn-group btn-group-sm" role="group">
+        @if($hasNavigation)
+        <a href="{{ $previous ?: '#' }}"
+           class="btn btn-outline-secondary {{ $previous ? '' : 'disabled' }}"
+           title="{{ __('general_content.previous_trans_key') }}"
+           aria-label="{{ __('general_content.previous_trans_key') }}"
+           @if(!$previous) tabindex="-1" aria-disabled="true" @endif>
+            <i class="fas fa-chevron-left"></i>
+        </a>
+        @endif
+        @if($list)
+            <a href="{{ $list }}"
+               class="btn btn-outline-secondary"
+               title="{{ __('general_content.back_to_list_trans_key') }}"
+               aria-label="{{ __('general_content.back_to_list_trans_key') }}">
+                <i class="fas fa-list"></i>
+            </a>
+        @endif
+        @if($hasNavigation)
+        <a href="{{ $next ?: '#' }}"
+           class="btn btn-outline-secondary {{ $next ? '' : 'disabled' }}"
+           title="{{ __('general_content.next_trans_key') }}"
+           aria-label="{{ __('general_content.next_trans_key') }}"
+           @if(!$next) tabindex="-1" aria-disabled="true" @endif>
+            <i class="fas fa-chevron-right"></i>
+        </a>
+        @endif
+    </div>
+</div>

--- a/resources/views/purchases/purchases-show.blade.php
+++ b/resources/views/purchases/purchases-show.blade.php
@@ -2,8 +2,21 @@
 
 @section('title', __('general_content.purchase_trans_key')   . ' - ' . $Purchase->code)
 
+@php
+$purchaseSteps = json_encode([
+    ['value' => 1, 'label' => __('general_content.in_progress_trans_key')],
+    ['value' => 2, 'label' => __('general_content.ordered_trans_key')],
+    ['value' => 3, 'label' => __('general_content.partly_received_trans_key')],
+    ['value' => 4, 'label' => __('general_content.rceived_trans_key')],
+]);
+@endphp
+
 @section('content_header')
-  <x-Content-header-previous-button  h1="{{  __('general_content.purchase_trans_key') }} : {{  $Purchase->code }}" previous="{{ $previousUrl }}" list="{{ route('purchases') }}" next="{{ $nextUrl }}"/>
+  <x-document-header h1="{{  __('general_content.purchase_trans_key') }} : {{  $Purchase->code }}"
+                     previous="{{ $previousUrl }}" list="{{ route('purchases') }}" next="{{ $nextUrl }}"
+                     :steps="$purchaseSteps" statu="{{ $Purchase->statu }}"
+                     endpoint="{{ route('purchases.json.statu', $Purchase->id) }}"
+                     redirect="{{ route('purchases.show', $Purchase->id) }}"/>
 @stop
 
 @section('right-sidebar')
@@ -26,20 +39,6 @@
   <div class="card-body">
     <div class="tab-content">
       <div class="tab-pane active" id="Purchase">
-        
-        @php
-        $purchaseSteps = json_encode([
-            ['value' => 1, 'label' => __('general_content.in_progress_trans_key')],
-            ['value' => 2, 'label' => __('general_content.ordered_trans_key')],
-            ['value' => 3, 'label' => __('general_content.partly_received_trans_key')],
-            ['value' => 4, 'label' => __('general_content.rceived_trans_key')],
-        ]);
-        @endphp
-        <div data-react="arrow-steps"
-             data-steps="{{ $purchaseSteps }}"
-             data-statu="{{ $Purchase->statu }}"
-             data-endpoint="{{ route('purchases.json.statu', $Purchase->id) }}"
-             data-redirect="{{ route('purchases.show', $Purchase->id) }}"></div>
         <div class="row">
           <div class="col-md-9">
             @include('include.alert-result')

--- a/resources/views/workflow/deliverys-show.blade.php
+++ b/resources/views/workflow/deliverys-show.blade.php
@@ -2,8 +2,19 @@
 
 @section('title', __('general_content.delivery_notes_trans_key')  . ' - ' . $Delivery->code)
 
+@php
+$deliverySteps = [
+    ['value' => 1, 'label' => __('general_content.in_progress_trans_key')],
+    ['value' => 2, 'label' => __('general_content.send_trans_key')],
+];
+@endphp
+
 @section('content_header')
-  <x-Content-header-previous-button  h1="{{ __('general_content.delivery_notes_trans_key') }} : {{  $Delivery->code }}" previous="{{ $previousUrl }}" list="{{ route('deliverys') }}" next="{{ $nextUrl }}"/>
+  <x-document-header h1="{{ __('general_content.delivery_notes_trans_key') }} : {{  $Delivery->code }}"
+                     previous="{{ $previousUrl }}" list="{{ route('deliverys') }}" next="{{ $nextUrl }}"
+                     :steps="$deliverySteps" statu="{{ $Delivery->statu }}"
+                     endpoint="{{ route('deliverys.json.statu', $Delivery->id) }}"
+                     redirect="{{ route('deliverys.show', $Delivery->id) }}"/>
 @stop
 
 @section('right-sidebar')
@@ -31,11 +42,6 @@
   <div class="card-body">
     <div class="tab-content">
       <div class="tab-pane active" id="Delivery">
-        <div data-react="arrow-steps"
-             data-steps="{{ json_encode([['value' => 1, 'label' => __('general_content.in_progress_trans_key')], ['value' => 2, 'label' => __('general_content.send_trans_key')]]) }}"
-             data-statu="{{ $Delivery->statu }}"
-             data-endpoint="{{ route('deliverys.json.statu', $Delivery->id) }}"
-             data-redirect="{{ route('deliverys.show', $Delivery->id) }}"></div>
         <x-relational-breadcrumb :entity="$Delivery" />
         <div class="row">
           <div class="col-md-9">

--- a/resources/views/workflow/invoices-show.blade.php
+++ b/resources/views/workflow/invoices-show.blade.php
@@ -2,8 +2,22 @@
 
 @section('title', __('general_content.invoices_trans_key') . ' - ' . $Invoice->code)
 
+@php
+$invoiceSteps = [
+    ['value' => 1, 'label' => __('general_content.in_progress_trans_key')],
+    ['value' => 2, 'label' => __('general_content.send_trans_key')],
+    ['value' => 3, 'label' => __('general_content.pending_trans_key')],
+    ['value' => 4, 'label' => __('general_content.unpaid_trans_key')],
+    ['value' => 5, 'label' => __('general_content.paid_trans_key')],
+];
+@endphp
+
 @section('content_header')
-  <x-Content-header-previous-button  h1="{{ __('general_content.invoices_trans_key') }} : {{  $Invoice->code }}" previous="{{ $previousUrl }}" list="{{ route('invoices') }}" next="{{ $nextUrl }}"/>
+  <x-document-header h1="{{ __('general_content.invoices_trans_key') }} : {{  $Invoice->code }}"
+                     previous="{{ $previousUrl }}" list="{{ route('invoices') }}" next="{{ $nextUrl }}"
+                     :steps="$invoiceSteps" statu="{{ $Invoice->statu }}"
+                     endpoint="{{ route('invoices.json.statu', $Invoice->id) }}"
+                     redirect="{{ route('invoices.show', $Invoice->id) }}"/>
 @stop
 
 
@@ -38,20 +52,6 @@
   <div class="card-body">
     <div class="tab-content">
       <div class="tab-pane active" id="Invoice">
-        @php
-        $invoiceSteps = [
-            ['value' => 1, 'label' => __('general_content.in_progress_trans_key')],
-            ['value' => 2, 'label' => __('general_content.send_trans_key')],
-            ['value' => 3, 'label' => __('general_content.pending_trans_key')],
-            ['value' => 4, 'label' => __('general_content.unpaid_trans_key')],
-            ['value' => 5, 'label' => __('general_content.paid_trans_key')],
-        ];
-        @endphp
-        <div data-react="arrow-steps"
-             data-steps="{{ json_encode($invoiceSteps) }}"
-             data-statu="{{ $Invoice->statu }}"
-             data-endpoint="{{ route('invoices.json.statu', $Invoice->id) }}"
-             data-redirect="{{ route('invoices.show', $Invoice->id) }}"></div>
         <x-relational-breadcrumb :entity="$Invoice" />
         <div class="row">
           <div class="col-md-9">

--- a/resources/views/workflow/leads-show.blade.php
+++ b/resources/views/workflow/leads-show.blade.php
@@ -2,13 +2,6 @@
 
 @section('title', __('general_content.lead_trans_key'))
 
-@section('content_header')
-    <x-Content-header-previous-button  h1="{{ __('general_content.lead_trans_key') }} : {{  $Lead->id }}" previous="{{ $previousUrl }}" list="{{ route('leads') }}" next="{{ $nextUrl }}"/>
-@stop
-
-@section('right-sidebar')
-
-@section('content')
 @php
 $leadSteps = json_encode([
     ['value' => 1, 'label' => __('general_content.new_trans_key')],
@@ -18,11 +11,19 @@ $leadSteps = json_encode([
     ['value' => 5, 'label' => __('general_content.lost_trans_key')],
 ]);
 @endphp
-<div data-react="arrow-steps"
-     data-steps="{{ $leadSteps }}"
-     data-statu="{{ $Lead->statu }}"
-     data-endpoint="{{ route('leads.json.statu', $Lead->id) }}"
-     data-redirect="{{ route('leads.show', $Lead->id) }}"></div>
+
+@section('content_header')
+    <x-document-header h1="{{ __('general_content.lead_trans_key') }} : {{  $Lead->id }}"
+                       previous="{{ $previousUrl }}" list="{{ route('leads') }}" next="{{ $nextUrl }}"
+                       :steps="$leadSteps" statu="{{ $Lead->statu }}"
+                       endpoint="{{ route('leads.json.statu', $Lead->id) }}"
+                       redirect="{{ route('leads.show', $Lead->id) }}"/>
+@stop
+
+@section('right-sidebar')
+
+@section('content')
+{{-- Le workflow de statut est remonté dans le header (x-document-header) ; seule la priorité reste ici. --}}
 <div data-react="arrow-steps"
      data-steps="{{ json_encode([['value' => 1, 'label' => __('general_content.burning_trans_key')], ['value' => 2, 'label' => __('general_content.hot_trans_key')], ['value' => 3, 'label' => __('general_content.lukewarm_trans_key')], ['value' => 4, 'label' => __('general_content.cold_trans_key')]]) }}"
      data-statu="{{ $Lead->priority }}"

--- a/resources/views/workflow/opportunities-show.blade.php
+++ b/resources/views/workflow/opportunities-show.blade.php
@@ -2,8 +2,23 @@
 
 @section('title', __('general_content.opportunity_trans_key')  . ' - ' . $Opportunity->label)
 
+@php
+$oppSteps = json_encode([
+    ['value' => 1, 'label' => __('general_content.new_trans_key')],
+    ['value' => 2, 'label' => __('general_content.quote_made_trans_key')],
+    ['value' => 3, 'label' => __('general_content.negotiation_trans_key')],
+    ['value' => 4, 'label' => __('general_content.closed_won_trans_key')],
+    ['value' => 5, 'label' => __('general_content.closed_lost_trans_key')],
+    ['value' => 6, 'label' => __('general_content.informational_trans_key')],
+]);
+@endphp
+
 @section('content_header')
-    <x-Content-header-previous-button  h1="{{ __('general_content.opportunity_trans_key') }} : {{  $Opportunity->label }}" previous="{{ $previousUrl }}" list="{{ route('opportunities') }}" next="{{ $nextUrl }}"/>
+    <x-document-header h1="{{ __('general_content.opportunity_trans_key') }} : {{  $Opportunity->label }}"
+                       previous="{{ $previousUrl }}" list="{{ route('opportunities') }}" next="{{ $nextUrl }}"
+                       :steps="$oppSteps" statu="{{ $Opportunity->statu }}"
+                       endpoint="{{ route('opportunities.json.statu', $Opportunity->id) }}"
+                       redirect="{{ route('opportunities.show', $Opportunity->id) }}"/>
 @stop
 
 @section('right-sidebar')
@@ -26,21 +41,6 @@
   <div class="card-body">
     <div class="tab-content">
       <div class="tab-pane active" id="Opportunity">
-        @php
-        $oppSteps = json_encode([
-            ['value' => 1, 'label' => __('general_content.new_trans_key')],
-            ['value' => 2, 'label' => __('general_content.quote_made_trans_key')],
-            ['value' => 3, 'label' => __('general_content.negotiation_trans_key')],
-            ['value' => 4, 'label' => __('general_content.closed_won_trans_key')],
-            ['value' => 5, 'label' => __('general_content.closed_lost_trans_key')],
-            ['value' => 6, 'label' => __('general_content.informational_trans_key')],
-        ]);
-        @endphp
-        <div data-react="arrow-steps"
-             data-steps="{{ $oppSteps }}"
-             data-statu="{{ $Opportunity->statu }}"
-             data-endpoint="{{ route('opportunities.json.statu', $Opportunity->id) }}"
-             data-redirect="{{ route('opportunities.show', $Opportunity->id) }}"></div>
         <x-relational-breadcrumb :entity="$Opportunity" />
         <div class="row">
           <div class="col-md-9">

--- a/resources/views/workflow/orders-show.blade.php
+++ b/resources/views/workflow/orders-show.blade.php
@@ -2,9 +2,37 @@
 
 @section('title', __('general_content.orders_trans_key')  . ' - ' . $Order->code)
 
+@php
+$orderSteps = [
+    ['value' => 1, 'label' => __('general_content.open_trans_key')],
+    ['value' => 2, 'label' => __('general_content.in_progress_trans_key')],
+];
+if ($Order->type == 1) {
+    $orderSteps[] = ['value' => 4, 'label' => __('general_content.partly_delivered_trans_key')];
+    $orderSteps[] = ['value' => 3, 'label' => __('general_content.delivered_trans_key')];
+} else {
+    $orderSteps[] = ['value' => 4, 'label' => __('general_content.partly_stored_trans_key')];
+    $orderSteps[] = ['value' => 3, 'label' => __('general_content.stock_trans_key')];
+}
+// Arrêté (5) reste toujours accessible.
+$orderSteps[] = ['value' => 5, 'label' => __('general_content.stopped_trans_key')];
+
+// Annulé (6) accessible même livré/partiellement livré (BL existant) :
+// l'annulation bascule les lignes de BL non facturées en "non facturable".
+// MAIS interdit dès qu'une ligne a été facturée (passer par un avoir).
+$orderHasInvoicedLines = $Order->OrderLines()->where('invoiced_qty', '>', 0)->exists();
+if (!$orderHasInvoicedLines) {
+    $orderSteps[] = ['value' => 6, 'label' => __('general_content.canceled_trans_key')];
+}
+@endphp
+
 @section('content_header')
   <script rel="stylesheet" src="{{ asset('js/switchtabNav.js') }}"></script>
-  <x-Content-header-previous-button  h1="{{ __('general_content.orders_trans_key') }} : {{  $Order->code }}" previous="{{ $previousUrl }}" list="{{ route('orders') }}" next="{{ $nextUrl }}"/>
+  <x-document-header h1="{{ __('general_content.orders_trans_key') }} : {{  $Order->code }}"
+                     previous="{{ $previousUrl }}" list="{{ route('orders') }}" next="{{ $nextUrl }}"
+                     :steps="$orderSteps" statu="{{ $Order->statu }}"
+                     endpoint="{{ route('orders.json.statu', $Order->id) }}"
+                     redirect="{{ route('orders.show', $Order->id) }}"/>
 @stop
 
 @push('css')
@@ -68,34 +96,6 @@
   <div class="card-body">
     <div class="tab-content">
       <div class="tab-pane" id="Order">
-        @php
-        $orderSteps = [
-            ['value' => 1, 'label' => __('general_content.open_trans_key')],
-            ['value' => 2, 'label' => __('general_content.in_progress_trans_key')],
-        ];
-        if ($Order->type == 1) {
-            $orderSteps[] = ['value' => 4, 'label' => __('general_content.partly_delivered_trans_key')];
-            $orderSteps[] = ['value' => 3, 'label' => __('general_content.delivered_trans_key')];
-        } else {
-            $orderSteps[] = ['value' => 4, 'label' => __('general_content.partly_stored_trans_key')];
-            $orderSteps[] = ['value' => 3, 'label' => __('general_content.stock_trans_key')];
-        }
-        // Arrêté (5) reste toujours accessible.
-        $orderSteps[] = ['value' => 5, 'label' => __('general_content.stopped_trans_key')];
-
-        // Annulé (6) accessible même livré/partiellement livré (BL existant) :
-        // l'annulation bascule les lignes de BL non facturées en "non facturable".
-        // MAIS interdit dès qu'une ligne a été facturée (passer par un avoir).
-        $orderHasInvoicedLines = $Order->OrderLines()->where('invoiced_qty', '>', 0)->exists();
-        if (!$orderHasInvoicedLines) {
-            $orderSteps[] = ['value' => 6, 'label' => __('general_content.canceled_trans_key')];
-        }
-        @endphp
-        <div data-react="arrow-steps"
-             data-steps="{{ json_encode($orderSteps) }}"
-             data-statu="{{ $Order->statu }}"
-             data-endpoint="{{ route('orders.json.statu', $Order->id) }}"
-             data-redirect="{{ route('orders.show', $Order->id) }}"></div>
         <x-relational-breadcrumb :entity="$Order" />
 
         @if($Order->statu === 0)

--- a/resources/views/workflow/proformas-show.blade.php
+++ b/resources/views/workflow/proformas-show.blade.php
@@ -2,11 +2,22 @@
 
 @section('title', 'Proforma - ' . $Proforma->code)
 
+@php
+  $steps = [
+    ['value' => 1, 'label' => 'Brouillon'],
+    ['value' => 2, 'label' => 'Envoyée'],
+    ['value' => 3, 'label' => 'Acceptée'],
+    ['value' => 4, 'label' => 'Refusée'],
+    ['value' => 5, 'label' => 'Convertie'],
+  ];
+@endphp
+
 @section('content_header')
-  <h1>
-    <span class="badge badge-warning mr-2">PROFORMA</span>
-    {{ $Proforma->code }}
-  </h1>
+  <x-document-header h1="{{ $Proforma->code }}" badge="PROFORMA"
+                     list="{{ route('proformas') }}"
+                     :steps="$steps" statu="{{ $Proforma->statu }}"
+                     endpoint="{{ route('proformas.json.statu', $Proforma->id) }}"
+                     redirect="{{ route('proformas.show', $Proforma->id) }}"/>
 @stop
 
 @section('content')
@@ -27,21 +38,6 @@
 
       {{-- Onglet infos --}}
       <div class="tab-pane active" id="Info">
-        @php
-          $steps = [
-            ['value' => 1, 'label' => 'Brouillon'],
-            ['value' => 2, 'label' => 'Envoyée'],
-            ['value' => 3, 'label' => 'Acceptée'],
-            ['value' => 4, 'label' => 'Refusée'],
-            ['value' => 5, 'label' => 'Convertie'],
-          ];
-        @endphp
-        <div data-react="arrow-steps"
-             data-steps="{{ json_encode($steps) }}"
-             data-statu="{{ $Proforma->statu }}"
-             data-endpoint="{{ route('proformas.json.statu', $Proforma->id) }}"
-             data-redirect="{{ route('proformas.show', $Proforma->id) }}"></div>
-
         <x-relational-breadcrumb :entity="$Proforma" />
 
         <div class="row">

--- a/resources/views/workflow/quotes-show.blade.php
+++ b/resources/views/workflow/quotes-show.blade.php
@@ -2,9 +2,24 @@
 
 @section('title', __('general_content.quote_trans_key')  . ' - ' . $Quote->code)
 
+@php
+$arrowSteps = json_encode([
+    ['value' => 1, 'label' => __('general_content.open_trans_key')],
+    ['value' => 2, 'label' => __('general_content.send_trans_key')],
+    ['value' => 3, 'label' => __('general_content.win_trans_key')],
+    ['value' => 4, 'label' => __('general_content.lost_trans_key')],
+    ['value' => 5, 'label' => __('general_content.closed_trans_key')],
+    ['value' => 6, 'label' => __('general_content.obsolete_trans_key')],
+]);
+@endphp
+
 @section('content_header')
     <script rel="stylesheet" src="{{ asset('js/switchtabNav.js') }}"></script>
-    <x-Content-header-previous-button  h1="{{ __('general_content.quote_trans_key') }} : {{  $Quote->code }}" previous="{{ $previousUrl }}" list="{{ route('quotes') }}" next="{{ $nextUrl }}"/>
+    <x-document-header h1="{{ __('general_content.quote_trans_key') }} : {{  $Quote->code }}"
+                       previous="{{ $previousUrl }}" list="{{ route('quotes') }}" next="{{ $nextUrl }}"
+                       :steps="$arrowSteps" statu="{{ $Quote->statu }}"
+                       endpoint="{{ route('quotes.json.statu', $Quote->id) }}"
+                       redirect="{{ route('quotes.show', $Quote->id) }}"/>
 @stop
 
 @section('right-sidebar')
@@ -34,21 +49,6 @@
   <div class="card-body">
     <div class="tab-content">
       <div class="tab-pane " id="Quote">
-        @php
-        $arrowSteps = json_encode([
-            ['value' => 1, 'label' => __('general_content.open_trans_key')],
-            ['value' => 2, 'label' => __('general_content.send_trans_key')],
-            ['value' => 3, 'label' => __('general_content.win_trans_key')],
-            ['value' => 4, 'label' => __('general_content.lost_trans_key')],
-            ['value' => 5, 'label' => __('general_content.closed_trans_key')],
-            ['value' => 6, 'label' => __('general_content.obsolete_trans_key')],
-        ]);
-        @endphp
-        <div data-react="arrow-steps"
-             data-steps="{{ $arrowSteps }}"
-             data-statu="{{ $Quote->statu }}"
-             data-endpoint="{{ route('quotes.json.statu', $Quote->id) }}"
-             data-redirect="{{ route('quotes.show', $Quote->id) }}"></div>
         <x-relational-breadcrumb :entity="$Quote" />
         <div class="row">
           <div class="col-md-9">


### PR DESCRIPTION
Les fiches document empilaient trois niveaux : titre + boutons de navigation, barre d'onglets, puis flèches de workflow. Le nouveau composant x-document-header réunit le premier et le troisième sur une seule ligne (grille auto | 1fr | auto). La barre d'onglets est inchangée.

Effet de bord notable : les flèches vivaient dans le tab-pane d'information, donc le statut disparaissait dès qu'on ouvrait un autre onglet. Remontées dans le header, elles restent visibles partout.

La densité compacte des flèches est appliquée en CSS depuis le header plutôt qu'en modifiant ArrowSteps.jsx : PurchasesQuotationShow.jsx injecte sa propre copie du même bloc de style sous l'id arrow-steps-react-v1, et toucher au composant React aurait rendu le résultat dépendant de l'ordre de montage. La spécificité à deux classes l'emporte quel que soit cet ordre.

Sous 1200px les flèches reprennent leur propre ligne ; la media query 576px existante d'ArrowSteps.jsx continue de les empiler.

Cas particuliers :
- leads : seul le workflow de statut remonte, la priorité reste dans le corps pour ne pas empiler deux barres de flèches dans le header
- proformas : pas de $previousUrl/$nextUrl côté contrôleur, les chevrons sont masqués et seul le retour liste s'affiche