### PR TITLE
feat(workshop): accueil tablette en 4 tuiles, scan stock et rapports …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,7 @@ mais un **cache de lecture**, resynchronisé par `FileStorageService::refreshLeg
   - **Avoirs** : CreditNotesIndex, ReturnsIndex, ReturnShow
   - **Stocks** : StockDetailPage, ProductHistory, ProductsIndex
   - **Tasks** : TasksIndex, TaskManagePage, TaskStatuApp, TaskLines, GtdBoard, TodayView
+  - **Atelier** : WorkshopReportsApp (rapports atelier : réalisé pointé, rebuts, charge machine, andon)
   - **Planning** : LoadPlanningIndex, KanbanBoard, KanbanSetting
   - **GMAO** : GmaoDashboard
   - **Qualité** : QualityIndex, NonConformitiesIndex, AuditPlannerApp, InspectionProjectsApp

--- a/app/Http/Controllers/Workshop/WorkshopController.php
+++ b/app/Http/Controllers/Workshop/WorkshopController.php
@@ -13,6 +13,7 @@ use App\Models\Products\StockMove;
 use App\Models\Methods\MethodsServices;
 use App\Models\Methods\MethodsRessources;
 use App\Services\TaskKPIService;
+use App\Services\WorkshopReportService;
 
 class WorkshopController extends Controller
 {
@@ -264,6 +265,12 @@ class WorkshopController extends Controller
      */
     public function stockDetail(Request $request)
     {
+        // La carte "Stocks" de l'accueil atelier arrive sans id : on affiche
+        // l'écran de scan au lieu de partir en 404 sur findOrFail(null).
+        if (! $request->id) {
+            return $this->stockScanView();
+        }
+
         $stockMove = StockMove::with([
             'UserManagement',
             'StockLocationProducts.product',
@@ -334,5 +341,79 @@ class WorkshopController extends Controller
 
         return view('workshop/workshop-stock-detail', compact('props'));
     }
-    
+
+    /**
+     * Écran de scan : l'opérateur douchette l'étiquette d'un mouvement de stock
+     * (code-barres = id) ou saisit un n° de traçabilité.
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    private function stockScanView(?string $error = null)
+    {
+        $recent = StockMove::with('StockLocationProducts.product:id,code,label')
+            ->orderByDesc('id')
+            ->limit(15)
+            ->get(['id', 'stock_location_products_id', 'qty', 'typ_move', 'tracability', 'created_at'])
+            ->map(fn ($move) => [
+                'id'           => $move->id,
+                'qty'          => $move->qty,
+                'tracability'  => $move->tracability,
+                'product_code' => $move->StockLocationProducts->product->code ?? null,
+                'product_label' => $move->StockLocationProducts->product->label ?? null,
+                'date'         => $move->created_at?->format('d/m/Y H:i'),
+                'url'          => route('workshop.stock.detail.id', ['id' => $move->id]),
+            ]);
+
+        return view('workshop/workshop-stock-scan', [
+            'recent'    => $recent,
+            'scanError' => $error,
+        ]);
+    }
+
+    /**
+     * Résout la saisie du scan vers un mouvement de stock, puis redirige.
+     * Un code inconnu revient sur l'écran de scan avec un message plutôt qu'un 404.
+     */
+    public function stockScan(Request $request)
+    {
+        $code = trim((string) $request->input('code', ''));
+
+        if ($code === '') {
+            return redirect()->route('workshop.stock.detail');
+        }
+
+        $stockMove = ctype_digit($code) ? StockMove::find((int) $code) : null;
+        $stockMove ??= StockMove::where('tracability', $code)->orderByDesc('id')->first();
+
+        if (! $stockMove) {
+            return $this->stockScanView('Aucun mouvement de stock trouvé pour « ' . $code . ' ».');
+        }
+
+        return redirect()->route('workshop.stock.detail.id', ['id' => $stockMove->id]);
+    }
+
+    /**
+     * Rapports atelier : réalisé pointé, rebuts, charge machine, andon.
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function reports(Request $request, WorkshopReportService $reportService)
+    {
+        return view('workshop/workshop-reports', [
+            'report'    => $reportService->build($request->get('period', 'today')),
+            'endpoints' => [
+                'report' => route('workshop.reports.json'),
+                'task'   => route('workshop.task.statu.id', ['id' => '__ID__']),
+            ],
+        ]);
+    }
+
+    /**
+     * Même rapport en JSON : le changement de période et le rafraîchissement
+     * automatique de l'écran atelier n'ont pas à recharger la page.
+     */
+    public function reportsJson(Request $request, WorkshopReportService $reportService)
+    {
+        return response()->json($reportService->build($request->get('period', 'today')));
+    }
 }

--- a/app/Services/WorkshopReportService.php
+++ b/app/Services/WorkshopReportService.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use App\Models\User;
+use App\Models\Planning\Task;
+use App\Models\Planning\AndonAlerts;
+use App\Models\Planning\TaskActivities;
+use App\Models\Methods\MethodsRessources;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Rapport atelier : reconstruit le réalisé (heures pointées, pièces bonnes,
+ * rebuts) à partir des déclarations brutes de task_activities.
+ *
+ * Les heures ne sont pas lues via Task::getTotalLogTime() : cet accesseur
+ * raisonne sur toute la vie de la tâche, alors qu'un rapport atelier doit
+ * borner le réalisé à une période. Les sessions sont donc appariées ici
+ * (type 1 = départ, types 2/3 = arrêt) et la durée est imputée à la ressource
+ * et à l'opérateur figés sur le départ, pas à l'affectation courante.
+ */
+class WorkshopReportService
+{
+    public const PERIODS = [
+        'today' => "Aujourd'hui",
+        '7d'    => '7 derniers jours',
+        '30d'   => '30 derniers jours',
+    ];
+
+    public function build(string $period = 'today'): array
+    {
+        $period = array_key_exists($period, self::PERIODS) ? $period : 'today';
+        [$from, $to] = $this->range($period);
+
+        $activities = TaskActivities::query()
+            ->whereBetween('timestamp', [$from, $to])
+            ->orderBy('task_id')
+            ->orderBy('timestamp')
+            ->orderBy('id')
+            ->get(['id', 'task_id', 'methods_ressources_id', 'user_id', 'type', 'timestamp', 'good_qt', 'bad_qt']);
+
+        $sessions = $this->pairSessions($activities);
+        $labels   = $this->labels($activities);
+        $buckets  = $this->aggregate($activities, $sessions, $labels, $from, $to);
+
+        return [
+            'period' => [
+                'key'   => $period,
+                'label' => self::PERIODS[$period],
+                'from'  => $from->format('d/m/Y H:i'),
+                'to'    => $to->format('d/m/Y H:i'),
+            ],
+            'periods'      => collect(self::PERIODS)->map(fn ($label, $key) => ['key' => $key, 'label' => $label])->values(),
+            'kpi'          => $this->kpi($activities, $sessions),
+            'per_day'      => $buckets['per_day'],
+            'per_resource' => $buckets['per_resource'],
+            'per_user'     => $buckets['per_user'],
+            'per_service'  => $buckets['per_service'],
+            'andon'        => $this->andon($from, $to),
+            'in_progress'  => $this->inProgress(),
+            'generated_at' => now()->format('d/m/Y H:i:s'),
+        ];
+    }
+
+    /**
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function range(string $period): array
+    {
+        return match ($period) {
+            '7d'    => [Carbon::today()->subDays(6), Carbon::now()],
+            '30d'   => [Carbon::today()->subDays(29), Carbon::now()],
+            default => [Carbon::today(), Carbon::now()],
+        };
+    }
+
+    /**
+     * Appariement départ -> arrêt, tâche par tâche.
+     *
+     * Un arrêt sans départ dans la période (session ouverte avant le début du
+     * rapport) est ignoré plutôt que compté depuis le début de la fenêtre :
+     * mieux vaut sous-estimer que d'inventer des heures.
+     *
+     * @return array<int, array{task_id: int, seconds: int, day: string, resource_id: ?int, user_id: ?int}>
+     */
+    private function pairSessions($activities): array
+    {
+        $sessions = [];
+        $pending  = [];
+
+        foreach ($activities as $row) {
+            $type = (int) $row->type;
+
+            if ($type === TaskActivities::TYPE_START) {
+                $pending[$row->task_id][] = $row;
+                continue;
+            }
+
+            if (! in_array($type, [TaskActivities::TYPE_END, TaskActivities::TYPE_FINISH], true)) {
+                continue;
+            }
+
+            $start = empty($pending[$row->task_id]) ? null : array_pop($pending[$row->task_id]);
+            if ($start === null) {
+                continue;
+            }
+
+            $startAt = Carbon::parse($start->timestamp);
+            $endAt   = Carbon::parse($row->timestamp);
+
+            $sessions[] = [
+                'task_id'     => (int) $row->task_id,
+                'seconds'     => max(0, $startAt->diffInSeconds($endAt, false)),
+                'day'         => $startAt->format('Y-m-d'),
+                'resource_id' => $start->methods_ressources_id ?? $row->methods_ressources_id,
+                'user_id'     => $start->user_id ?? $row->user_id,
+            ];
+        }
+
+        return $sessions;
+    }
+
+    /**
+     * Libellés des ressources, opérateurs et tâches touchés par la période.
+     */
+    private function labels($activities): array
+    {
+        $tasks = Task::with('service:id,label,color')
+            ->whereIn('id', $activities->pluck('task_id')->unique()->all())
+            ->get(['id', 'label', 'methods_services_id'])
+            ->keyBy('id');
+
+        return [
+            'resources' => MethodsRessources::pluck('label', 'id')->all(),
+            'users'     => User::pluck('name', 'id')->all(),
+            'tasks'     => $tasks,
+        ];
+    }
+
+    private function aggregate($activities, array $sessions, array $labels, Carbon $from, Carbon $to): array
+    {
+        $perDay = [];
+        for ($day = $from->copy()->startOfDay(); $day->lte($to); $day->addDay()) {
+            $perDay[$day->format('Y-m-d')] = [
+                'date'  => $day->format('Y-m-d'),
+                'label' => $day->format('d/m'),
+                'hours' => 0.0,
+                'good'  => 0,
+                'bad'   => 0,
+            ];
+        }
+
+        $perResource = [];
+        $perUser     = [];
+        $perService  = [];
+
+        $touchResource = function ($id) use (&$perResource, $labels) {
+            $key = $id ? (int) $id : 0;
+            if (! isset($perResource[$key])) {
+                $perResource[$key] = [
+                    'label' => $key ? ($labels['resources'][$key] ?? "Ressource #{$key}") : 'Non affecté',
+                    'hours' => 0.0, 'good' => 0, 'bad' => 0, 'sessions' => 0,
+                ];
+            }
+            return $key;
+        };
+
+        $touchUser = function ($id) use (&$perUser, $labels) {
+            $key = $id ? (int) $id : 0;
+            if (! isset($perUser[$key])) {
+                $perUser[$key] = [
+                    'label' => $key ? ($labels['users'][$key] ?? "Utilisateur #{$key}") : 'Inconnu',
+                    'hours' => 0.0, 'good' => 0, 'bad' => 0, 'sessions' => 0,
+                ];
+            }
+            return $key;
+        };
+
+        $touchService = function ($taskId) use (&$perService, $labels) {
+            $service = $labels['tasks'][$taskId]->service ?? null;
+            $key     = $service->id ?? 0;
+            if (! isset($perService[$key])) {
+                $perService[$key] = [
+                    'label' => $service->label ?? 'Sans service',
+                    'color' => $service->color ?? '#6c757d',
+                    'hours' => 0.0, 'good' => 0, 'bad' => 0,
+                ];
+            }
+            return $key;
+        };
+
+        foreach ($sessions as $session) {
+            $hours = $session['seconds'] / 3600;
+
+            if (isset($perDay[$session['day']])) {
+                $perDay[$session['day']]['hours'] += $hours;
+            }
+
+            $rKey = $touchResource($session['resource_id']);
+            $perResource[$rKey]['hours']    += $hours;
+            $perResource[$rKey]['sessions'] += 1;
+
+            $uKey = $touchUser($session['user_id']);
+            $perUser[$uKey]['hours']    += $hours;
+            $perUser[$uKey]['sessions'] += 1;
+
+            $sKey = $touchService($session['task_id']);
+            $perService[$sKey]['hours'] += $hours;
+        }
+
+        foreach ($activities as $row) {
+            $type = (int) $row->type;
+            $good = $type === TaskActivities::TYPE_DECLARE_GOOD ? (int) $row->good_qt : 0;
+            $bad  = $type === TaskActivities::TYPE_DECLARE_BAD  ? (int) $row->bad_qt  : 0;
+            if ($good === 0 && $bad === 0) {
+                continue;
+            }
+
+            $day = Carbon::parse($row->timestamp)->format('Y-m-d');
+            if (isset($perDay[$day])) {
+                $perDay[$day]['good'] += $good;
+                $perDay[$day]['bad']  += $bad;
+            }
+
+            $rKey = $touchResource($row->methods_ressources_id);
+            $perResource[$rKey]['good'] += $good;
+            $perResource[$rKey]['bad']  += $bad;
+
+            $uKey = $touchUser($row->user_id);
+            $perUser[$uKey]['good'] += $good;
+            $perUser[$uKey]['bad']  += $bad;
+
+            $sKey = $touchService($row->task_id);
+            $perService[$sKey]['good'] += $good;
+            $perService[$sKey]['bad']  += $bad;
+        }
+
+        return [
+            'per_day'      => array_values($perDay),
+            'per_resource' => $this->finalize($perResource),
+            'per_user'     => $this->finalize($perUser),
+            'per_service'  => $this->finalize($perService),
+        ];
+    }
+
+    /**
+     * Arrondit, calcule le taux de rebut de la ligne et trie par charge décroissante.
+     */
+    private function finalize(array $rows): array
+    {
+        return collect($rows)
+            ->map(function ($row) {
+                $produced          = $row['good'] + $row['bad'];
+                $row['hours']      = round($row['hours'], 2);
+                $row['scrap_rate'] = $produced > 0 ? round($row['bad'] / $produced * 100, 1) : 0.0;
+                return $row;
+            })
+            ->sortByDesc(fn ($row) => $row['hours'] * 1000 + $row['good'])
+            ->values()
+            ->all();
+    }
+
+    private function kpi($activities, array $sessions): array
+    {
+        $good     = (int) $activities->where('type', TaskActivities::TYPE_DECLARE_GOOD)->sum('good_qt');
+        $bad      = (int) $activities->where('type', TaskActivities::TYPE_DECLARE_BAD)->sum('bad_qt');
+        $produced = $good + $bad;
+        $seconds  = array_sum(array_column($sessions, 'seconds'));
+
+        return [
+            'declared_hours' => round($seconds / 3600, 2),
+            'sessions'       => count($sessions),
+            'good_qty'       => $good,
+            'bad_qty'        => $bad,
+            'scrap_rate'     => $produced > 0 ? round($bad / $produced * 100, 1) : 0.0,
+            'finished_tasks' => $activities->where('type', TaskActivities::TYPE_FINISH)->pluck('task_id')->unique()->count(),
+            'active_users'   => $activities->pluck('user_id')->filter()->unique()->count(),
+            'late_tasks'     => Task::whereNotNull('end_date')
+                ->whereDate('end_date', '<', Carbon::today())
+                ->whereHas('status', fn ($q) => $q->where('title', '!=', 'Finished'))
+                ->count(),
+        ];
+    }
+
+    private function andon(Carbon $from, Carbon $to): array
+    {
+        $alerts = AndonAlerts::with('resource:id,label')
+            ->whereBetween('triggered_at', [$from, $to])
+            ->get(['id', 'type', 'status', 'methods_ressources_id', 'triggered_at', 'resolved_at']);
+
+        $avgMinutes = function ($rows) {
+            $resolved = $rows->filter(fn ($a) => $a->resolved_at !== null);
+            if ($resolved->isEmpty()) {
+                return null;
+            }
+            return round($resolved->avg(fn ($a) => Carbon::parse($a->triggered_at)->diffInMinutes(Carbon::parse($a->resolved_at))), 1);
+        };
+
+        return [
+            'total'       => $alerts->count(),
+            'open'        => AndonAlerts::where('status', '!=', 3)->count(),
+            'avg_minutes' => $avgMinutes($alerts),
+            'by_type'     => $alerts->groupBy('type')->map(fn ($rows, $type) => [
+                'label'       => $type !== '' && $type !== null ? $type : 'Non typé',
+                'count'       => $rows->count(),
+                'open'        => $rows->where('status', '!=', 3)->count(),
+                'avg_minutes' => $avgMinutes($rows),
+            ])->sortByDesc('count')->values()->all(),
+            'by_resource' => $alerts->groupBy('methods_ressources_id')->map(fn ($rows) => [
+                'label' => $rows->first()->resource->label ?? 'Non affecté',
+                'count' => $rows->count(),
+            ])->sortByDesc('count')->take(6)->values()->all(),
+        ];
+    }
+
+    /**
+     * Sessions encore ouvertes : un départ non refermé, tous historiques confondus.
+     * C'est l'information la plus utile sur un écran d'atelier — qui tourne, sur quoi.
+     */
+    private function inProgress(): array
+    {
+        $openTaskIds = DB::table('task_activities')
+            ->whereIn('type', [TaskActivities::TYPE_START, TaskActivities::TYPE_END, TaskActivities::TYPE_FINISH])
+            ->groupBy('task_id')
+            ->havingRaw('SUM(CASE WHEN type = ? THEN 1 ELSE -1 END) > 0', [TaskActivities::TYPE_START])
+            ->pluck('task_id');
+
+        if ($openTaskIds->isEmpty()) {
+            return [];
+        }
+
+        $starts = TaskActivities::with(['user:id,name', 'resource:id,label'])
+            ->whereIn('task_id', $openTaskIds)
+            ->where('type', TaskActivities::TYPE_START)
+            ->orderByDesc('timestamp')
+            ->get(['id', 'task_id', 'user_id', 'methods_ressources_id', 'timestamp'])
+            ->unique('task_id');
+
+        $tasks = Task::with('service:id,label,color')
+            ->whereIn('id', $starts->pluck('task_id'))
+            ->get(['id', 'label', 'methods_services_id'])
+            ->keyBy('id');
+
+        return $starts->map(function ($start) use ($tasks) {
+            $task    = $tasks[$start->task_id] ?? null;
+            $startAt = Carbon::parse($start->timestamp);
+
+            return [
+                'task_id'  => (int) $start->task_id,
+                'label'    => $task->label ?? "Tâche #{$start->task_id}",
+                'service'  => $task->service->label ?? null,
+                'color'    => $task->service->color ?? '#6c757d',
+                'user'     => $start->user->name ?? null,
+                'resource' => $start->resource->label ?? null,
+                'since'    => $startAt->format('d/m H:i'),
+                'minutes'  => $startAt->diffInMinutes(now()),
+            ];
+        })->sortByDesc('minutes')->values()->all();
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1229,6 +1229,21 @@ async function mountStockDetailPage() {
     );
 }
 
+async function mountWorkshopReportsApp() {
+    const el = document.getElementById('workshop-reports-app');
+    if (!el) return;
+
+    const { default: WorkshopReportsApp } = await import('./components/WorkshopReportsApp.jsx');
+    const parse = (attr) => { try { return JSON.parse(el.dataset[attr] ?? 'null'); } catch { return null; } };
+
+    createRoot(el).render(
+        React.createElement(WorkshopReportsApp, {
+            initial:   parse('initial'),
+            endpoints: parse('endpoints') ?? {},
+        })
+    );
+}
+
 async function mountChatWidget() {
     // Le widget est global : il crée son propre container sur document.body
     // et s'affiche uniquement si l'utilisateur est authentifié (présence du meta csrf-token)
@@ -1352,6 +1367,7 @@ mountProductHistory();
 mountOrderPurchaseHistory();
 mountProductPriceHistory();
 mountStockDetailPage();
+mountWorkshopReportsApp();
 mountProformasIndex();
 mountProformasRequest();
 

--- a/resources/js/components/WorkshopReportsApp.jsx
+++ b/resources/js/components/WorkshopReportsApp.jsx
@@ -1,0 +1,391 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * WorkshopReportsApp — écran de rapports orienté atelier.
+ *
+ * Pensé pour un poste debout / écran mural : gros chiffres, peu de clics,
+ * rafraîchissement automatique. Les données viennent de WorkshopReportService
+ * (réalisé pointé, rebuts, charge machine, andon).
+ */
+
+const REFRESH_MS = 60_000;
+
+function fmtHours(value) {
+    const hours = Number(value) || 0;
+    const h = Math.floor(hours);
+    const m = Math.round((hours - h) * 60);
+    return `${h}h${String(m).padStart(2, '0')}`;
+}
+
+function fmtNum(value) {
+    return new Intl.NumberFormat('fr-FR').format(Number(value) || 0);
+}
+
+function fmtDuration(minutes) {
+    const total = Math.max(0, Math.round(Number(minutes) || 0));
+    const h = Math.floor(total / 60);
+    return h > 0 ? `${h}h${String(total % 60).padStart(2, '0')}` : `${total} min`;
+}
+
+// ─── Tuile KPI ────────────────────────────────────────────────────────────────
+
+function Tile({ icon, color, label, value, hint }) {
+    return (
+        <div className="col-6 col-md-3 mb-3">
+            <div style={{
+                display: 'flex', alignItems: 'stretch', height: '100%',
+                background: '#fff', borderRadius: 6, overflow: 'hidden',
+                boxShadow: '0 1px 4px rgba(0,0,0,0.16)',
+            }}>
+                <div style={{
+                    width: 64, flexShrink: 0, background: color,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>
+                    <i className={icon} style={{ fontSize: 24, color: '#fff' }} />
+                </div>
+                <div style={{ padding: '0.5rem 0.8rem', minWidth: 0 }}>
+                    <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.4, color: '#6c757d' }}>
+                        {label}
+                    </div>
+                    <div style={{ fontSize: 28, fontWeight: 700, lineHeight: 1.1, color: '#343a40' }}>
+                        {value}
+                    </div>
+                    {hint && <div style={{ fontSize: 12, color: '#6c757d' }}>{hint}</div>}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ─── Histogramme SVG empilé (aucune dépendance graphique dans le projet) ──────
+
+function BarChart({ labels, series, height = 200, formatValue = fmtNum }) {
+    const totals = labels.map((_, i) => series.reduce((sum, s) => sum + (Number(s.values[i]) || 0), 0));
+    const max = Math.max(1, ...totals);
+    const barW = 100 / Math.max(labels.length, 1);
+
+    return (
+        <div>
+            <div style={{ display: 'flex', gap: '1rem', marginBottom: 6, fontSize: 12 }}>
+                {series.map(s => (
+                    <span key={s.label}>
+                        <span style={{
+                            display: 'inline-block', width: 10, height: 10,
+                            background: s.color, borderRadius: 2, marginRight: 4,
+                        }} />
+                        {s.label}
+                    </span>
+                ))}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'flex-end', height, gap: 2 }}>
+                {labels.map((label, i) => (
+                    <div key={`${label}-${i}`}
+                         title={`${label} — ${series.map(s => `${s.label}: ${formatValue(s.values[i] ?? 0)}`).join(' / ')}`}
+                         style={{ flex: `0 0 ${barW}%`, display: 'flex', flexDirection: 'column',
+                                  justifyContent: 'flex-end', height: '100%', minWidth: 0 }}>
+                        <div style={{ fontSize: 10, textAlign: 'center', color: '#6c757d', whiteSpace: 'nowrap' }}>
+                            {totals[i] > 0 ? formatValue(totals[i]) : ''}
+                        </div>
+                        {series.map(s => {
+                            const value = Number(s.values[i]) || 0;
+                            if (value <= 0) return null;
+                            return (
+                                <div key={s.label}
+                                     style={{ height: `${(value / max) * (height - 26)}px`, background: s.color }} />
+                            );
+                        })}
+                        <div style={{ borderTop: '1px solid #dee2e6', fontSize: 10, textAlign: 'center',
+                                      color: '#6c757d', paddingTop: 2, whiteSpace: 'nowrap', overflow: 'hidden' }}>
+                            {label}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// ─── Tableau de répartition ───────────────────────────────────────────────────
+
+function BreakdownCard({ title, icon, rows, showSessions = true }) {
+    return (
+        <div className="card">
+            <div className="card-header">
+                <h3 className="card-title"><i className={`${icon} mr-2`} />{title}</h3>
+            </div>
+            <div className="card-body p-0" style={{ maxHeight: 320, overflowY: 'auto' }}>
+                <table className="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>{title.includes('opérateur') ? 'Opérateur' : 'Libellé'}</th>
+                            <th className="text-right">Heures</th>
+                            <th className="text-right">Bonnes</th>
+                            <th className="text-right">Rebuts</th>
+                            <th className="text-right">% rebut</th>
+                            {showSessions && <th className="text-right">Sessions</th>}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.length === 0 && (
+                            <tr><td colSpan={showSessions ? 6 : 5} className="text-center text-muted p-3">Aucune déclaration</td></tr>
+                        )}
+                        {rows.map((row, i) => (
+                            <tr key={`${row.label}-${i}`}>
+                                <td>
+                                    {row.color && (
+                                        <span style={{ display: 'inline-block', width: 10, height: 10, borderRadius: 2,
+                                                       background: row.color, marginRight: 6 }} />
+                                    )}
+                                    {row.label}
+                                </td>
+                                <td className="text-right"><strong>{fmtHours(row.hours)}</strong></td>
+                                <td className="text-right text-success">{fmtNum(row.good)}</td>
+                                <td className="text-right text-danger">{row.bad > 0 ? fmtNum(row.bad) : '—'}</td>
+                                <td className="text-right">
+                                    {row.good + row.bad > 0
+                                        ? <span className={`badge ${row.scrap_rate > 5 ? 'badge-danger' : 'badge-success'}`}>
+                                              {row.scrap_rate}&nbsp;%
+                                          </span>
+                                        : '—'}
+                                </td>
+                                {showSessions && <td className="text-right">{row.sessions ?? '—'}</td>}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}
+
+// ─── Écran principal ──────────────────────────────────────────────────────────
+
+export default function WorkshopReportsApp({ initial, endpoints }) {
+    const [report, setReport]   = useState(initial);
+    const [period, setPeriod]   = useState(initial?.period?.key ?? 'today');
+    const [loading, setLoading] = useState(false);
+    const [error, setError]     = useState(null);
+    const firstRender           = useRef(true);
+
+    const load = useCallback(async (key) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const url = new URL(endpoints.report, window.location.origin);
+            url.searchParams.set('period', key);
+            const res = await fetch(url, { headers: { Accept: 'application/json' } });
+            if (!res.ok) throw new Error('Chargement impossible');
+            setReport(await res.json());
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, [endpoints.report]);
+
+    // La période initiale est déjà rendue côté serveur : pas de double appel au montage.
+    useEffect(() => {
+        if (firstRender.current) {
+            firstRender.current = false;
+            return;
+        }
+        load(period);
+    }, [period, load]);
+
+    useEffect(() => {
+        const timer = setInterval(() => load(period), REFRESH_MS);
+        return () => clearInterval(timer);
+    }, [period, load]);
+
+    if (!report) return <div className="p-4 text-muted">Aucune donnée.</div>;
+
+    const { kpi, per_day: perDay, per_resource: perResource, per_user: perUser,
+            per_service: perService, andon, in_progress: inProgress } = report;
+
+    const taskUrl = (id) => (endpoints.task ? endpoints.task.replace('__ID__', id) : null);
+
+    return (
+        <div>
+            {/* Barre de période */}
+            <div className="d-flex flex-wrap align-items-center mb-3">
+                <div className="btn-group btn-group-lg mr-3 mb-2">
+                    {(report.periods ?? []).map(p => (
+                        <button key={p.key}
+                                type="button"
+                                className={`btn ${p.key === period ? 'btn-warning' : 'btn-default'}`}
+                                onClick={() => setPeriod(p.key)}>
+                            {p.label}
+                        </button>
+                    ))}
+                </div>
+                <button type="button" className="btn btn-default btn-lg mb-2 mr-3" onClick={() => load(period)}>
+                    <i className={`fas fa-sync-alt ${loading ? 'fa-spin' : ''}`} />
+                </button>
+                <div className="mb-2 text-muted">
+                    <div>{report.period.from} → {report.period.to}</div>
+                    <small>Mis à jour à {report.generated_at} — rafraîchissement auto toutes les 60 s</small>
+                </div>
+            </div>
+
+            {error && <div className="alert alert-warning">{error}</div>}
+
+            {/* KPI */}
+            <div className="row">
+                <Tile icon="fas fa-stopwatch"       color="#17a2b8" label="Heures pointées" value={fmtHours(kpi.declared_hours)} hint={`${fmtNum(kpi.sessions)} session(s)`} />
+                <Tile icon="fas fa-check-circle"    color="#28a745" label="Pièces bonnes"   value={fmtNum(kpi.good_qty)} />
+                <Tile icon="fas fa-times-circle"    color="#dc3545" label="Rebuts"          value={fmtNum(kpi.bad_qty)} hint={`Taux ${kpi.scrap_rate} %`} />
+                <Tile icon="fas fa-flag-checkered"  color="#6f42c1" label="Tâches terminées" value={fmtNum(kpi.finished_tasks)} />
+                <Tile icon="fas fa-users"           color="#20c997" label="Opérateurs actifs" value={fmtNum(kpi.active_users)} />
+                <Tile icon="fas fa-play-circle"     color="#fd7e14" label="En cours"        value={fmtNum(inProgress.length)} hint="sessions ouvertes" />
+                <Tile icon="fas fa-hourglass-end"   color="#e83e8c" label="Tâches en retard" value={fmtNum(kpi.late_tasks)} hint="échéance dépassée" />
+                <Tile icon="fas fa-bell"            color="#ffc107" label="Andon ouverts"   value={fmtNum(andon.open)} hint={andon.avg_minutes !== null ? `Résolution moy. ${fmtDuration(andon.avg_minutes)}` : 'aucune résolution'} />
+            </div>
+
+            {/* En cours maintenant */}
+            <div className="card card-warning card-outline">
+                <div className="card-header">
+                    <h3 className="card-title"><i className="fas fa-play mr-2" />En cours maintenant</h3>
+                    <span className="badge badge-warning right">{inProgress.length}</span>
+                </div>
+                <div className="card-body p-0" style={{ maxHeight: 300, overflowY: 'auto' }}>
+                    <table className="table table-hover mb-0">
+                        <thead>
+                            <tr>
+                                <th>Tâche</th>
+                                <th>Service</th>
+                                <th>Ressource</th>
+                                <th>Opérateur</th>
+                                <th>Depuis</th>
+                                <th className="text-right">Durée</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {inProgress.length === 0 && (
+                                <tr><td colSpan={6} className="text-center text-muted p-3">Aucune tâche en cours</td></tr>
+                            )}
+                            {inProgress.map(row => (
+                                <tr key={row.task_id}>
+                                    <td>
+                                        {taskUrl(row.task_id)
+                                            ? <a href={taskUrl(row.task_id)}><strong>{row.label}</strong></a>
+                                            : <strong>{row.label}</strong>}
+                                        <small className="text-muted"> #{row.task_id}</small>
+                                    </td>
+                                    <td>
+                                        {row.service
+                                            ? <span className="badge" style={{ background: row.color, color: '#fff' }}>{row.service}</span>
+                                            : '—'}
+                                    </td>
+                                    <td>{row.resource ?? '—'}</td>
+                                    <td>{row.user ?? '—'}</td>
+                                    <td>{row.since}</td>
+                                    <td className="text-right">
+                                        <span className={`badge ${row.minutes > 480 ? 'badge-danger' : 'badge-secondary'}`}>
+                                            {fmtDuration(row.minutes)}
+                                        </span>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            {/* Courbes journalières */}
+            <div className="row">
+                <div className="col-md-6">
+                    <div className="card">
+                        <div className="card-header">
+                            <h3 className="card-title"><i className="fas fa-cubes mr-2" />Pièces par jour</h3>
+                        </div>
+                        <div className="card-body">
+                            <BarChart
+                                labels={perDay.map(d => d.label)}
+                                series={[
+                                    { label: 'Bonnes', color: '#28a745', values: perDay.map(d => d.good) },
+                                    { label: 'Rebuts', color: '#dc3545', values: perDay.map(d => d.bad) },
+                                ]}
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div className="col-md-6">
+                    <div className="card">
+                        <div className="card-header">
+                            <h3 className="card-title"><i className="fas fa-clock mr-2" />Heures pointées par jour</h3>
+                        </div>
+                        <div className="card-body">
+                            <BarChart
+                                labels={perDay.map(d => d.label)}
+                                series={[{ label: 'Heures', color: '#17a2b8', values: perDay.map(d => d.hours) }]}
+                                formatValue={fmtHours}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Répartitions */}
+            <div className="row">
+                <div className="col-md-6">
+                    <BreakdownCard title="Par ressource" icon="fas fa-cogs" rows={perResource} />
+                </div>
+                <div className="col-md-6">
+                    <BreakdownCard title="Par opérateur" icon="fas fa-user-clock" rows={perUser} />
+                </div>
+                <div className="col-md-6">
+                    <BreakdownCard title="Par service" icon="fas fa-sitemap" rows={perService} showSessions={false} />
+                </div>
+                <div className="col-md-6">
+                    <div className="card">
+                        <div className="card-header">
+                            <h3 className="card-title"><i className="fas fa-bell mr-2" />Alertes andon</h3>
+                            <span className="badge badge-secondary right">{andon.total} sur la période</span>
+                        </div>
+                        <div className="card-body p-0" style={{ maxHeight: 320, overflowY: 'auto' }}>
+                            <table className="table table-sm table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Type</th>
+                                        <th className="text-right">Total</th>
+                                        <th className="text-right">Non résolues</th>
+                                        <th className="text-right">Résolution moy.</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {andon.by_type.length === 0 && (
+                                        <tr><td colSpan={4} className="text-center text-muted p-3">Aucune alerte</td></tr>
+                                    )}
+                                    {andon.by_type.map(row => (
+                                        <tr key={row.label}>
+                                            <td>{row.label}</td>
+                                            <td className="text-right">{fmtNum(row.count)}</td>
+                                            <td className="text-right">
+                                                {row.open > 0
+                                                    ? <span className="badge badge-danger">{row.open}</span>
+                                                    : '—'}
+                                            </td>
+                                            <td className="text-right">
+                                                {row.avg_minutes !== null ? fmtDuration(row.avg_minutes) : '—'}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                            {andon.by_resource.length > 0 && (
+                                <div className="p-2 border-top">
+                                    <small className="text-muted d-block mb-1">Ressources les plus alertées</small>
+                                    {andon.by_resource.map(r => (
+                                        <span key={r.label} className="badge badge-light mr-1" style={{ fontSize: 12 }}>
+                                            {r.label} <strong>{r.count}</strong>
+                                        </span>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/tests/workflow/WorkshopReportsApp.test.jsx
+++ b/resources/js/tests/workflow/WorkshopReportsApp.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import WorkshopReportsApp from '../../components/WorkshopReportsApp.jsx';
+
+const REPORT = {
+    period:  { key: 'today', label: "Aujourd'hui", from: '17/08/2026 00:00', to: '17/08/2026 14:00' },
+    periods: [
+        { key: 'today', label: "Aujourd'hui" },
+        { key: '7d',    label: '7 derniers jours' },
+    ],
+    kpi: {
+        declared_hours: 7.5, sessions: 3, good_qty: 120, bad_qty: 6, scrap_rate: 4.8,
+        finished_tasks: 2, active_users: 2, late_tasks: 4,
+    },
+    per_day:      [{ date: '2026-08-17', label: '17/08', hours: 7.5, good: 120, bad: 6 }],
+    per_resource: [{ label: 'Laser 4kW', hours: 5.25, good: 100, bad: 4, scrap_rate: 3.8, sessions: 2 }],
+    per_user:     [{ label: 'Kevin',     hours: 7.5,  good: 120, bad: 6, scrap_rate: 4.8, sessions: 3 }],
+    per_service:  [{ label: 'Découpe', color: '#17a2b8', hours: 7.5, good: 120, bad: 6, scrap_rate: 4.8 }],
+    andon: {
+        total: 2, open: 1, avg_minutes: 35.5,
+        by_type:     [{ label: 'breakdown', count: 2, open: 1, avg_minutes: 35.5 }],
+        by_resource: [{ label: 'Laser 4kW', count: 2 }],
+    },
+    in_progress: [{
+        task_id: 195, label: 'Pliage capot', service: 'Pliage', color: '#28a745',
+        user: 'Kevin', resource: 'Presse 100T', since: '17/08 08:12', minutes: 95,
+    }],
+    generated_at: '17/08/2026 14:00:00',
+};
+
+const ENDPOINTS = { report: '/fr/workshop/Reports/json', task: '/fr/workshop/Task/Statu/Id/__ID__' };
+
+describe('WorkshopReportsApp', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(REPORT) })));
+    });
+
+    it('affiche les KPI atelier de la période servie par le serveur', () => {
+        render(<WorkshopReportsApp initial={REPORT} endpoints={ENDPOINTS} />);
+
+        expect(screen.getByText('Heures pointées')).toBeInTheDocument();
+        expect(screen.getAllByText('7h30').length).toBeGreaterThan(0);   // 7.5 h formatées
+        expect(screen.getByText('Taux 4.8 %')).toBeInTheDocument();
+        expect(screen.getByText('Pièces bonnes')).toBeInTheDocument();
+    });
+
+    it('liste les sessions ouvertes avec un lien vers la déclaration de production', () => {
+        render(<WorkshopReportsApp initial={REPORT} endpoints={ENDPOINTS} />);
+
+        const link = screen.getByRole('link', { name: /Pliage capot/ });
+        expect(link).toHaveAttribute('href', '/fr/workshop/Task/Statu/Id/195');
+        expect(screen.getByText('1h35')).toBeInTheDocument();   // 95 min ouvertes
+    });
+
+    it('ne recharge pas depuis le serveur au montage', () => {
+        render(<WorkshopReportsApp initial={REPORT} endpoints={ENDPOINTS} />);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('recharge la période demandée quand on change de bouton', async () => {
+        const { findByRole } = render(<WorkshopReportsApp initial={REPORT} endpoints={ENDPOINTS} />);
+
+        (await findByRole('button', { name: '7 derniers jours' })).click();
+
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+        expect(String(fetch.mock.calls[0][0])).toContain('period=7d');
+    });
+});

--- a/resources/views/workshop/workshop-reports.blade.php
+++ b/resources/views/workshop/workshop-reports.blade.php
@@ -1,0 +1,37 @@
+@extends('adminlte::page')
+
+@section('title', 'Rapports atelier')
+
+@section('content_header')
+  <h1>
+    Rapports atelier
+    <small class="text-muted">{{ $report['period']['label'] }}</small>
+  </h1>
+@stop
+
+@section('content')
+  <div id="workshop-reports-app"
+       data-initial='@json($report, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_TAG)'
+       data-endpoints='@json($endpoints, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_TAG)'>
+  </div>
+
+  <div class="text-center mb-4">
+    <a href="{{ route('workshop') }}" class="btn btn-default btn-lg">
+      <i class="fas fa-arrow-left mr-2"></i>{{ __('general_content.back_trans_key') }}
+    </a>
+  </div>
+@stop
+
+@section('css')
+  @viteReactRefresh
+  @vite(['resources/sass/app.scss', 'resources/js/app.js'])
+@stop
+
+@section('js')
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script>
+        $(document).ready(function(){
+            $("body").addClass("sidebar-hidden");
+        });
+    </script>
+@stop

--- a/resources/views/workshop/workshop-stock-scan.blade.php
+++ b/resources/views/workshop/workshop-stock-scan.blade.php
@@ -1,0 +1,107 @@
+@extends('adminlte::page')
+
+@section('title', __('general_content.stock_trans_key'))
+
+@section('content_header')
+  <h1>{{ __('general_content.stock_trans_key') }}</h1>
+@stop
+
+@section('content')
+<div class="container-fluid">
+
+  @if($scanError)
+    <div class="alert alert-warning">
+      <i class="fas fa-exclamation-triangle mr-2"></i>{{ $scanError }}
+    </div>
+  @endif
+
+  <div class="row justify-content-center">
+    <div class="col-lg-7">
+      <div class="card card-danger card-outline">
+        <div class="card-header">
+          <h3 class="card-title"><i class="fas fa-barcode mr-2"></i>Scanner une étiquette de stock</h3>
+        </div>
+        <form method="GET" action="{{ route('workshop.stock.scan') }}" autocomplete="off">
+          <div class="card-body">
+            <p class="text-muted">
+              Douchez le code-barres de l'étiquette (n° de mouvement) ou saisissez un n° de traçabilité.
+            </p>
+            <div class="input-group input-group-lg">
+              <input type="text"
+                     name="code"
+                     class="form-control form-control-lg"
+                     style="font-size: 1.6rem; height: 4rem;"
+                     placeholder="N° de mouvement ou traçabilité"
+                     autofocus>
+              <div class="input-group-append">
+                <button type="submit" class="btn btn-danger btn-lg px-4">
+                  <i class="fas fa-search mr-2"></i>Ouvrir
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="row justify-content-center">
+    <div class="col-lg-7">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title"><i class="fas fa-history mr-2"></i>Derniers mouvements</h3>
+        </div>
+        <div class="card-body p-0">
+          <table class="table table-hover mb-0">
+            <thead>
+              <tr>
+                <th style="width: 6rem;">N°</th>
+                <th>Produit</th>
+                <th class="text-right">Qté</th>
+                <th>Traçabilité</th>
+                <th>Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              @forelse($recent as $move)
+                <tr style="cursor: pointer;" onclick="window.location='{{ $move['url'] }}'">
+                  <td><span class="badge badge-secondary">{{ $move['id'] }}</span></td>
+                  <td>
+                    <strong>{{ $move['product_code'] ?? '—' }}</strong>
+                    <small class="d-block text-muted">{{ $move['product_label'] }}</small>
+                  </td>
+                  <td class="text-right">{{ $move['qty'] }}</td>
+                  <td>{{ $move['tracability'] ?: '—' }}</td>
+                  <td>{{ $move['date'] }}</td>
+                </tr>
+              @empty
+                <tr>
+                  <td colspan="5" class="text-center text-muted p-4">{{ __('general_content.no_data_trans_key') }}</td>
+                </tr>
+              @endforelse
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row justify-content-center">
+    <div class="col-lg-7 text-center mb-4">
+      <a href="{{ route('workshop') }}" class="btn btn-default btn-lg">
+        <i class="fas fa-arrow-left mr-2"></i>{{ __('general_content.back_trans_key') }}
+      </a>
+    </div>
+  </div>
+
+</div>
+@stop
+
+@section('js')
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script>
+        $(document).ready(function(){
+            $("body").addClass("sidebar-hidden");
+        });
+    </script>
+@stop

--- a/resources/views/workshop/workshop.blade.php
+++ b/resources/views/workshop/workshop.blade.php
@@ -2,62 +2,111 @@
 
 @section('title', __('general_content.workshop_interface_trans_key'))
 
-@section('content_header')
-  <h1>{{ __('general_content.workshop_interface_trans_key') }}</h1>
-@stop
-
 @section('content')
-<div class="container mt-5">
+{{--
+  Accueil atelier : 4 tuiles qui remplissent l'écran de la tablette (2 x 2).
+  Toute la tuile est cliquable — pas de petit bouton à viser avec des gants.
+--}}
+<div class="ws-home">
+    <a class="ws-tile ws-tile--tasks" href="{{ route('workshop.task.lines') }}">
+        <span class="ws-tile__badge badge badge-danger">Beta</span>
+        <i class="ws-tile__icon fas fa-tasks"></i>
+        <span class="ws-tile__title">{{ __('general_content.tasks_list_trans_key') }}</span>
+        <span class="ws-tile__text">{{ __('general_content.note_1_trans_key') }}</span>
+    </a>
 
-    <div class="row">
-        <div class="col-md-4 offset-md-2">
-            <div class="card text-center mb-4" style="background-color: #17a2b8;">
-                <div class="card-body">
-                    <h5 class="card-title text-white">{{ __('general_content.tasks_list_trans_key') }}</h5> <span class="badge badge-danger right">Beta</span>
-                    <p class="card-text text-white">{{ __('general_content.note_1_trans_key') }}</p>
-                    <a href="{{ route('workshop.task.lines') }}" class="btn btn-primary btn-lg btn-block">{{ __('general_content.to_access_trans_key') }}</a>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card text-center mb-4" style="background-color: #28a745;">
-                <div class="card-body">
-                    <h5 class="card-title text-white">{{ __('general_content.production_declaration_trans_key') }}</h5><span class="badge badge-danger right">Beta</span>
-                    <p class="card-text text-white">{{ __('general_content.note_2_trans_key') }}</p>
-                    <a href="{{ route('workshop.task.statu') }}" class="btn btn-primary btn-lg btn-block">{{ __('general_content.to_access_trans_key') }}</a>
-                </div>
-            </div>
-        </div>
-    </div>
+    <a class="ws-tile ws-tile--production" href="{{ route('workshop.task.statu') }}">
+        <span class="ws-tile__badge badge badge-danger">Beta</span>
+        <i class="ws-tile__icon fas fa-play-circle"></i>
+        <span class="ws-tile__title">{{ __('general_content.production_declaration_trans_key') }}</span>
+        <span class="ws-tile__text">{{ __('general_content.note_2_trans_key') }}</span>
+    </a>
 
-    <div class="row">
-        <div class="col-md-4 offset-md-2">
-            <div class="card text-center mb-4" style="background-color: #dc3545;"> 
-                <div class="card-body">
-                    <h5 class="card-title text-white">Stocks</h5> <span class="badge badge-danger right">Beta</span>
-                    <p class="card-text text-white"></p>
-                    <a href="{{ route('workshop.stock.detail') }}" class="btn btn-primary btn-lg btn-block">{{ __('general_content.to_access_trans_key') }}</a>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card text-center mb-4" style="background-color: #ffc107;"> 
-                <div class="card-body">
-                    <h5 class="card-title text-white">Reports</h5> <span class="badge badge-info right">Soon</span>
-                    <p class="card-text text-white"></p>
-                    <a href="#" class="btn btn-primary btn-lg btn-block">{{ __('general_content.to_access_trans_key') }}</a>
-                </div>
-            </div>
-        </div>
-    </div>
+    <a class="ws-tile ws-tile--stock" href="{{ route('workshop.stock.detail') }}">
+        <span class="ws-tile__badge badge badge-danger">Beta</span>
+        <i class="ws-tile__icon fas fa-barcode"></i>
+        <span class="ws-tile__title">Stocks</span>
+        <span class="ws-tile__text">Scannez une étiquette de mouvement de stock</span>
+    </a>
 
-
+    <a class="ws-tile ws-tile--reports" href="{{ route('workshop.reports') }}">
+        <span class="ws-tile__badge badge badge-danger">Beta</span>
+        <i class="ws-tile__icon fas fa-chart-line"></i>
+        <span class="ws-tile__title">Reports</span>
+        <span class="ws-tile__text">Réalisé pointé, rebuts, charge machine, andon</span>
+    </a>
 </div>
-
 @stop
 
 @section('css')
+<style>
+    /*
+      La grille doit remplir la hauteur utile : on rend la chaîne AdminLTE flex
+      (.content-wrapper > .content > .container-fluid) et les enfants s'étirent.
 
+      Le min-height d'origine déduit navbar + footer, or ce layout ne rend aucun
+      footer (pas de section 'footer' dans le projet) : sans ce recalcul une
+      bande vide de 3,5 rem reste sous la 2e ligne de tuiles.
+    */
+    .content-wrapper { display: flex; flex-direction: column; }
+    .wrapper .content-wrapper { min-height: calc(100vh - 3.5rem - 1px); }
+    .content-wrapper > .content { flex: 1 1 auto; display: flex; padding: 0; }
+    .content-wrapper > .content > .container-fluid { flex: 1 1 auto; display: flex; padding: 0; }
+
+    .ws-home {
+        flex: 1 1 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 12px;
+        padding: 12px;
+        box-sizing: border-box;
+    }
+
+    .ws-tile {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 1rem;
+        border-radius: 10px;
+        color: #fff;
+        text-decoration: none;
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.22);
+        transition: transform 0.08s ease-out, filter 0.08s ease-out;
+        -webkit-tap-highlight-color: transparent;
+        overflow: hidden;
+    }
+
+    .ws-tile:hover,
+    .ws-tile:focus { color: #fff; text-decoration: none; filter: brightness(1.06); }
+
+    /* Retour tactile : la tuile s'enfonce sous le doigt. */
+    .ws-tile:active { transform: scale(0.97); filter: brightness(0.94); }
+
+    .ws-tile__icon  { font-size: clamp(2.5rem, 7vh, 5rem); margin-bottom: 0.6rem; opacity: 0.95; }
+    .ws-tile__title { font-size: clamp(1.25rem, 3.2vh, 2.25rem); font-weight: 700; line-height: 1.15; }
+    .ws-tile__text  { font-size: clamp(0.85rem, 1.9vh, 1.15rem); margin-top: 0.35rem; opacity: 0.9; max-width: 90%; }
+    .ws-tile__badge { position: absolute; top: 10px; right: 10px; font-size: 0.8rem; }
+
+    .ws-tile--tasks      { background-color: #17a2b8; }
+    .ws-tile--production { background-color: #28a745; }
+    .ws-tile--stock      { background-color: #dc3545; }
+    .ws-tile--reports    { background-color: #ffc107; color: #212529; }
+    .ws-tile--reports:hover,
+    .ws-tile--reports:focus { color: #212529; }
+
+    /* Téléphone en portrait : on empile plutôt que d'écraser 4 tuiles. */
+    @media (max-width: 575px) {
+        .ws-home {
+            grid-template-columns: 1fr;
+            grid-template-rows: repeat(4, minmax(110px, 1fr));
+        }
+        .ws-tile__text { display: none; }
+    }
+</style>
 @stop
 
 @section('js')

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,4 @@
 <?php
-
 use App\Http\Controllers\Api\Collaboration\WhiteboardController as ApiWhiteboardController;
 use App\Http\Controllers\Api\Collaboration\WhiteboardFileController;
 use App\Http\Controllers\Api\Collaboration\WhiteboardSnapshotController;
@@ -179,8 +178,12 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::get('/Task/Statu', 'App\Http\Controllers\Workshop\WorkshopController@statu')->name('workshop.task.statu');
         Route::get('/Stock/Detail/{id}', 'App\Http\Controllers\Workshop\WorkshopController@stockDetail')->name('workshop.stock.detail.id');
         Route::get('/Stock/Detail', 'App\Http\Controllers\Workshop\WorkshopController@stockDetail')->name('workshop.stock.detail');
+        Route::get('/Stock/Scan', 'App\Http\Controllers\Workshop\WorkshopController@stockScan')->name('workshop.stock.scan');
 
-        
+        Route::get('/Reports', 'App\Http\Controllers\Workshop\WorkshopController@reports')->name('workshop.reports');
+        Route::get('/Reports/json', 'App\Http\Controllers\Workshop\WorkshopController@reportsJson')->name('workshop.reports.json');
+
+
         Route::get('/andon', 'App\Http\Controllers\Planning\AndonAlertController@taskAlertsDashboard')->name('workshop.andon');
         Route::post('/andon/store', 'App\Http\Controllers\Planning\AndonAlertController@triggerAlert')->name('workshop.andon.store');
         Route::post('/andon/inProgress/{id}', 'App\Http\Controllers\Planning\AndonAlertController@inProgressAlert')->name('workshop.andon.inProgress');

--- a/tests/Feature/WorkshopScreensTest.php
+++ b/tests/Feature/WorkshopScreensTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Planning\Task;
+use App\Models\Planning\TaskActivities;
+use App\Models\Products\StockMove;
+use App\Services\WorkshopReportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class WorkshopScreensTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware([
+            \App\Http\Middleware\CheckUserRole::class,
+            \App\Http\Middleware\CheckFactory::class,
+            \App\Http\Middleware\CheckTaskStatus::class,
+        ]);
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    /** L'accueil tablette : 4 tuiles plein écran, chacune entièrement cliquable. */
+    public function test_home_shows_four_full_screen_tiles(): void
+    {
+        $response = $this->get(route('workshop'))->assertOk();
+
+        foreach ([
+            route('workshop.task.lines'),
+            route('workshop.task.statu'),
+            route('workshop.stock.detail'),
+            route('workshop.reports'),
+        ] as $url) {
+            $response->assertSee('class="ws-tile ws-tile--', false);
+            $response->assertSee('href="' . $url . '"', false);
+        }
+
+        $this->assertSame(4, substr_count($response->getContent(), 'class="ws-tile ws-tile--'));
+    }
+
+    /** La carte "Stocks" de l'accueil atelier pointe ici, sans id : c'était un 404. */
+    public function test_stock_detail_without_id_shows_the_scan_screen(): void
+    {
+        $this->get(route('workshop.stock.detail'))
+            ->assertOk()
+            ->assertSee('Scanner une étiquette de stock');
+    }
+
+    public function test_stock_scan_redirects_to_the_matching_move(): void
+    {
+        $move = StockMove::create([
+            'user_id'                    => $this->user->id,
+            'qty'                        => 5,
+            'typ_move'                   => 5,
+            // Emplacement fictif : la chaîne de factories produit/unité/famille
+            // n'apporte rien à la résolution du scan, seule la colonne compte.
+            'stock_location_products_id' => 1,
+        ]);
+
+        $this->get(route('workshop.stock.scan', ['code' => $move->id]))
+            ->assertRedirect(route('workshop.stock.detail.id', ['id' => $move->id]));
+    }
+
+    public function test_stock_scan_resolves_a_tracability_serial(): void
+    {
+        $move = StockMove::create([
+            'user_id'                    => $this->user->id,
+            'qty'                        => 2,
+            'typ_move'                   => 5,
+            'tracability'                => 'LOT-2026-42',
+            // Emplacement fictif : la chaîne de factories produit/unité/famille
+            // n'apporte rien à la résolution du scan, seule la colonne compte.
+            'stock_location_products_id' => 1,
+        ]);
+
+        $this->get(route('workshop.stock.scan', ['code' => 'LOT-2026-42']))
+            ->assertRedirect(route('workshop.stock.detail.id', ['id' => $move->id]));
+    }
+
+    public function test_unknown_scan_code_returns_the_scan_screen_not_a_404(): void
+    {
+        $this->get(route('workshop.stock.scan', ['code' => 'INCONNU-999']))
+            ->assertOk()
+            ->assertSee('INCONNU-999', false);
+    }
+
+    public function test_scan_screen_lists_the_last_moves(): void
+    {
+        $move = StockMove::create([
+            'user_id'                    => $this->user->id,
+            'qty'                        => 7,
+            'typ_move'                   => 5,
+            'tracability'                => 'LOT-2026-77',
+            'stock_location_products_id' => 1,
+        ]);
+
+        $this->get(route('workshop.stock.detail'))
+            ->assertOk()
+            ->assertSee('Derniers mouvements')
+            ->assertSee('LOT-2026-77')
+            ->assertSee(route('workshop.stock.detail.id', ['id' => $move->id]), false);
+    }
+
+    public function test_reports_page_loads(): void
+    {
+        $this->get(route('workshop.reports'))->assertOk();
+    }
+
+    public function test_reports_json_exposes_the_workshop_blocks(): void
+    {
+        $this->getJson(route('workshop.reports.json', ['period' => '7d']))
+            ->assertOk()
+            ->assertJsonStructure([
+                'period'  => ['key', 'label', 'from', 'to'],
+                'kpi'     => ['declared_hours', 'good_qty', 'bad_qty', 'scrap_rate', 'finished_tasks', 'late_tasks'],
+                'per_day', 'per_resource', 'per_user', 'per_service', 'in_progress',
+                'andon'   => ['total', 'open', 'by_type'],
+            ])
+            ->assertJsonPath('period.key', '7d');
+    }
+
+    /**
+     * Le réalisé doit être borné à la période : une session appariée dans la
+     * fenêtre compte, une session ouverte n'ajoute pas d'heures mais apparaît
+     * comme "en cours".
+     */
+    public function test_report_pairs_declarations_within_the_period(): void
+    {
+        $closed = Task::factory()->create();
+        $open   = Task::factory()->create();
+
+        TaskActivities::create([
+            'task_id'   => $closed->id,
+            'user_id'   => $this->user->id,
+            'type'      => TaskActivities::TYPE_START,
+            'timestamp' => now()->subHours(3),
+        ]);
+        TaskActivities::create([
+            'task_id'   => $closed->id,
+            'user_id'   => $this->user->id,
+            'type'      => TaskActivities::TYPE_END,
+            'timestamp' => now()->subHours(1),
+        ]);
+        TaskActivities::create([
+            'task_id'   => $closed->id,
+            'user_id'   => $this->user->id,
+            'type'      => TaskActivities::TYPE_DECLARE_GOOD,
+            'timestamp' => now()->subHours(1),
+            'good_qt'   => 18,
+        ]);
+        TaskActivities::create([
+            'task_id'   => $closed->id,
+            'user_id'   => $this->user->id,
+            'type'      => TaskActivities::TYPE_DECLARE_BAD,
+            'timestamp' => now()->subHours(1),
+            'bad_qt'    => 2,
+        ]);
+        TaskActivities::create([
+            'task_id'   => $open->id,
+            'user_id'   => $this->user->id,
+            'type'      => TaskActivities::TYPE_START,
+            'timestamp' => now()->subMinutes(30),
+        ]);
+
+        $report = app(WorkshopReportService::class)->build('today');
+
+        $this->assertSame(2.0, $report['kpi']['declared_hours']);
+        $this->assertSame(1, $report['kpi']['sessions']);
+        $this->assertSame(18, $report['kpi']['good_qty']);
+        $this->assertSame(2, $report['kpi']['bad_qty']);
+        $this->assertSame(10.0, $report['kpi']['scrap_rate']);
+        $this->assertSame([$open->id], array_column($report['in_progress'], 'task_id'));
+        $this->assertSame(2.0, $report['per_user'][0]['hours']);
+        $this->assertSame(18, $report['per_user'][0]['good']);
+    }
+}


### PR DESCRIPTION
…atelier

L'accueil atelier devient un menu plein écran pour tablette : grille 2x2 en flex sur la chaîne AdminLTE, tuile entièrement cliquable, typographie en vh. Le min-height est recalculé car ce layout ne rend aucun footer et AdminLTE lui réservait quand même 3,5 rem.

La carte Stocks pointait sur workshop.stock.detail sans id, donc findOrFail(null) et un 404 systématique. Sans id on affiche désormais un écran de scan (douchette ou n° de traçabilité) avec les 15 derniers mouvements ; un code inconnu revient sur cet écran avec un message.

Nouvelle section Reports : WorkshopReportService apparie les sessions départ/arrêt dans la période demandée au lieu de lire getTotalLogTime(), qui raisonne sur toute la vie de la tâche. La durée est imputée à la ressource et à l'opérateur figés sur le départ, donc le réalisé ne bouge plus si la tâche est réaffectée. Une session ouverte n'ajoute pas d'heures mais remonte dans "en cours". L'écran React expose les KPI, les sessions ouvertes, deux histogrammes SVG (le projet n'a aucune lib de graphes), les répartitions par ressource/opérateur/service et le bilan andon.