### PR TITLE
feat(facturation): lignes de facture libres et edition des lignes en …

### DIFF
--- a/app/Exports/InvoiceLinesExport.php
+++ b/app/Exports/InvoiceLinesExport.php
@@ -33,15 +33,17 @@ class InvoiceLinesExport implements FromCollection , WithHeadings, WithMapping
 
     public function map($invoiceLine): array
     {
+        // Une ligne libre n'a pas de commande d'origine : tout vient du snapshot
+        // porté par la ligne de facture.
         return [
             $invoiceLine->invoice->code,
-            $invoiceLine->orderLine->order->code,
-            $invoiceLine->orderLine->label,
+            $invoiceLine->orderLine?->order?->code,
+            $invoiceLine->display_label,
             $invoiceLine->qty,
-            $invoiceLine->orderLine->Unit->label,
-            $invoiceLine->orderLine->selling_price,
-            $invoiceLine->orderLine->discount,
-            $invoiceLine->orderLine->vat->rate,
+            $invoiceLine->display_unit_label,
+            $invoiceLine->resolved_unit_price,
+            $invoiceLine->resolved_discount,
+            $invoiceLine->resolved_vat_rate,
         ];
     }
 

--- a/app/Http/Controllers/Admin/ImportsExportsController.php
+++ b/app/Http/Controllers/Admin/ImportsExportsController.php
@@ -105,6 +105,9 @@ class ImportsExportsController extends Controller
             'orderLine.order',
             'orderLine.Unit',
             'orderLine.VAT',
+            // Référentiels portés directement par la ligne (lignes libres)
+            'Unit',
+            'VAT',
         ])
         ->whereHas('invoice', fn ($q) => $q->where('invoice_type', 1))
         ->where('exported', false)
@@ -117,13 +120,13 @@ class ImportsExportsController extends Controller
             'order_code'      => $l->orderLine?->order?->code,
             'companie_id'     => $l->invoice?->companies_id,
             'companie_label'  => $l->invoice?->companie?->label,
-            'line_code'       => $l->orderLine?->code,
-            'line_label'      => $l->orderLine?->label,
+            'line_code'       => $l->display_code,
+            'line_label'      => $l->display_label,
             'qty'             => $l->qty,
-            'unit'            => $l->orderLine?->Unit?->label,
+            'unit'            => $l->display_unit_label,
             'formatted_price' => $l->formatted_selling_price,
-            'discount'        => $l->orderLine?->discount,
-            'vat_rate'        => $l->orderLine?->VAT?->rate,
+            'discount'        => $l->resolved_discount,
+            'vat_rate'        => $l->resolved_vat_rate,
         ]));
     }
 

--- a/app/Http/Controllers/Workflow/CreditNoteController.php
+++ b/app/Http/Controllers/Workflow/CreditNoteController.php
@@ -84,27 +84,39 @@ class CreditNoteController extends Controller
 
             foreach ($invoiceLines as $invoiceLine) {
                 CreditNoteLines::create([
-                    'credit_note_id'  => $creditNote->id,
-                    'order_line_id'   => $invoiceLine->order_line_id,
-                    'invoice_line_id' => $invoiceLine->id,
-                    'product_id'      => $invoiceLine->orderLine->product_id,
-                    'qty'             => $invoiceLine->qty,
+                    'credit_note_id'     => $creditNote->id,
+                    'order_line_id'      => $invoiceLine->order_line_id,
+                    'invoice_line_id'    => $invoiceLine->id,
+                    'product_id'         => $invoiceLine->product_id ?? $invoiceLine->orderLine?->product_id,
+                    // Snapshot descriptif : une ligne libre n'a pas de ligne de
+                    // commande où retrouver ces informations.
+                    'label'              => $invoiceLine->display_label,
+                    'qty'                => $invoiceLine->qty,
                     // Utilise le snapshot stocké sur la ligne de facture (fix immutabilité)
-                    'unit_price'      => $invoiceLine->unit_price ?? $invoiceLine->orderLine->selling_price,
+                    'unit_price'         => $invoiceLine->resolved_unit_price,
+                    'discount'           => $invoiceLine->resolved_discount,
+                    'vat_rate'           => $invoiceLine->resolved_vat_rate,
+                    'accounting_vats_id' => $invoiceLine->resolved_vat_id,
                 ]);
 
-                // Inverse les quantités facturées sur la ligne de commande
-                $orderLine = OrderLines::lockForUpdate()->find($invoiceLine->order_line_id);
-                $orderLine->invoiced_qty            = max(0, $orderLine->invoiced_qty - $invoiceLine->qty);
-                $orderLine->invoiced_remaining_qty += $invoiceLine->qty;
+                // Inverse les quantités facturées sur la ligne de commande.
+                // Sans objet pour une ligne libre, qui n'en a pas.
+                $orderLine = $invoiceLine->order_line_id
+                    ? OrderLines::lockForUpdate()->find($invoiceLine->order_line_id)
+                    : null;
 
-                if ($orderLine->invoiced_qty <= 0) {
-                    $orderLine->invoice_status = 1;
-                } elseif ($orderLine->invoiced_remaining_qty > 0) {
-                    $orderLine->invoice_status = 2;
+                if ($orderLine) {
+                    $orderLine->invoiced_qty            = max(0, $orderLine->invoiced_qty - $invoiceLine->qty);
+                    $orderLine->invoiced_remaining_qty += $invoiceLine->qty;
+
+                    if ($orderLine->invoiced_qty <= 0) {
+                        $orderLine->invoice_status = 1;
+                    } elseif ($orderLine->invoiced_remaining_qty > 0) {
+                        $orderLine->invoice_status = 2;
+                    }
+
+                    $orderLine->save();
                 }
-
-                $orderLine->save();
             }
 
             return $creditNote;

--- a/app/Http/Controllers/Workflow/InvoicesController.php
+++ b/app/Http/Controllers/Workflow/InvoicesController.php
@@ -28,9 +28,13 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Workflow\DeliveryLines;
 use App\Models\Companies\Companies;
+use App\Models\Accounting\AccountingEntry;
+use App\Models\Accounting\AccountingVat;
+use App\Models\Methods\MethodsUnits;
 use App\Services\InvoiceCalculatorService;
 use App\Services\AccountingPeriodService;
 use App\Http\Requests\Workflow\UpdateInvoiceRequest;
+use Illuminate\Support\Facades\DB;
 
 class InvoicesController extends Controller
 {
@@ -140,7 +144,10 @@ class InvoicesController extends Controller
         }
 
         $dir      = $sortAsc ? 'asc' : 'desc';
-        $totalSub = 'COALESCE((SELECT SUM((order_lines.selling_price * invoice_lines.qty) * (1 - COALESCE(order_lines.discount,0)/100)) FROM invoice_lines JOIN order_lines ON invoice_lines.order_line_id = order_lines.id WHERE invoice_lines.invoices_id = invoices.id AND invoice_lines.deleted_at IS NULL), 0)';
+        // LEFT JOIN : une ligne libre n'a pas de ligne de commande et serait
+        // sinon absente du total. Le snapshot porté par la ligne de facture
+        // prime sur le prix courant de la ligne de commande.
+        $totalSub = 'COALESCE((SELECT SUM((COALESCE(invoice_lines.unit_price, order_lines.selling_price, 0) * invoice_lines.qty) * (1 - COALESCE(invoice_lines.discount, order_lines.discount, 0)/100)) FROM invoice_lines LEFT JOIN order_lines ON invoice_lines.order_line_id = order_lines.id WHERE invoice_lines.invoices_id = invoices.id AND invoice_lines.deleted_at IS NULL), 0)';
 
         $query = Invoices::withCount('invoiceLines')
             ->selectRaw("invoices.*, {$totalSub} as total_amount")
@@ -545,6 +552,9 @@ class InvoicesController extends Controller
             'addresses'        => $addresses,
             'contacts'         => $contacts,
             'companyAcUrl'     => route('invoices.company-ac'),
+            // Référentiels du formulaire d'ajout de ligne libre (brouillon).
+            'vats'             => AccountingVat::orderBy('label')->get(['id', 'label', 'rate', 'default']),
+            'units'            => MethodsUnits::orderBy('label')->get(['id', 'label', 'code', 'default']),
             'paymentMethods'   => AccountingPaymentMethod::orderBy('label')->get(['id', 'label']),
             'paymentEndpoints' => [
                 'index'   => route('invoices.payments.index', $id->id),
@@ -620,6 +630,107 @@ class InvoicesController extends Controller
             'line_total' => round($line->qty * $line->unit_price * (1 - $line->discount / 100), 2),
             'formatted'  => Number::currency($line->unit_price, $currency, config('app.locale')),
         ]);
+    }
+
+    /**
+     * Ajoute une ligne libre à une facture en brouillon.
+     *
+     * Couvre le frais oublié au moment de la commande — port, frais de dossier,
+     * prestation ponctuelle — que l'on veut porter sur la facture existante
+     * plutôt que sur un second document.
+     *
+     * Volontairement limité au brouillon : une facture émise est intangible
+     * (art. L441-9 du code de commerce, art. 242 nonies A du CGI). Passée
+     * l'émission, la correction relève de la facture complémentaire ou de l'avoir.
+     */
+    public function storeLine(Request $request, int $id): \Illuminate\Http\JsonResponse
+    {
+        abort_unless(auth()->check(), 403);
+        $invoice = Invoices::findOrFail($id);
+        abort_if($invoice->statu !== 1, 403, 'La facture n\'est plus en brouillon.');
+
+        if (app(AccountingPeriodService::class)->isLocked($invoice->created_at)) {
+            return response()->json([
+                'message' => "Période {$invoice->created_at->format('m/Y')} verrouillée — cette facture ne peut plus être modifiée.",
+            ], 422);
+        }
+
+        $data = $request->validate([
+            'label'              => 'required|string|max:255',
+            'code'               => 'nullable|string|max:255',
+            'qty'                => 'required|numeric|min:0',
+            'unit_price'         => 'required|numeric|min:0',
+            'discount'           => 'nullable|numeric|min:0|max:100',
+            'product_id'         => 'nullable|exists:products,id',
+            'methods_units_id'   => 'nullable|exists:methods_units,id',
+            'accounting_vats_id' => 'nullable|exists:accounting_vats,id',
+        ]);
+
+        $line = $this->invoiceLineService->createFreeLine($invoice, $data);
+
+        return response()->json([
+            'ok'   => true,
+            'line' => $this->invoiceDataService->formatDraftLine($line),
+        ], 201);
+    }
+
+    /**
+     * Supprime une ligne d'une facture en brouillon.
+     *
+     * Une ligne issue d'une commande rend ses quantités à la ligne d'origine et
+     * rouvre la ligne de BL : sans cela la commande resterait marquée facturée
+     * sans facture en face. Aucun document n'étant encore sorti, il s'agit d'une
+     * correction de saisie et non d'un avoir.
+     */
+    public function destroyLine(Request $request, int $id, int $lineId): \Illuminate\Http\JsonResponse
+    {
+        abort_unless(auth()->check(), 403);
+        $invoice = Invoices::findOrFail($id);
+        abort_if($invoice->statu !== 1, 403, 'La facture n\'est plus en brouillon.');
+
+        if (app(AccountingPeriodService::class)->isLocked($invoice->created_at)) {
+            return response()->json([
+                'message' => "Période {$invoice->created_at->format('m/Y')} verrouillée — cette facture ne peut plus être modifiée.",
+            ], 422);
+        }
+
+        $line = InvoiceLines::where('id', $lineId)->where('invoices_id', $id)->firstOrFail();
+
+        DB::transaction(function () use ($line) {
+            // Écritures de vente générées à la création de la ligne.
+            AccountingEntry::where('invoice_line_id', $line->id)->delete();
+
+            if ($line->order_line_id) {
+                $orderLine = OrderLines::lockForUpdate()->find($line->order_line_id);
+                if ($orderLine) {
+                    $orderLine->invoiced_qty            = max(0, $orderLine->invoiced_qty - $line->qty);
+                    $orderLine->invoiced_remaining_qty += $line->qty;
+                    $orderLine->invoice_status          = $orderLine->invoiced_qty <= 0 ? 1 : 2;
+                    $orderLine->save();
+                }
+            }
+
+            // La ligne de BL redevient facturable, sauf si une autre ligne de
+            // facture la référence encore. Statut dérivé plutôt que forcé : on
+            // ne repasse jamais « facturable » une ligne encore facturée ailleurs.
+            if ($line->delivery_line_id) {
+                $deliveryLine = DeliveryLines::find($line->delivery_line_id);
+                if ($deliveryLine) {
+                    $stillInvoiced = InvoiceLines::where('delivery_line_id', $deliveryLine->id)
+                        ->where('id', '<>', $line->id)
+                        ->exists();
+
+                    $deliveryLine->invoice_status = $stillInvoiced ? 4 : 1;
+                    $deliveryLine->save();
+                    // Recalcule l'en-tête du BL (deliverys.invoice_status).
+                    event(new DeliveryLineUpdated($deliveryLine));
+                }
+            }
+
+            $line->delete();
+        });
+
+        return response()->json(['ok' => true]);
     }
 
     public function emit(Request $request, int $id): \Illuminate\Http\JsonResponse

--- a/app/Models/Workflow/CreditNoteLines.php
+++ b/app/Models/Workflow/CreditNoteLines.php
@@ -18,13 +18,51 @@ class CreditNoteLines extends Model
     
     // Fillable attributes for mass assignment
     protected $fillable= [
-        'credit_note_id', 
-        'order_line_id', 
-        'invoice_line_id', 
-        'product_id', 
-        'qty', 
-        'unit_price', 
+        'credit_note_id',
+        'order_line_id',
+        'invoice_line_id',
+        'product_id',
+        'label',
+        'qty',
+        'unit_price',
+        'discount',
+        'vat_rate',
+        'accounting_vats_id',
     ];
+
+    /**
+     * Désignation à afficher. Une ligne d'avoir peut porter sur une ligne de
+     * facture libre, sans ligne de commande derrière.
+     */
+    public function getDisplayLabelAttribute(): string
+    {
+        return $this->label ?? $this->orderLine?->label ?? $this->invoiceLine?->display_label ?? '';
+    }
+
+    public function getDisplayCodeAttribute(): string
+    {
+        return $this->orderLine?->code ?? $this->invoiceLine?->display_code ?? '';
+    }
+
+    public function getDisplayUnitLabelAttribute(): string
+    {
+        return $this->orderLine?->Unit?->label ?? $this->invoiceLine?->display_unit_label ?? '';
+    }
+
+    public function getResolvedDiscountAttribute(): float
+    {
+        return (float) ($this->discount ?? $this->orderLine?->discount ?? 0);
+    }
+
+    public function getResolvedVatRateAttribute(): float
+    {
+        return (float) ($this->vat_rate ?? $this->orderLine?->VAT?->rate ?? 0);
+    }
+
+    public function getResolvedVatIdAttribute(): ?int
+    {
+        return $this->accounting_vats_id ?? $this->orderLine?->accounting_vats_id;
+    }
 
     public function creditNote()
     {

--- a/app/Models/Workflow/InvoiceLines.php
+++ b/app/Models/Workflow/InvoiceLines.php
@@ -7,12 +7,29 @@ use App\Models\Workflow\Invoices;
 use Spatie\Activitylog\LogOptions;
 use App\Models\Workflow\OrderLines;
 use App\Models\Workflow\DeliveryLines;
+use App\Models\Products\Products;
+use App\Models\Methods\MethodsUnits;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Accounting\AccountingVat;
 use App\Models\Accounting\AccountingEntry;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * Ligne de facture.
+ *
+ * Deux natures de lignes cohabitent :
+ *  - la ligne issue d'une commande (`order_line_id` renseigné), qui reste la
+ *    très grande majorité des cas ;
+ *  - la ligne libre (`order_line_id` null), saisie directement sur une facture
+ *    en brouillon : frais de port, frais de dossier, prestation ponctuelle.
+ *
+ * Les accesseurs `display_*` / `resolved_*` donnent la valeur à utiliser sans
+ * avoir à savoir de quelle nature est la ligne : ils lisent le champ porté par
+ * la ligne de facture et retombent sur la ligne de commande pour les lignes
+ * antérieures au snapshot.
+ */
 class InvoiceLines extends Model
 {
     use HasFactory, SoftDeletes, LogsActivity;
@@ -21,11 +38,16 @@ class InvoiceLines extends Model
     protected $fillable= ['invoices_id',
                             'order_line_id',
                             'delivery_line_id',
+                            'label',
+                            'code',
+                            'product_id',
+                            'methods_units_id',
                             'ordre',
                             'qty',
                             'unit_price',
                             'discount',
                             'vat_rate',
+                            'accounting_vats_id',
                             'accounting_allocation_id',
                             'invoice_status',
                         ];
@@ -45,10 +67,96 @@ class InvoiceLines extends Model
         return $this->belongsTo(DeliveryLines::class, 'delivery_line_id');
     }
 
+    public function Product()
+    {
+        return $this->belongsTo(Products::class, 'product_id');
+    }
+
+    public function Unit()
+    {
+        return $this->belongsTo(MethodsUnits::class, 'methods_units_id');
+    }
+
+    public function VAT()
+    {
+        return $this->belongsTo(AccountingVat::class, 'accounting_vats_id');
+    }
+
     // Relation avec AccountingEntry pour l'entrée comptable liée à cette ligne de facture
     public function accountingEntry()
     {
         return $this->hasOne(AccountingEntry::class, 'invoice_line_id');
+    }
+
+    /**
+     * Une ligne libre n'a pas de ligne de commande d'origine.
+     */
+    public function getIsFreeLineAttribute(): bool
+    {
+        return $this->order_line_id === null;
+    }
+
+    /**
+     * Désignation à afficher : celle portée par la ligne de facture, sinon
+     * celle de la ligne de commande.
+     */
+    public function getDisplayLabelAttribute(): string
+    {
+        return $this->label ?? $this->orderLine?->label ?? '';
+    }
+
+    public function getDisplayCodeAttribute(): string
+    {
+        return $this->code ?? $this->orderLine?->code ?? '';
+    }
+
+    /**
+     * Unité résolue (objet MethodsUnits) ou null.
+     */
+    public function getDisplayUnitAttribute()
+    {
+        return $this->methods_units_id ? $this->Unit : $this->orderLine?->Unit;
+    }
+
+    public function getDisplayUnitLabelAttribute(): string
+    {
+        return $this->display_unit->label ?? '';
+    }
+
+    public function getDisplayUnitCodeAttribute(): ?string
+    {
+        return $this->display_unit->code ?? null;
+    }
+
+    public function getResolvedUnitPriceAttribute(): float
+    {
+        return (float) ($this->unit_price ?? $this->orderLine?->selling_price ?? 0);
+    }
+
+    public function getResolvedDiscountAttribute(): float
+    {
+        return (float) ($this->discount ?? $this->orderLine?->discount ?? 0);
+    }
+
+    public function getResolvedVatRateAttribute(): float
+    {
+        return (float) ($this->vat_rate ?? $this->orderLine?->VAT?->rate ?? 0);
+    }
+
+    /**
+     * Identifiant de TVA servant de clé de regroupement dans la ventilation.
+     */
+    public function getResolvedVatIdAttribute(): ?int
+    {
+        return $this->accounting_vats_id ?? $this->orderLine?->accounting_vats_id;
+    }
+
+    /**
+     * Montant HT de la ligne, remise déduite.
+     */
+    public function getLineTotalAttribute(): float
+    {
+        return (float) $this->qty * $this->resolved_unit_price * (1 - $this->resolved_discount / 100);
     }
 
     /**
@@ -64,8 +172,7 @@ class InvoiceLines extends Model
     {
         $factory  = app('Factory');
         $currency = $factory->curency ?? 'EUR';
-        $price    = $this->unit_price ?? $this->orderLine->selling_price;
-        return Number::currency($price, $currency, config('app.locale'));
+        return Number::currency($this->resolved_unit_price, $currency, config('app.locale'));
     }
 
     /**

--- a/app/Services/CreditNoteCalculatorService.php
+++ b/app/Services/CreditNoteCalculatorService.php
@@ -20,6 +20,25 @@ class CreditNoteCalculatorService
     }
 
     /**
+     * Résout prix unitaire, remise, taux et identifiant de TVA d'une ligne d'avoir.
+     *
+     * Le prix vient du snapshot figé à la création de l'avoir, et non du prix
+     * courant de la ligne de commande. Les lignes d'avoir portant sur une ligne
+     * de facture libre n'ont d'ailleurs aucune ligne de commande derrière.
+     */
+    private function lineSnapshot($creditNotesLine): array
+    {
+        $unitPrice = (float) ($creditNotesLine->unit_price ?? $creditNotesLine->orderLine?->selling_price ?? 0);
+        $discount  = $creditNotesLine->resolved_discount;
+        $vatRate   = $creditNotesLine->resolved_vat_rate;
+
+        // Clé de regroupement : à défaut d'identifiant de TVA, le taux.
+        $vatId = $creditNotesLine->resolved_vat_id ?? 'rate-' . number_format($vatRate, 3, '.', '');
+
+        return [$unitPrice, $discount, $vatRate, $vatId];
+    }
+
+    /**
      * Calculate the total VAT for the credit notes.
      *
      * This function iterates through the credit note lines and calculates the total VAT for each line.
@@ -31,17 +50,20 @@ class CreditNoteCalculatorService
     {
         $tableauTVA = array();
         $creditNotesLines = $this->creditNotes->creditNotelines;
+
         foreach ($creditNotesLines as $creditNotesLine) {
-            $vatRate = optional($creditNotesLine->orderLine->VAT)['rate'] ?? 0;
-            $TotalCurentLine = ($creditNotesLine->qty*$creditNotesLine->orderLine->selling_price)-($creditNotesLine->qty*$creditNotesLine->orderLine->selling_price)*($creditNotesLine->orderLine->discount/100);
+            [$unitPrice, $discount, $vatRate, $vatId] = $this->lineSnapshot($creditNotesLine);
+
+            $TotalCurentLine    = $creditNotesLine->qty * $unitPrice * (1 - $discount / 100);
             $TotalVATCurentLine = $TotalCurentLine * ($vatRate / 100);
-            if(array_key_exists($creditNotesLine->orderLine->accounting_vats_id, $tableauTVA)){
-                $tableauTVA[$creditNotesLine->orderLine->accounting_vats_id][1] += $TotalVATCurentLine;
-            }
-            else{
-                $tableauTVA[$creditNotesLine->orderLine->accounting_vats_id] = array($vatRate, $TotalVATCurentLine);
+
+            if (array_key_exists($vatId, $tableauTVA)) {
+                $tableauTVA[$vatId][1] += $TotalVATCurentLine;
+            } else {
+                $tableauTVA[$vatId] = array($vatRate, $TotalVATCurentLine);
             }
         }
+
         asort($tableauTVA);
         return $tableauTVA;
     }
@@ -50,8 +72,8 @@ class CreditNoteCalculatorService
     /**
      * Calculate the total price of all credit note lines including VAT and discount.
      *
-     * This method iterates through each credit note line, calculates the line total 
-     * by considering the quantity, selling price, and discount. It then adds the VAT 
+     * This method iterates through each credit note line, calculates the line total
+     * by considering the quantity, selling price, and discount. It then adds the VAT
      * to the line total and accumulates the total price.
      *
      * @return float The total price of all credit note lines including VAT and discount.
@@ -60,16 +82,15 @@ class CreditNoteCalculatorService
     {
         $TotalPrice = 0;
         $creditNotesLines = $this->creditNotes->creditNotelines;
-        
-        foreach ($creditNotesLines as $creditNotesLine) {
-            $vatRate = optional($creditNotesLine->orderLine->VAT)['rate'] ?? 0;
-            $TotalPriceLine = ($creditNotesLine->qty * $creditNotesLine->orderLine->selling_price)-($creditNotesLine->qty * $creditNotesLine->orderLine->selling_price)*($creditNotesLine->orderLine->discount/100);
-            $TotalVATPrice = $TotalPriceLine * ($vatRate / 100);
-            $TotalPrice += $TotalPriceLine+$TotalVATPrice;
 
-            
+        foreach ($creditNotesLines as $creditNotesLine) {
+            [$unitPrice, $discount, $vatRate] = $this->lineSnapshot($creditNotesLine);
+
+            $TotalPriceLine = $creditNotesLine->qty * $unitPrice * (1 - $discount / 100);
+            $TotalVATPrice  = $TotalPriceLine * ($vatRate / 100);
+            $TotalPrice    += $TotalPriceLine + $TotalVATPrice;
         }
-        
+
         return $TotalPrice;
     }
 
@@ -77,7 +98,7 @@ class CreditNoteCalculatorService
      * Calculate the subtotal for the credit notes.
      *
      * This method iterates through the credit note lines and calculates the subtotal
-     * by summing up the product of quantity and selling price for each line, 
+     * by summing up the product of quantity and selling price for each line,
      * adjusted for any discounts.
      *
      * @return float The calculated subtotal for the credit notes.
@@ -86,12 +107,13 @@ class CreditNoteCalculatorService
     {
         $SubTotal = 0;
         $creditNotesLines = $this->creditNotes->creditNotelines;
+
         foreach ($creditNotesLines as $creditNotesLine) {
-            $SubTotal += round(
-                $creditNotesLine->qty * $creditNotesLine->orderLine->selling_price * (1 - $creditNotesLine->orderLine->discount / 100),
-                2
-            );
+            [$unitPrice, $discount] = $this->lineSnapshot($creditNotesLine);
+
+            $SubTotal += round($creditNotesLine->qty * $unitPrice * (1 - $discount / 100), 2);
         }
+
         return $SubTotal;
     }
 

--- a/app/Services/CreditNoteKPIService.php
+++ b/app/Services/CreditNoteKPIService.php
@@ -32,11 +32,14 @@ class CreditNoteKPIService
      */
     public function getCreditNotesMonthlyRecap($year)
     {
+        // LEFT JOIN : un avoir peut porter sur une ligne de facture libre, sans
+        // ligne de commande. Le prix figé sur la ligne d'avoir fait foi.
         return DB::table('credit_note_lines')
-                    ->join('order_lines', 'credit_note_lines.order_line_id', '=', 'order_lines.id')
+                    ->leftJoin('order_lines', 'credit_note_lines.order_line_id', '=', 'order_lines.id')
                     ->selectRaw('
                         MONTH(credit_note_lines.created_at) AS month,
-                        SUM((order_lines.selling_price * credit_note_lines.qty)-(order_lines.selling_price * credit_note_lines.qty)*(order_lines.discount/100)) AS orderSum
+                        SUM(COALESCE(credit_note_lines.unit_price, order_lines.selling_price, 0) * credit_note_lines.qty
+                            * (1 - COALESCE(credit_note_lines.discount, order_lines.discount, 0)/100)) AS orderSum
                     ')
                     ->whereYear('credit_note_lines.created_at', $year)
                     ->groupByRaw('MONTH(credit_note_lines.created_at) ')

--- a/app/Services/InvoiceCalculatorService.php
+++ b/app/Services/InvoiceCalculatorService.php
@@ -20,13 +20,20 @@ class InvoiceCalculatorService
      * Résout le prix unitaire, remise et taux TVA pour une ligne.
      * Utilise le snapshot stocké sur invoice_lines en priorité ;
      * repli sur orderLine pour les lignes antérieures à la migration.
+     *
+     * Les lignes libres (frais de port, prestation ponctuelle) n'ont pas de
+     * ligne de commande : tout vient alors du snapshot.
      */
     private function lineSnapshot($invoicesLine): array
     {
-        $unitPrice = $invoicesLine->unit_price ?? $invoicesLine->orderLine->selling_price;
-        $discount  = $invoicesLine->discount  ?? $invoicesLine->orderLine->discount;
-        $vatRate   = $invoicesLine->vat_rate  ?? ($invoicesLine->orderLine->VAT['rate'] ?? 0);
-        $vatId     = $invoicesLine->orderLine->accounting_vats_id;
+        $unitPrice = $invoicesLine->resolved_unit_price;
+        $discount  = $invoicesLine->resolved_discount;
+        $vatRate   = $invoicesLine->resolved_vat_rate;
+
+        // Clé de regroupement de la ventilation TVA. Une ligne libre peut ne
+        // porter aucun identifiant de TVA : on retombe alors sur le taux, pour
+        // ne pas agréger toutes ces lignes sous une clé vide.
+        $vatId = $invoicesLine->resolved_vat_id ?? 'rate-' . number_format((float) $vatRate, 3, '.', '');
 
         return [$unitPrice, $discount, $vatRate, $vatId];
     }
@@ -129,15 +136,15 @@ class InvoiceCalculatorService
             $netUnitPrice = $unitPrice * (1 - $discount / 100);
 
             $lines[] = [
-                'label'          => $invoicesLine->orderLine->label ?? '',
-                'code'           => $invoicesLine->orderLine->code ?? '',
+                'label'          => $invoicesLine->display_label,
+                'code'           => $invoicesLine->display_code,
                 'qty'            => (float) $invoicesLine->qty,
                 'unit_price'     => (float) $unitPrice,
                 'discount'       => (float) $discount,
                 'vat_rate'       => (float) $vatRate,
                 'net_unit_price' => $netUnitPrice,
                 'line_total'     => $invoicesLine->qty * $netUnitPrice,
-                'unit_code'      => $invoicesLine->orderLine->Unit->code ?? null,
+                'unit_code'      => $invoicesLine->display_unit_code,
             ];
         }
 

--- a/app/Services/InvoiceDataService.php
+++ b/app/Services/InvoiceDataService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Workflow\DeliveryLines;
+use App\Models\Workflow\InvoiceLines;
 use Illuminate\Support\Collection;
 
 class InvoiceDataService
@@ -55,5 +56,35 @@ class InvoiceDataService
                     $q->whereDate('created_at', '<=', $dateEnd);
                 }
             })->get();
+    }
+
+    /**
+     * Sérialise une ligne de facture pour le composant React du brouillon.
+     *
+     * Source unique pour la vue (rendu initial) et pour l'API (ligne ajoutée),
+     * afin que les deux ne divergent pas. Tolère les lignes libres, qui n'ont
+     * ni commande ni bon de livraison en face.
+     */
+    public function formatDraftLine(InvoiceLines $line): array
+    {
+        $order    = $line->orderLine?->order;
+        $delivery = $line->delivery_line_id ? $line->deliveryLine?->delivery : null;
+
+        return [
+            'id'               => $line->id,
+            'qty'              => (float) $line->qty,
+            'unit_price'       => $line->resolved_unit_price,
+            'discount'         => $line->resolved_discount,
+            'vat_rate'         => $line->resolved_vat_rate,
+            'invoice_status'   => $line->invoice_status,
+            'is_free_line'     => $line->is_free_line,
+            'order_line_code'  => $line->display_code,
+            'order_line_label' => $line->display_label,
+            'unit_label'       => $line->display_unit_label,
+            'order_code'       => $order?->code,
+            'order_url'        => $order ? route('orders.show', $order->id) : null,
+            'delivery_code'    => $delivery?->code,
+            'delivery_url'     => $delivery ? route('deliverys.show', ['id' => $delivery->id]) : null,
+        ];
     }
 }

--- a/app/Services/InvoiceKPIService.php
+++ b/app/Services/InvoiceKPIService.php
@@ -29,12 +29,16 @@ class InvoiceKPIService
             : 'invoice_monthly_recap_' . $year;
 
         return Cache::remember($cacheKey, now()->addHours(1), function () use ($year, $start, $end) {
+            // LEFT JOIN : les lignes libres n'ont pas de ligne de commande et
+            // seraient sinon absentes du CA. Le snapshot de la ligne de facture
+            // prime sur le prix courant de la ligne de commande.
             $query = DB::table('invoice_lines')
-                        ->join('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
+                        ->leftJoin('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
                         ->join('invoices', 'invoice_lines.invoices_id', '=', 'invoices.id')
                         ->selectRaw('
                             MONTH(invoice_lines.created_at) AS month,
-                            SUM((order_lines.selling_price * invoice_lines.qty) - (order_lines.selling_price * invoice_lines.qty)*(order_lines.discount/100)) AS orderSum
+                            SUM(COALESCE(invoice_lines.unit_price, order_lines.selling_price, 0) * invoice_lines.qty
+                                * (1 - COALESCE(invoice_lines.discount, order_lines.discount, 0)/100)) AS orderSum
                         ')
                         ->where('invoices.invoice_type', 1)
                         ->whereNull('invoices.deleted_at')
@@ -64,13 +68,14 @@ class InvoiceKPIService
                 ->join('invoice_lines', fn ($j) => $j
                     ->on('invoice_lines.invoices_id', '=', 'invoices.id')
                     ->whereNull('invoice_lines.deleted_at'))
-                ->join('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
+                ->leftJoin('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
                 ->leftJoin('accounting_vats', 'accounting_vats.id', '=', 'order_lines.accounting_vats_id')
                 ->where('invoices.invoice_type', 1)
                 ->whereNull('invoices.deleted_at')
                 ->selectRaw('COALESCE(SUM(
-                    order_lines.selling_price * invoice_lines.qty * (1 - order_lines.discount / 100) *
-                    (1 + COALESCE(accounting_vats.rate, 0) / 100)
+                    COALESCE(invoice_lines.unit_price, order_lines.selling_price, 0) * invoice_lines.qty
+                    * (1 - COALESCE(invoice_lines.discount, order_lines.discount, 0) / 100) *
+                    (1 + COALESCE(invoice_lines.vat_rate, accounting_vats.rate, 0) / 100)
                 ), 0) as total')
                 ->value('total') ?? 0;
         });
@@ -83,14 +88,15 @@ class InvoiceKPIService
                 ->join('invoice_lines', fn ($j) => $j
                     ->on('invoice_lines.invoices_id', '=', 'invoices.id')
                     ->whereNull('invoice_lines.deleted_at'))
-                ->join('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
+                ->leftJoin('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
                 ->leftJoin('accounting_vats', 'accounting_vats.id', '=', 'order_lines.accounting_vats_id')
                 ->where('invoices.invoice_type', 1)
                 ->where('invoices.statu', 5)
                 ->whereNull('invoices.deleted_at')
                 ->selectRaw('COALESCE(SUM(
-                    order_lines.selling_price * invoice_lines.qty * (1 - order_lines.discount / 100) *
-                    (1 + COALESCE(accounting_vats.rate, 0) / 100)
+                    COALESCE(invoice_lines.unit_price, order_lines.selling_price, 0) * invoice_lines.qty
+                    * (1 - COALESCE(invoice_lines.discount, order_lines.discount, 0) / 100) *
+                    (1 + COALESCE(invoice_lines.vat_rate, accounting_vats.rate, 0) / 100)
                 ), 0) as total')
                 ->value('total') ?? 0;
         });
@@ -150,9 +156,9 @@ class InvoiceKPIService
     public function getTopClients()
     {
         return Cache::remember('invoice_top_clients_' . now()->year, now()->addHours(1), function () {
-            return Invoices::select('companies_id', DB::raw('SUM((invoice_lines.qty * order_lines.selling_price) - (invoice_lines.qty * order_lines.selling_price)*(order_lines.discount/100)) as total_amount'))
+            return Invoices::select('companies_id', DB::raw('SUM(invoice_lines.qty * COALESCE(invoice_lines.unit_price, order_lines.selling_price, 0) * (1 - COALESCE(invoice_lines.discount, order_lines.discount, 0)/100)) as total_amount'))
                             ->join('invoice_lines', 'invoices.id', '=', 'invoice_lines.invoices_id')
-                            ->join('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
+                            ->leftJoin('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
                             ->where('invoices.invoice_type', 1)
                             ->whereNull('invoice_lines.deleted_at')
                             ->groupBy('companies_id')
@@ -165,12 +171,15 @@ class InvoiceKPIService
     public function getTopProducts()
     {
         return Cache::remember('invoice_top_products_' . now()->year, now()->addHours(1), function () {
-            return InvoiceLines::select('order_lines.product_id', DB::raw('SUM(invoice_lines.qty) as total_quantity'))
-                                ->join('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
+            // Une ligne libre peut porter son propre produit ; à défaut elle est
+            // exclue (product_id null), comme les lignes de commande sans produit.
+            return InvoiceLines::select(DB::raw('COALESCE(invoice_lines.product_id, order_lines.product_id) as product_id'), DB::raw('SUM(invoice_lines.qty) as total_quantity'))
+                                ->leftJoin('order_lines', 'invoice_lines.order_line_id', '=', 'order_lines.id')
                                 ->join('invoices', 'invoice_lines.invoices_id', '=', 'invoices.id')
                                 ->where('invoices.invoice_type', 1)
                                 ->whereNull('invoices.deleted_at')
-                                ->groupBy('order_lines.product_id')
+                                ->whereRaw('COALESCE(invoice_lines.product_id, order_lines.product_id) IS NOT NULL')
+                                ->groupByRaw('COALESCE(invoice_lines.product_id, order_lines.product_id)')
                                 ->orderByDesc('total_quantity')
                                 ->take(5)
                                 ->get();

--- a/app/Services/InvoiceLineService.php
+++ b/app/Services/InvoiceLineService.php
@@ -4,7 +4,10 @@ namespace App\Services;
 
 use App\Services\TaskService;
 use App\Models\Workflow\InvoiceLines;
+use App\Models\Workflow\Invoices;
 use App\Models\Workflow\OrderLines;
+use App\Models\Accounting\AccountingVat;
+use App\Models\Methods\MethodsUnits;
 
 class InvoiceLineService
 {
@@ -48,8 +51,9 @@ class InvoiceLineService
             'unit_price'               => $orderLine->selling_price,
             'discount'                 => $orderLine->discount,
             'vat_rate'                 => $orderLine->VAT?->rate ?? 0,
+            'accounting_vats_id'       => $orderLine->accounting_vats_id,
             'accounting_allocation_id' => $allocationId,
-            'statu'                    => 1,
+            'invoice_status'           => 1,
         ]);
 
         if ($allocationId != null && $invoiceCreated->invoice_type === 1) {
@@ -61,5 +65,57 @@ class InvoiceLineService
         }
 
         return $invoiceLines;
+    }
+
+    /**
+     * Crée une ligne de facture libre, sans ligne de commande d'origine.
+     *
+     * Répond au cas des prestations facturées après coup — frais de port, frais
+     * de dossier, prestation ponctuelle — pour lesquelles il n'existe ni ligne
+     * de commande ni bon de livraison. La ligne porte elle-même sa désignation,
+     * son unité et sa TVA ; le snapshot de prix est donc complet dès la création.
+     *
+     * @param  \App\Models\Workflow\Invoices  $invoice  Facture (en brouillon) qui reçoit la ligne.
+     * @param  array  $data  label, code, qty, unit_price, discount, accounting_vats_id, methods_units_id, product_id.
+     * @return \App\Models\Workflow\InvoiceLines
+     */
+    public function createFreeLine(Invoices $invoice, array $data): InvoiceLines
+    {
+        $vat  = isset($data['accounting_vats_id'])
+            ? AccountingVat::find($data['accounting_vats_id'])
+            : AccountingVat::getDefault();
+
+        $unit = isset($data['methods_units_id'])
+            ? MethodsUnits::find($data['methods_units_id'])
+            : MethodsUnits::getDefault();
+
+        $allocationId = $vat ? $this->accountingEntryService->getAllocationId(1, $vat->id) : null;
+
+        // La ligne se place en fin de facture.
+        $ordre = (int) InvoiceLines::where('invoices_id', $invoice->id)->max('ordre') + 10;
+
+        $invoiceLine = InvoiceLines::create([
+            'invoices_id'              => $invoice->id,
+            'order_line_id'            => null,
+            'delivery_line_id'         => null,
+            'label'                    => $data['label'],
+            'code'                     => $data['code'] ?? null,
+            'product_id'               => $data['product_id'] ?? null,
+            'methods_units_id'         => $unit?->id,
+            'ordre'                    => $ordre,
+            'qty'                      => $data['qty'],
+            'unit_price'               => $data['unit_price'],
+            'discount'                 => $data['discount'] ?? 0,
+            'vat_rate'                 => $vat?->rate ?? 0,
+            'accounting_vats_id'       => $vat?->id,
+            'accounting_allocation_id' => $allocationId,
+            'invoice_status'           => $invoice->statu,
+        ]);
+
+        if ($allocationId !== null && $invoice->invoice_type === 1) {
+            $this->accountingEntryService->createSaleEntry($invoiceLine);
+        }
+
+        return $invoiceLine;
     }
 }

--- a/database/migrations/2026_08_20_000001_allow_free_invoice_lines.php
+++ b/database/migrations/2026_08_20_000001_allow_free_invoice_lines.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lignes de facture libres.
+ *
+ * Jusqu'ici une ligne de facture ne pouvait exister qu'en face d'une ligne de
+ * commande : `order_line_id` était NOT NULL et le libellé, le code, l'unité et
+ * la TVA étaient tous lus depuis `order_lines`. Impossible donc de facturer un
+ * frais de port, un frais de dossier ou une prestation ponctuelle oubliés au
+ * moment de la commande.
+ *
+ * On rend `order_line_id` nullable et on porte sur la ligne de facture les
+ * champs descriptifs, dans la continuité du snapshot de prix introduit par
+ * 2026_04_21_000003_add_price_snapshot_to_invoice_lines.
+ *
+ * Même traitement sur `credit_note_lines` : un avoir doit pouvoir porter sur
+ * une ligne libre.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoice_lines', function (Blueprint $table) {
+            $table->integer('order_line_id')->nullable()->change();
+
+            $table->string('label')->nullable()->after('delivery_line_id');
+            $table->string('code')->nullable()->after('label');
+            $table->unsignedBigInteger('product_id')->nullable()->after('code');
+            $table->unsignedBigInteger('methods_units_id')->nullable()->after('product_id');
+            $table->unsignedBigInteger('accounting_vats_id')->nullable()->after('vat_rate');
+        });
+
+        // La FK doit tomber avant de pouvoir modifier la colonne sous MySQL.
+        Schema::table('credit_note_lines', function (Blueprint $table) {
+            $table->dropForeign(['order_line_id']);
+        });
+
+        Schema::table('credit_note_lines', function (Blueprint $table) {
+            $table->unsignedBigInteger('order_line_id')->nullable()->change();
+
+            // Snapshot descriptif, nécessaire dès lors que la ligne d'origine
+            // n'est plus systématiquement une ligne de commande.
+            $table->string('label')->nullable()->after('invoice_line_id');
+            $table->decimal('discount', 5, 2)->nullable()->after('unit_price');
+            $table->decimal('vat_rate', 5, 2)->nullable()->after('discount');
+            $table->unsignedBigInteger('accounting_vats_id')->nullable()->after('vat_rate');
+        });
+
+        Schema::table('credit_note_lines', function (Blueprint $table) {
+            $table->foreign('order_line_id')->references('id')->on('order_lines')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('credit_note_lines', function (Blueprint $table) {
+            $table->dropForeign(['order_line_id']);
+        });
+
+        Schema::table('credit_note_lines', function (Blueprint $table) {
+            $table->dropColumn(['label', 'discount', 'vat_rate', 'accounting_vats_id']);
+            $table->unsignedBigInteger('order_line_id')->nullable(false)->change();
+        });
+
+        Schema::table('credit_note_lines', function (Blueprint $table) {
+            $table->foreign('order_line_id')->references('id')->on('order_lines')->onDelete('cascade');
+        });
+
+        Schema::table('invoice_lines', function (Blueprint $table) {
+            $table->dropColumn(['label', 'code', 'product_id', 'methods_units_id', 'accounting_vats_id']);
+            $table->integer('order_line_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1622,6 +1622,8 @@ async function mountInvoiceLinesDraft() {
             lines:     parse('lines')     ?? [],
             endpoints: parse('endpoints') ?? {},
             currency:  el.dataset.currency ?? 'EUR',
+            vats:      parse('vats')      ?? [],
+            units:     parse('units')     ?? [],
             trans:     parse('trans')     ?? {},
         })
     );

--- a/resources/js/components/InvoiceLinesDraft.jsx
+++ b/resources/js/components/InvoiceLinesDraft.jsx
@@ -28,14 +28,134 @@ function LineTotal({ qty, unitPrice, discount }) {
     return <span>{formatCurrency(isNaN(total) ? 0 : total)}</span>;
 }
 
-export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, lines: initialLines, endpoints, currency, trans }) {
+/**
+ * Première erreur de validation renvoyée par Laravel, à défaut le message brut.
+ */
+function firstError(e, fallback) {
+    const errors = e?.data?.errors;
+    if (errors) {
+        const first = Object.values(errors)[0];
+        if (Array.isArray(first) && first.length) return first[0];
+    }
+    return e?.data?.message ?? fallback;
+}
+
+const EMPTY_LINE = {
+    label: '', code: '', qty: '1', unit_price: '', discount: '0',
+    methods_units_id: '', accounting_vats_id: '',
+};
+
+/**
+ * Saisie d'une ligne libre : une ligne de facture sans ligne de commande en
+ * face. Sert au frais oublié au moment de la commande — port, frais de dossier,
+ * prestation ponctuelle — que l'on veut porter sur la facture existante plutôt
+ * que sur un second document.
+ */
+function NewLineForm({ vats, units, currency, onSubmit, saving }) {
+    const defaultVat  = vats.find(v => Number(v.default) === 1);
+    const defaultUnit = units.find(u => Number(u.default) === 1);
+
+    const blank = () => ({
+        ...EMPTY_LINE,
+        methods_units_id:   defaultUnit ? String(defaultUnit.id) : '',
+        accounting_vats_id: defaultVat  ? String(defaultVat.id)  : '',
+    });
+
+    const [form, setForm] = useState(blank);
+
+    const set = (field) => (e) => setForm(prev => ({ ...prev, [field]: e.target.value }));
+
+    const qty      = parseFloat(form.qty) || 0;
+    const price    = parseFloat(form.unit_price) || 0;
+    const discount = parseFloat(form.discount) || 0;
+    const total    = qty * price * (1 - discount / 100);
+
+    function handleSubmit(e) {
+        e.preventDefault();
+        onSubmit({
+            label:              form.label,
+            code:               form.code || null,
+            qty,
+            unit_price:         price,
+            discount,
+            methods_units_id:   form.methods_units_id   ? Number(form.methods_units_id)   : null,
+            accounting_vats_id: form.accounting_vats_id ? Number(form.accounting_vats_id) : null,
+        }, () => setForm(blank()));
+    }
+
+    return (
+        <form className="card card-outline card-primary mt-3" onSubmit={handleSubmit}>
+            <div className="card-header py-2">
+                <h3 className="card-title">
+                    <i className="fas fa-plus-circle mr-2"></i>Ajouter une ligne
+                </h3>
+                <span className="text-muted small float-right">
+                    Frais de port, frais de dossier, prestation non commandée
+                </span>
+            </div>
+            <div className="card-body py-2">
+                <div className="form-row align-items-end">
+                    <div className="form-group col-md-3 mb-2">
+                        <label className="small mb-1">Désignation *</label>
+                        <input type="text" className="form-control form-control-sm" required maxLength={255}
+                               placeholder="Frais de port" value={form.label} onChange={set('label')} />
+                    </div>
+                    <div className="form-group col-md-1 mb-2">
+                        <label className="small mb-1">Réf.</label>
+                        <input type="text" className="form-control form-control-sm" maxLength={255}
+                               value={form.code} onChange={set('code')} />
+                    </div>
+                    <div className="form-group col-md-1 mb-2">
+                        <label className="small mb-1">Qté *</label>
+                        <input type="number" min="0" step="0.001" className="form-control form-control-sm text-right"
+                               required value={form.qty} onChange={set('qty')} />
+                    </div>
+                    <div className="form-group col-md-1 mb-2">
+                        <label className="small mb-1">Unité</label>
+                        <select className="form-control form-control-sm" value={form.methods_units_id} onChange={set('methods_units_id')}>
+                            {units.map(u => <option key={u.id} value={u.id}>{u.label}</option>)}
+                        </select>
+                    </div>
+                    <div className="form-group col-md-2 mb-2">
+                        <label className="small mb-1">P.U HT *</label>
+                        <input type="number" min="0" step="0.01" className="form-control form-control-sm text-right"
+                               required value={form.unit_price} onChange={set('unit_price')} />
+                    </div>
+                    <div className="form-group col-md-1 mb-2">
+                        <label className="small mb-1">Remise %</label>
+                        <input type="number" min="0" max="100" step="0.01" className="form-control form-control-sm text-right"
+                               value={form.discount} onChange={set('discount')} />
+                    </div>
+                    <div className="form-group col-md-1 mb-2">
+                        <label className="small mb-1">TVA</label>
+                        <select className="form-control form-control-sm" value={form.accounting_vats_id} onChange={set('accounting_vats_id')}>
+                            {vats.map(v => <option key={v.id} value={v.id}>{v.label}</option>)}
+                        </select>
+                    </div>
+                    <div className="form-group col-md-2 mb-2 text-right">
+                        <div className="small text-muted mb-1">{formatCurrency(total, currency)} HT</div>
+                        <button type="submit" className="btn btn-primary btn-sm btn-block" disabled={saving}>
+                            {saving
+                                ? <><i className="fas fa-spinner fa-spin mr-1"></i>Ajout…</>
+                                : <><i className="fas fa-plus mr-1"></i>Ajouter</>}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    );
+}
+
+export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, lines: initialLines, endpoints, currency, vats = [], units = [], trans }) {
     const [lines, setLines]   = useState(initialLines);
     const [statu, setStatu]   = useState(initialStatu);
     const [saving, setSaving] = useState({});
+    const [adding, setAdding] = useState(false);
     const [emitting, setEmitting] = useState(false);
     const [error, setError]   = useState(null);
 
-    const isDraft = statu === 1;
+    const isDraft  = statu === 1;
+    const colCount = isDraft ? 12 : 11;
 
     async function handleLineChange(lineId, field, rawValue) {
         const value = parseFloat(rawValue);
@@ -49,9 +169,40 @@ export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, line
         try {
             await apiFetch(url, 'PATCH', { [field]: value });
         } catch (e) {
-            setError(e.data?.message ?? 'Erreur lors de la sauvegarde.');
+            setError(firstError(e, 'Erreur lors de la sauvegarde.'));
         } finally {
             setSaving(prev => ({ ...prev, [lineId]: false }));
+        }
+    }
+
+    async function handleAddLine(payload, reset) {
+        setAdding(true);
+        setError(null);
+        try {
+            const data = await apiFetch(endpoints.storeLine, 'POST', payload);
+            setLines(prev => [...prev, data.line]);
+            reset();
+        } catch (e) {
+            setError(firstError(e, "Erreur lors de l'ajout de la ligne."));
+        } finally {
+            setAdding(false);
+        }
+    }
+
+    async function handleDeleteLine(line) {
+        const message = line.is_free_line
+            ? `Supprimer la ligne « ${line.order_line_label} » ?`
+            : `Supprimer la ligne « ${line.order_line_label} » ? Les quantités seront rendues à la commande ${line.order_code ?? ''}.`;
+        if (!confirm(message)) return;
+
+        setSaving(prev => ({ ...prev, [line.id]: true }));
+        setError(null);
+        try {
+            await apiFetch(endpoints.deleteLine.replace('__LINE_ID__', line.id), 'DELETE');
+            setLines(prev => prev.filter(l => l.id !== line.id));
+        } catch (e) {
+            setError(firstError(e, 'Erreur lors de la suppression.'));
+            setSaving(prev => ({ ...prev, [line.id]: false }));
         }
     }
 
@@ -65,7 +216,7 @@ export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, line
             setLines(prev => prev.map(l => ({ ...l, invoice_status: 2 })));
             window.location.reload();
         } catch (e) {
-            setError(e.data?.message ?? 'Erreur lors de l\'émission.');
+            setError(firstError(e, "Erreur lors de l'émission."));
             setEmitting(false);
         }
     }
@@ -76,7 +227,7 @@ export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, line
                 <div className="alert alert-warning d-flex justify-content-between align-items-center py-2 mb-3">
                     <span>
                         <i className="fas fa-edit mr-2"></i>
-                        <strong>Brouillon</strong> — Les prix, quantités et remises sont modifiables. La facture sera verrouillée après émission.
+                        <strong>Brouillon</strong> — Les lignes, prix, quantités et remises sont modifiables. La facture sera verrouillée après émission.
                     </span>
                     <button className="btn btn-success btn-sm ml-3" onClick={handleEmit} disabled={emitting}>
                         {emitting
@@ -103,15 +254,18 @@ export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, line
                             <th className="text-right">{trans.vat ?? 'TVA'}</th>
                             <th className="text-right">{trans.total ?? 'Montant HT'}</th>
                             <th>{trans.status ?? 'Statut'}</th>
+                            {isDraft && <th></th>}
                         </tr>
                     </thead>
                     <tbody>
                         {lines.map(line => (
                             <tr key={line.id}>
                                 <td>
-                                    <a href={line.order_url} className="btn btn-xs btn-default">
-                                        <i className="fas fa-external-link-alt mr-1"></i>{line.order_code}
-                                    </a>
+                                    {line.order_url
+                                        ? <a href={line.order_url} className="btn btn-xs btn-default">
+                                            <i className="fas fa-external-link-alt mr-1"></i>{line.order_code}
+                                          </a>
+                                        : <span className="badge badge-light border">Ligne libre</span>}
                                 </td>
                                 <td>
                                     {line.delivery_url
@@ -176,14 +330,38 @@ export default function InvoiceLinesDraft({ invoiceId, statu: initialStatu, line
                                 <td>
                                     <InvoiceStatusBadge status={line.invoice_status} trans={trans} />
                                 </td>
+
+                                {isDraft && (
+                                    <td className="text-right">
+                                        <button
+                                            type="button"
+                                            className="btn btn-xs btn-outline-danger"
+                                            title="Supprimer la ligne"
+                                            disabled={saving[line.id]}
+                                            onClick={() => handleDeleteLine(line)}
+                                        >
+                                            <i className="fas fa-trash"></i>
+                                        </button>
+                                    </td>
+                                )}
                             </tr>
                         ))}
                         {lines.length === 0 && (
-                            <tr><td colSpan="11" className="text-center text-muted py-3">Aucune ligne</td></tr>
+                            <tr><td colSpan={colCount} className="text-center text-muted py-3">Aucune ligne</td></tr>
                         )}
                     </tbody>
                 </table>
             </div>
+
+            {isDraft && (
+                <NewLineForm
+                    vats={vats}
+                    units={units}
+                    currency={currency}
+                    saving={adding}
+                    onSubmit={handleAddLine}
+                />
+            )}
         </div>
     );
 }

--- a/resources/views/customer/invoices/show.blade.php
+++ b/resources/views/customer/invoices/show.blade.php
@@ -42,15 +42,15 @@
                                             <td>
                                                 <div class="d-flex mb-2">
                                                     <div class="flex-lg-grow-1">
-                                                        <h6 class="small mb-0">{{ $DocumentLine->orderLine?->label }}</h6>
-                                                        <span class="text-muted">{{ $DocumentLine->orderLine?->code }}</span>
+                                                        <h6 class="small mb-0">{{ $DocumentLine->display_label }}</h6>
+                                                        <span class="text-muted">{{ $DocumentLine->display_code }}</span>
                                                     </div>
                                                 </div>
                                             </td>
-                                            <td>{{ $DocumentLine->qty }} {{ $DocumentLine->orderLine?->Unit['label'] }}</td>
-                                            <td class="text-end">{{ number_format((float) $DocumentLine->selling_price, 2, '.', ' ') }} {{ $Factory->curency }}</td>
-                                            <td>{{ $DocumentLine->discount }} %</td>
-                                            <td>{{ $DocumentLine->orderLine?->VAT['rate'] }} %</td>
+                                            <td>{{ $DocumentLine->qty }} {{ $DocumentLine->display_unit_label }}</td>
+                                            <td class="text-end">{{ number_format($DocumentLine->resolved_unit_price, 2, '.', ' ') }} {{ $Factory->curency }}</td>
+                                            <td>{{ $DocumentLine->resolved_discount }} %</td>
+                                            <td>{{ $DocumentLine->resolved_vat_rate }} %</td>
                                             <td>
                                                 @if($DocumentLine->deliveryLine?->delivery)
                                                     <x-ButtonTextView route="{{ route('customer.deliveries.show', ['delivery' => $DocumentLine->deliveryLine->delivery->uuid]) }}" />

--- a/resources/views/print/pdf-credit-note.blade.php
+++ b/resources/views/print/pdf-credit-note.blade.php
@@ -116,17 +116,17 @@
                 <tbody>
                     @forelse($Document->Lines as $DocumentLine)
                     <tr>
-                        <td align="center">{{ $DocumentLine->OrderLine->order['code'] }}</td>
+                        <td align="center">{{ $DocumentLine->OrderLine?->order['code'] ?? '-' }}</td>
                         <td>
-                            {{ $DocumentLine->OrderLine['label'] }}<br>
-                            <span style="color: #6c757d">{{ $DocumentLine->OrderLine['code'] }}</span>
+                            {{ $DocumentLine->display_label }}<br>
+                            <span style="color: #6c757d">{{ $DocumentLine->display_code }}</span>
                         </td>
                         <td>{{ $DocumentLine->qty }}</td>
-                        <td>{{ $DocumentLine->OrderLine->Unit['label'] }}</td>
-                        <td>{{ $normalizeCurrency($DocumentLine->OrderLine->formatted_selling_price) }}</td>
-                        <td align="center">{{ $DocumentLine->OrderLine->discount }} %</td>
-                        <td>{{ $DocumentLine->OrderLine->VAT['rate'] }} %</td>
-                        @if($DocumentLine->OrderLine->delivery_date )
+                        <td>{{ $DocumentLine->display_unit_label }}</td>
+                        <td>{{ $normalizeCurrency($DocumentLine->formatted_selling_price) }}</td>
+                        <td align="center">{{ $DocumentLine->resolved_discount }} %</td>
+                        <td>{{ $DocumentLine->resolved_vat_rate }} %</td>
+                        @if($DocumentLine->OrderLine?->delivery_date )
                         <td align="center">{{ $DocumentLine->OrderLine->delivery_date }}</td>
                         @else
                         <td align="center">-</td>

--- a/resources/views/print/pdf-invoice.blade.php
+++ b/resources/views/print/pdf-invoice.blade.php
@@ -119,16 +119,16 @@
                 <tbody>
                     @forelse($Document->Lines as $DocumentLine)
                     <tr>
-                        <td align="center">{{ $DocumentLine->deliveryLine?->delivery?->code ?? $DocumentLine->OrderLine->order['code'] }}</td>
+                        <td align="center">{{ $DocumentLine->deliveryLine?->delivery?->code ?? $DocumentLine->OrderLine?->order['code'] ?? '-' }}</td>
                         <td>
-                            {{ $DocumentLine->OrderLine['label'] }}<br>
-                            <span style="color: #6c757d">{{ $DocumentLine->OrderLine['code'] }}</span>
+                            {{ $DocumentLine->display_label }}<br>
+                            <span style="color: #6c757d">{{ $DocumentLine->display_code }}</span>
                         </td>
                         <td>{{ $DocumentLine->qty }}</td>
-                        <td>{{ $DocumentLine->OrderLine->Unit['label'] }}</td>
-                        <td>{{ $normalizeCurrency($DocumentLine->OrderLine->formatted_selling_price) }}</td>
-                        <td align="center">{{ $DocumentLine->OrderLine->discount }} %</td>
-                        @if($DocumentLine->OrderLine->delivery_date )
+                        <td>{{ $DocumentLine->display_unit_label }}</td>
+                        <td>{{ $normalizeCurrency($DocumentLine->formatted_selling_price) }}</td>
+                        <td align="center">{{ $DocumentLine->resolved_discount }} %</td>
+                        @if($DocumentLine->OrderLine?->delivery_date )
                         <td align="center">{{ $DocumentLine->OrderLine->delivery_date }}</td>
                         @else
                         <td align="center">-</td>

--- a/resources/views/workflow/credit-notes-show.blade.php
+++ b/resources/views/workflow/credit-notes-show.blade.php
@@ -128,7 +128,11 @@
                             @forelse($CreditNotes->creditNotelines as $CreditNotesLine)
                             <tr>
                                 <td>
+                                    @if($CreditNotesLine->orderLine?->order)
                                     <x-OrderButton id="{{ $CreditNotesLine->orderLine->order['id'] }}" code="{{ $CreditNotesLine->orderLine->order['code'] }}"  />
+                                    @else
+                                    <span class="badge badge-light border">{{ __('general_content.no_data_trans_key') }}</span>
+                                    @endif
                                 </td>
                                 <td>
                                     @if($CreditNotesLine->invoiceLine->delivery_line_id)
@@ -148,12 +152,12 @@
                                     -
                                     @endif
                                 </td>
-                                <td>{{ $CreditNotesLine->orderLine['code'] }}</td>
-                                <td>{{ $CreditNotesLine->orderLine['label'] }}</td>
+                                <td>{{ $CreditNotesLine->display_code }}</td>
+                                <td>{{ $CreditNotesLine->display_label }}</td>
                                 <td>{{ format_qty($CreditNotesLine->qty) }}</td>
-                                <td>{{ $CreditNotesLine->OrderLine->Unit['label'] }}</td>
+                                <td>{{ $CreditNotesLine->display_unit_label }}</td>
                                 <td>{{ $CreditNotesLine->formatted_selling_price }}</td>
-                                <td>{{ $CreditNotesLine->OrderLine->VAT['rate'] }} %</td>
+                                <td>{{ $CreditNotesLine->resolved_vat_rate }} %</td>
                             </tr>
                             @empty
                                 <x-EmptyDataLine col="10" text="{{ __('general_content.no_data_trans_key') }}"  />

--- a/resources/views/workflow/invoices-show.blade.php
+++ b/resources/views/workflow/invoices-show.blade.php
@@ -171,25 +171,12 @@ $invoiceSteps = [
       </div>       
       <div class="tab-pane " id="InvoiceLines">
         @php
-          $invoiceLinesData = $Invoice->InvoiceLines->map(function ($l) {
-              return [
-                  'id'              => $l->id,
-                  'qty'             => (float) $l->qty,
-                  'unit_price'      => (float) ($l->unit_price ?? $l->orderLine->selling_price),
-                  'discount'        => (float) ($l->discount ?? 0),
-                  'vat_rate'        => (float) ($l->vat_rate ?? 0),
-                  'invoice_status'  => $l->invoice_status,
-                  'order_line_code' => $l->orderLine['code'],
-                  'order_line_label'=> $l->orderLine['label'],
-                  'unit_label'      => $l->orderLine->Unit['label'] ?? '',
-                  'order_code'      => $l->orderLine->order['code'],
-                  'order_url'       => route('orders.show', $l->orderLine->order['id']),
-                  'delivery_code'   => $l->delivery_line_id ? $l->deliveryLine->delivery['code'] : null,
-                  'delivery_url'    => $l->delivery_line_id ? route('deliverys.show', ['id' => $l->deliveryLine->delivery['id']]) : null,
-              ];
-          });
+          $invoiceDataService = app(\App\Services\InvoiceDataService::class);
+          $invoiceLinesData = $Invoice->InvoiceLines->map(fn ($l) => $invoiceDataService->formatDraftLine($l));
           $linesEndpoints = [
               'updateLine' => route('invoices.lines.update', [$Invoice->id, '__LINE_ID__']),
+              'storeLine'  => route('invoices.lines.store', $Invoice->id),
+              'deleteLine' => route('invoices.lines.destroy', [$Invoice->id, '__LINE_ID__']),
               'emit'       => route('invoices.emit', $Invoice->id),
           ];
           $linesTrans = [
@@ -218,6 +205,8 @@ $invoiceSteps = [
           data-lines="{{ json_encode($invoiceLinesData) }}"
           data-endpoints="{{ json_encode($linesEndpoints) }}"
           data-currency="{{ app('Factory')->curency ?? 'EUR' }}"
+          data-vats="{{ json_encode($vats) }}"
+          data-units="{{ json_encode($units) }}"
           data-trans="{{ json_encode($linesTrans) }}"
         ></div>
 
@@ -233,7 +222,7 @@ $invoiceSteps = [
               @foreach($Invoice->InvoiceLines as $line)
                 <label class="mr-3 mb-0 small">
                   <input type="checkbox" name="selected_invoice_lines[]" value="{{ $line->id }}" class="mr-1">
-                  {{ $line->orderLine['code'] }}
+                  {{ $line->display_code ?: $line->display_label }}
                 </label>
               @endforeach
               <button type="submit" class="btn btn-info btn-sm ml-auto">

--- a/resources/views/workflow/proformas-show.blade.php
+++ b/resources/views/workflow/proformas-show.blade.php
@@ -179,13 +179,13 @@
                       <x-OrderButton id="{{ $line->orderLine->order->id }}" code="{{ $line->orderLine->order->code }}" />
                     @endif
                   </td>
-                  <td>{{ $line->orderLine?->code }}</td>
-                  <td>{{ $line->orderLine?->label }}</td>
+                  <td>{{ $line->display_code }}</td>
+                  <td>{{ $line->display_label }}</td>
                   <td>{{ format_qty($line->qty) }}</td>
-                  <td>{{ $line->orderLine?->Unit?->label }}</td>
+                  <td>{{ $line->display_unit_label }}</td>
                   <td>{{ $line->formatted_selling_price }}</td>
-                  <td>{{ $line->orderLine?->discount }} %</td>
-                  <td>{{ $line->orderLine?->VAT?->rate }} %</td>
+                  <td>{{ $line->resolved_discount }} %</td>
+                  <td>{{ $line->resolved_vat_rate }} %</td>
                 </tr>
                 @empty
                   <x-EmptyDataLine col="8" text="Aucune ligne" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -442,6 +442,9 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
         Route::post('/edit/{id}', 'App\Http\Controllers\Workflow\InvoicesController@update')->name('invoices.update');
         Route::post('/{id}/json/statu', 'App\Http\Controllers\Workflow\InvoicesController@changeStatusJson')->name('invoices.json.statu');
         Route::patch('/{id}/lines/{lineId}', 'App\Http\Controllers\Workflow\InvoicesController@updateLine')->name('invoices.lines.update');
+        // Ligne libre sur facture en brouillon (frais de port, prestation oubliée)
+        Route::post('/{id}/lines', 'App\Http\Controllers\Workflow\InvoicesController@storeLine')->name('invoices.lines.store');
+        Route::delete('/{id}/lines/{lineId}', 'App\Http\Controllers\Workflow\InvoicesController@destroyLine')->name('invoices.lines.destroy');
         Route::patch('/{id}/emit', 'App\Http\Controllers\Workflow\InvoicesController@emit')->name('invoices.emit');
         // JSON endpoint for React InvoicesIndex
         Route::get('/json/list', 'App\Http\Controllers\Workflow\InvoicesController@listJson')->name('invoices.json.list');

--- a/tests/Feature/CreditNotesTest.php
+++ b/tests/Feature/CreditNotesTest.php
@@ -93,6 +93,40 @@ class CreditNotesTest extends TestCase
         ]);
     }
 
+    public function test_can_create_credit_note_from_a_free_invoice_line(): void
+    {
+        $invoice = Invoices::factory()->create(['statu' => 2]);
+        // Ligne libre : aucune ligne de commande à rembobiner derrière.
+        $invoiceLine = InvoiceLines::create([
+            'invoices_id'    => $invoice->id,
+            'label'          => 'Frais de port',
+            'ordre'          => 10,
+            'qty'            => 1,
+            'unit_price'     => 80,
+            'discount'       => 0,
+            'vat_rate'       => 20,
+            'invoice_status' => 4,
+        ]);
+
+        $response = $this->post(route('credit-notes.store.from.invoice'), [
+            'selected_invoice_lines' => [$invoiceLine->id],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('credit_note_lines', [
+            'order_line_id'   => null,
+            'invoice_line_id' => $invoiceLine->id,
+            'label'           => 'Frais de port',
+            'unit_price'      => 80,
+            'vat_rate'        => 20,
+        ]);
+
+        $creditNote = CreditNotes::where('invoices_id', $invoice->id)->firstOrFail();
+        $calculator = new \App\Services\CreditNoteCalculatorService($creditNote);
+        $this->assertEquals(80.0, round($calculator->getSubTotal(), 2));
+        $this->assertEquals(96.0, round($calculator->getTotalPrice(), 2));
+    }
+
     public function test_credit_note_reverses_order_line_invoiced_qty(): void
     {
         $order = Orders::factory()->create();

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -12,6 +12,7 @@ use App\Models\Workflow\DeliveryLines;
 use App\Models\Workflow\Orders;
 use App\Models\Workflow\OrderLines;
 use App\Models\Accounting\AccountingVat;
+use App\Models\Methods\MethodsUnits;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class InvoicesTest extends TestCase
@@ -192,6 +193,251 @@ class InvoicesTest extends TestCase
 
         $response->assertOk();
         $this->assertDatabaseMissing('invoice_payments', ['id' => $payment->id]);
+    }
+
+    public function test_can_add_free_line_to_draft_invoice(): void
+    {
+        $vat     = AccountingVat::factory()->create(['rate' => 20]);
+        $unit    = MethodsUnits::factory()->create();
+        $invoice = Invoices::factory()->create(['statu' => 1]);
+
+        $response = $this->postJson(route('invoices.lines.store', $invoice->id), [
+            'label'              => 'Frais de port',
+            'code'               => 'PORT',
+            'qty'                => 1,
+            'unit_price'         => 80,
+            'discount'           => 0,
+            'methods_units_id'   => $unit->id,
+            'accounting_vats_id' => $vat->id,
+        ]);
+
+        $response->assertStatus(201)->assertJsonPath('line.is_free_line', true);
+
+        $this->assertDatabaseHas('invoice_lines', [
+            'invoices_id'   => $invoice->id,
+            'order_line_id' => null,
+            'label'         => 'Frais de port',
+            'unit_price'    => 80,
+            'vat_rate'      => 20,
+        ]);
+
+        // La ligne libre entre bien dans les totaux de la facture.
+        $calculator = new \App\Services\InvoiceCalculatorService($invoice->fresh());
+        $this->assertEquals(80.0, round($calculator->getSubTotal(), 2));
+        $this->assertEquals(96.0, round($calculator->getTotalPrice(), 2));
+    }
+
+    public function test_cannot_add_free_line_to_emitted_invoice(): void
+    {
+        $invoice = Invoices::factory()->create(['statu' => 2]);
+
+        $response = $this->postJson(route('invoices.lines.store', $invoice->id), [
+            'label'      => 'Frais de port',
+            'qty'        => 1,
+            'unit_price' => 80,
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseMissing('invoice_lines', ['invoices_id' => $invoice->id]);
+    }
+
+    public function test_add_free_line_requires_label_and_price(): void
+    {
+        $invoice = Invoices::factory()->create(['statu' => 1]);
+
+        $this->postJson(route('invoices.lines.store', $invoice->id), ['qty' => 1])
+             ->assertStatus(422);
+    }
+
+    public function test_can_delete_free_line_from_draft_invoice(): void
+    {
+        $invoice = Invoices::factory()->create(['statu' => 1]);
+        $line    = InvoiceLines::create([
+            'invoices_id' => $invoice->id,
+            'label'       => 'Frais de port',
+            'ordre'       => 10,
+            'qty'         => 1,
+            'unit_price'  => 80,
+            'discount'    => 0,
+            'vat_rate'    => 20,
+        ]);
+
+        $this->deleteJson(route('invoices.lines.destroy', [$invoice->id, $line->id]))
+             ->assertOk();
+
+        $this->assertSoftDeleted('invoice_lines', ['id' => $line->id]);
+    }
+
+    public function test_deleting_order_line_restores_invoiced_qty(): void
+    {
+        $vat       = AccountingVat::factory()->create();
+        $order     = Orders::factory()->create(['statu' => 1]);
+        $orderLine = OrderLines::factory()->create([
+            'orders_id'               => $order->id,
+            'qty'                     => 5,
+            'invoiced_qty'            => 5,
+            'invoiced_remaining_qty'  => 0,
+            'invoice_status'          => 3,
+            'accounting_vats_id'      => $vat->id,
+        ]);
+        $invoice = Invoices::factory()->create(['statu' => 1]);
+        $line    = InvoiceLines::create([
+            'invoices_id'   => $invoice->id,
+            'order_line_id' => $orderLine->id,
+            'ordre'         => 10,
+            'qty'           => 5,
+            'unit_price'    => 10,
+            'discount'      => 0,
+            'vat_rate'      => 20,
+        ]);
+
+        $this->deleteJson(route('invoices.lines.destroy', [$invoice->id, $line->id]))
+             ->assertOk();
+
+        $orderLine->refresh();
+        $this->assertEquals(0, $orderLine->invoiced_qty);
+        $this->assertEquals(5, $orderLine->invoiced_remaining_qty);
+        $this->assertEquals(1, $orderLine->invoice_status);
+    }
+
+    public function test_deleting_line_reopens_the_delivery_line(): void
+    {
+        $vat       = AccountingVat::factory()->create();
+        $order     = Orders::factory()->create(['statu' => 1]);
+        $orderLine = OrderLines::factory()->create([
+            'orders_id'               => $order->id,
+            'qty'                     => 4,
+            'invoiced_qty'            => 4,
+            'invoiced_remaining_qty'  => 0,
+            'invoice_status'          => 3,
+            'accounting_vats_id'      => $vat->id,
+        ]);
+        $delivery = Deliverys::factory()->create([
+            'companies_id'           => $order->companies_id,
+            'companies_contacts_id'  => $order->companies_contacts_id,
+            'companies_addresses_id' => $order->companies_addresses_id,
+            'order_id'               => $order->id,
+        ]);
+        $deliveryLine = DeliveryLines::create([
+            'deliverys_id'   => $delivery->id,
+            'order_line_id'  => $orderLine->id,
+            'ordre'          => 10,
+            'qty'            => 4,
+            'invoice_status' => 4, // facturée
+        ]);
+        $invoice = Invoices::factory()->create(['statu' => 1]);
+        $line    = InvoiceLines::create([
+            'invoices_id'      => $invoice->id,
+            'order_line_id'    => $orderLine->id,
+            'delivery_line_id' => $deliveryLine->id,
+            'ordre'            => 10,
+            'qty'              => 4,
+            'unit_price'       => 10,
+            'discount'         => 0,
+            'vat_rate'         => 20,
+        ]);
+
+        $this->deleteJson(route('invoices.lines.destroy', [$invoice->id, $line->id]))
+             ->assertOk();
+
+        $deliveryLine->refresh();
+        $orderLine->refresh();
+
+        $this->assertEquals(1, $deliveryLine->invoice_status);  // redevient facturable
+        $this->assertEquals(0, $orderLine->invoiced_qty);
+        $this->assertEquals(4, $orderLine->invoiced_remaining_qty);
+        $this->assertEquals(1, $orderLine->invoice_status);
+    }
+
+    public function test_deleting_one_of_two_lines_keeps_the_delivery_line_invoiced(): void
+    {
+        $order     = Orders::factory()->create(['statu' => 1]);
+        $orderLine = OrderLines::factory()->create([
+            'orders_id'              => $order->id,
+            'qty'                    => 10,
+            'invoiced_qty'           => 10,
+            'invoiced_remaining_qty' => 0,
+            'invoice_status'         => 3,
+        ]);
+        $delivery = Deliverys::factory()->create([
+            'companies_id'           => $order->companies_id,
+            'companies_contacts_id'  => $order->companies_contacts_id,
+            'companies_addresses_id' => $order->companies_addresses_id,
+            'order_id'               => $order->id,
+        ]);
+        $deliveryLine = DeliveryLines::create([
+            'deliverys_id'   => $delivery->id,
+            'order_line_id'  => $orderLine->id,
+            'ordre'          => 10,
+            'qty'            => 10,
+            'invoice_status' => 4,
+        ]);
+
+        $invoice = Invoices::factory()->create(['statu' => 1]);
+        $common  = [
+            'invoices_id'      => $invoice->id,
+            'order_line_id'    => $orderLine->id,
+            'delivery_line_id' => $deliveryLine->id,
+            'unit_price'       => 10,
+            'discount'         => 0,
+            'vat_rate'         => 20,
+        ];
+        $lineA = InvoiceLines::create($common + ['ordre' => 10, 'qty' => 5]);
+        InvoiceLines::create($common + ['ordre' => 20, 'qty' => 5]);
+
+        $this->deleteJson(route('invoices.lines.destroy', [$invoice->id, $lineA->id]))
+             ->assertOk();
+
+        $deliveryLine->refresh();
+        $orderLine->refresh();
+
+        // Une seconde ligne facture toujours ce BL : il reste facturé.
+        $this->assertEquals(4, $deliveryLine->invoice_status);
+        // Seule la quantité de la ligne supprimée est rendue.
+        $this->assertEquals(5, $orderLine->invoiced_qty);
+        $this->assertEquals(5, $orderLine->invoiced_remaining_qty);
+        $this->assertEquals(2, $orderLine->invoice_status); // partiellement facturée
+    }
+
+    public function test_invoice_pdf_renders_with_a_free_line(): void
+    {
+        $vat     = AccountingVat::factory()->create(['rate' => 20]);
+        $unit    = MethodsUnits::factory()->create();
+        $invoice = Invoices::factory()->create(['statu' => 2]);
+
+        InvoiceLines::create([
+            'invoices_id'        => $invoice->id,
+            'label'              => 'Frais de port',
+            'code'               => 'PORT',
+            'methods_units_id'   => $unit->id,
+            'ordre'              => 10,
+            'qty'                => 1,
+            'unit_price'         => 80,
+            'discount'           => 0,
+            'vat_rate'           => $vat->rate,
+            'accounting_vats_id' => $vat->id,
+        ]);
+
+        $response = $this->get(route('pdf.invoice', ['Document' => $invoice->id]));
+
+        $response->assertOk();
+    }
+
+    public function test_cannot_delete_line_from_emitted_invoice(): void
+    {
+        $invoice = Invoices::factory()->create(['statu' => 2]);
+        $line    = InvoiceLines::create([
+            'invoices_id' => $invoice->id,
+            'label'       => 'Frais de port',
+            'ordre'       => 10,
+            'qty'         => 1,
+            'unit_price'  => 80,
+        ]);
+
+        $this->deleteJson(route('invoices.lines.destroy', [$invoice->id, $line->id]))
+             ->assertStatus(403);
+
+        $this->assertDatabaseHas('invoice_lines', ['id' => $line->id, 'deleted_at' => null]);
     }
 
     public function test_create_invoice_requires_at_least_one_line(): void


### PR DESCRIPTION
…brouillon

Une ligne de facture ne pouvait exister qu'en face d'une ligne de commande : impossible de facturer un frais de port oublie autrement qu'en creant un second document.

- invoice_lines.order_line_id devient nullable ; la ligne porte desormais son libelle, son code, son produit, son unite et sa TVA, dans la continuite du snapshot de prix
- credit_note_lines suit, pour qu'un avoir puisse porter sur une ligne libre
- POST et DELETE sur les lignes d'une facture en brouillon, avec controle de periode comptable ; la suppression rend les quantites a la ligne de commande, rouvre la ligne de BL si plus aucune facture ne la reference, et supprime les ecritures de vente associees
- formulaire d'ajout et suppression de ligne dans l'onglet des lignes

Corrige au passage plusieurs lectures du prix courant de la ligne de commande la ou le prix fige existait deja (liste des factures, KPI de chiffre d'affaires, PDF de facture, calcul des avoirs) et le prix unitaire affiche a zero sur le portail client.

10 tests ajoutes.